### PR TITLE
feat: Add AdwAvatar and specialized ListBox row components

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,20 @@ Creates a view switcher with a button bar and content area.
   // viewSwitcher.setActiveView("Settings");
   ```
 
+### `Adw.createAvatar(options = {})`
+Displays an image, text initials, or custom content as a circular avatar.
+- **`options`**: `object`
+    - `size` (number, default: 48): Diameter of the avatar in pixels.
+    - `imageSrc` (string): URL for the avatar image.
+    - `text` (string): Fallback text used to generate initials if no image or if image fails to load. Also used for default alt text.
+    - `customFallback` (HTMLElement): A custom DOM element to display as fallback.
+    - `alt` (string): Alt text for the image.
+- **Example:**
+  ```javascript
+  const avatar1 = Adw.createAvatar({ text: "Jules Verne", size: 64 });
+  const avatar2 = Adw.createAvatar({ imageSrc: "path/to/image.png", text: "User Name", size: 48 });
+  ```
+
 ### `Adw.createFlap(options = {})`
 Creates a two-pane layout with a collapsible "flap".
 - **`options`**: `object`
@@ -329,6 +343,80 @@ Creates a two-pane layout with a collapsible "flap".
   // const toggleFlapButton = Adw.createButton("Toggle Flap", { onClick: () => flap.toggleFlap() });
   // document.body.appendChild(toggleFlapButton);
   // document.body.appendChild(flap.element);
+  ```
+
+### Specialized ListBox Rows
+These components are designed to be used as children of `Adw.createListBox()`. They provide pre-defined structures for common list item patterns.
+
+#### `Adw.createActionRow(options = {})`
+A row for `AdwListBox` that can be activated, often used to trigger an action or navigate.
+- **`options`**: `object`
+    - `title` (string): Main text.
+    - `subtitle` (string, optional): Secondary text displayed below the title.
+    - `iconHTML` (string, optional): SVG string or icon font class for an icon displayed at the start of the row.
+    - `onClick` (function, optional): Makes the row activatable and triggers this callback.
+    - `showChevron` (boolean, default: `true`): If `onClick` is provided, displays a chevron arrow at the end of the row.
+- **Example:**
+  ```javascript
+  const settingsAction = Adw.createActionRow({
+      title: "Open Settings",
+      subtitle: "Configure application preferences",
+      onClick: () => console.log("Settings clicked")
+  });
+  ```
+
+#### `Adw.createEntryRow(options = {})`
+A row for `AdwListBox` that embeds a label and an `AdwEntry` (text input field).
+- **`options`**: `object`
+    - `title` (string): Label for the entry.
+    - `entryOptions` (object, optional): Options passed directly to `Adw.createEntry()`.
+    - `labelForEntry` (boolean, default: `true`): If true, links the title label to the entry using `for`/`id` attributes for accessibility.
+- **Example:**
+  ```javascript
+  const usernameRow = Adw.createEntryRow({
+      title: "Username:",
+      entryOptions: { placeholder: "Enter your username" }
+  });
+  ```
+
+#### `Adw.createExpanderRow(options = {})`
+A row for `AdwListBox` that can expand to show or hide additional content.
+- **`options`**: `object`
+    - `title` (string): Text displayed on the clickable part of the row.
+    - `subtitle` (string, optional): Secondary text on the clickable part.
+    - `expanded` (boolean, default: `false`): Initial expanded state.
+    - `content` (HTMLElement): The DOM element to show or hide when expanded.
+- **Example:**
+  ```javascript
+  const detailsContent = Adw.createLabel("Some detailed information here.");
+  const advancedOptions = Adw.createExpanderRow({
+      title: "Advanced Options",
+      subtitle: "Click to see more",
+      content: detailsContent
+  });
+  ```
+
+#### `Adw.createComboRow(options = {})`
+A row for `AdwListBox` that includes a label and a dropdown/select menu.
+- **`options`**: `object`
+    - `title` (string): Label for the combo row.
+    - `subtitle` (string, optional): Secondary text.
+    - `selectOptions` (Array<string|{label: string, value: string}>): Options for the `<select>` element.
+    - `selectedValue` (string|number, optional): The value of the initially selected option.
+    - `onChanged` (function, optional): Callback when the selected value changes. Receives the new value.
+    - `disabled` (boolean, default: `false`): Disables the select element.
+- **Example:**
+  ```javascript
+  const qualityCombo = Adw.createComboRow({
+      title: "Video Quality",
+      selectOptions: [
+          {label: "Low (480p)", value: "480p"},
+          {label: "Medium (720p)", value: "720p"},
+          {label: "High (1080p)", value: "1080p"}
+      ],
+      selectedValue: "720p",
+      onChanged: (value) => console.log("Quality set to:", value)
+  });
   ```
 
 ## Theming

--- a/index.html
+++ b/index.html
@@ -283,12 +283,15 @@
                 flapExampleBox,
 
                 Adw.createLabel("Accent Color Picker", {title:1}),
-                // This will be populated by JavaScript below
+                // This will be populated by JavaScript below (accentPickerBox)
+
+                Adw.createLabel("Avatars", {title:1}),
+                // Avatar examples will be added here by JS
             ],
         });
 
         // --- Accent Color Picker Example ---
-        const accentPickerBox = Adw.createBox({ orientation: 'horizontal', spacing: 's', align: 'center'});
+        const accentPickerBox = Adw.createBox({ orientation: 'horizontal', spacing: 's', align: 'center', children: [Adw.createLabel("Accents:")]});
         const accentColors = Adw.getAccentColors();
         accentColors.forEach(colorName => {
             const colorButton = Adw.createButton(colorName.charAt(0).toUpperCase() + colorName.slice(1), {
@@ -313,6 +316,100 @@
         });
         // Find where to insert the accent picker. For now, append to the main content.
         content.appendChild(Adw.createRow({children: [accentPickerBox]}));
+
+        // --- Avatar Examples ---
+        const avatarSection = Adw.createBox({orientation: 'vertical', spacing: 'm'});
+
+        const avatarRow1 = Adw.createBox({ orientation: 'horizontal', spacing: 'm', align: 'center' });
+        avatarRow1.appendChild(Adw.createAvatar({ text: "John Doe", size: 32 }));
+        avatarRow1.appendChild(Adw.createAvatar({ text: "Jane Roe", size: 48 }));
+        avatarRow1.appendChild(Adw.createAvatar({ text: "Single", size: 64 }));
+        avatarRow1.appendChild(Adw.createAvatar({ text: "X", size: 72 }));
+
+        const avatarRow2 = Adw.createBox({ orientation: 'horizontal', spacing: 'm', align: 'center' });
+        // Placeholder image - replace with a real one if available for testing
+        const imgSrc = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%23ddd'/%3E%3Ctext x='50' y='55' font-size='40' text-anchor='middle' fill='%23777'%3EIMG%3C/text%3E%3C/svg%3E";
+        avatarRow2.appendChild(Adw.createAvatar({ imageSrc: imgSrc, alt: "User Image 1", size: 48 }));
+        avatarRow2.appendChild(Adw.createAvatar({ imageSrc: "nonexistent.jpg", text: "Error Fallback", size: 64, alt:"Non Existent" }));
+
+        const customFallbackEl = Adw.createLabel("CF", {isCaption: true}); // Custom fallback example
+        avatarRow2.appendChild(Adw.createAvatar({ imageSrc: "another_error.png", customFallback: customFallbackEl, size: 72, alt: "Custom Fallback Demo"}));
+
+        avatarSection.appendChild(avatarRow1);
+        avatarSection.appendChild(avatarRow2);
+        content.appendChild(Adw.createRow({children: [avatarSection]}));
+
+        // --- Specialized Row Types ---
+        const specializedRowsTitle = Adw.createLabel("Specialized List Rows", {title:1});
+        content.appendChild(specializedRowsTitle);
+
+        const actionRow1 = Adw.createActionRow({
+            title: "Action Row",
+            subtitle: "Click to do something",
+            onClick: () => Adw.createToast("Action Row Clicked!")
+        });
+        const actionRowWithIcon = Adw.createActionRow({
+            title: "Action with Icon",
+            subtitle: "And a subtitle too",
+            iconHTML: '<svg width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16ZM6.5 4.5a.5.5 0 0 1 1 0V7h2.5a.5.5 0 0 1 0 1H7.5v2.5a.5.5 0 0 1-1 0V8H4a.5.5 0 0 1 0-1h2.5V4.5Z"/></svg>', // Placeholder plus icon
+            onClick: () => Adw.createToast("Action Row with Icon Clicked!")
+        });
+         const actionRowNoChevron = Adw.createActionRow({
+            title: "Action Row (No Chevron)",
+            subtitle: "Still clickable",
+            showChevron: false,
+            onClick: () => Adw.createToast("Action Row (No Chevron) Clicked!")
+        });
+
+
+        const entryRow1 = Adw.createEntryRow({
+            title: "Username:",
+            entryOptions: { placeholder: "Enter username..." }
+        });
+
+        const expanderContent = Adw.createBox({ orientation: 'vertical', spacing: 's', children: [
+            Adw.createLabel("This is the expanded content."),
+            Adw.createButton("A button inside expander")
+        ]});
+        const expanderRow1 = Adw.createExpanderRow({
+            title: "Expander Row",
+            subtitle: "Click to expand/collapse",
+            content: expanderContent
+        });
+        const expanderRow2 = Adw.createExpanderRow({
+            title: "Initially Expanded",
+            subtitle: "This one starts open",
+            content: Adw.createLabel("Some pre-expanded content here."),
+            expanded: true
+        });
+
+        const comboRow1 = Adw.createComboRow({
+            title: "Choose an Option",
+            subtitle: "Select from the list",
+            selectOptions: ["Option A", "Option B", {label: "Option C (Val C)", value: "C"}],
+            selectedValue: "B",
+            onChanged: (value) => Adw.createToast(`Combo changed to: ${value}`)
+        });
+         const disabledComboRow = Adw.createComboRow({
+            title: "Disabled Combo",
+            selectOptions: ["Can't choose"],
+            disabled: true
+        });
+
+
+        const specializedRowsListBox = Adw.createListBox({
+            children: [
+                actionRow1,
+                actionRowWithIcon,
+                actionRowNoChevron,
+                entryRow1,
+                expanderRow1,
+                expanderRow2,
+                comboRow1,
+                disabledComboRow
+            ]
+        });
+        content.appendChild(specializedRowsListBox);
 
 
         // Create the window and append it to the body.

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -1,0 +1,89 @@
+// scss/_avatar.scss
+@use "variables";
+
+// Define default avatar colors if they aren't in _variables.scss already
+// These can be overridden by users.
+:root {
+  --avatar-bg-color: var(--shade-color); // Using shade-color as a neutral default
+  --avatar-text-color: var(--view-fg-color); // Default text on avatar background
+}
+
+body.light-theme {
+  --avatar-bg-color: var(--shade-color); // e.g., a light gray
+  --avatar-text-color: var(--view-fg-color);
+}
+
+body.dark-theme {
+  --avatar-bg-color: var(--shade-color); // e.g., a darker gray
+  --avatar-text-color: var(--view-fg-color);
+}
+
+
+.adw-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--avatar-bg-color);
+  color: var(--avatar-text-color); // Default text color for initials if not overridden by .adw-avatar-text
+  font-weight: bold;
+  vertical-align: middle; // Helps align with adjacent text if needed
+  user-select: none; // Text in avatar usually not selectable
+  box-sizing: border-box; // Ensure padding/border are included in width/height
+
+  // Default size if not set by JS or specific class (optional)
+  // It's better if JS always sets the size for consistency.
+  // width: 48px;
+  // height: 48px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover; // Ensures the image covers the area, cropping if necessary
+    display: block; // Remove extra space below image
+  }
+
+  .adw-avatar-text {
+    color: var(--avatar-text-color); // Specific text color for initials
+    text-align: center;
+    line-height: 1; // Keep line height tight for initials
+    // Font size will be set dynamically by JavaScript based on avatar size
+  }
+
+  // Optional: Default placeholder (e.g., an icon) if no image, no text, no custom fallback
+  // &:empty::before {
+  //   content: "👤"; // Placeholder icon or SVG
+  //   font-size: calc(var(--avatar-current-size, 48px) * 0.6); // Adjust icon size based on avatar size
+  //   color: var(--avatar-text-color);
+  // }
+}
+
+// Optional: Predefined size classes (JS primarily controls size via style attribute)
+// These can be useful if you want to use avatars purely from HTML/CSS sometimes.
+// The font-size here is a rough guide; JS will calculate it more precisely.
+.adw-avatar.size-tiny { // Example: 16px
+  width: 16px;
+  height: 16px;
+  // .adw-avatar-text font-size would be ~6-7px
+}
+.adw-avatar.size-small { // Example: 24px
+  width: 24px;
+  height: 24px;
+  // .adw-avatar-text font-size would be ~10px
+}
+.adw-avatar.size-medium { // Example: 48px
+  width: 48px;
+  height: 48px;
+  // .adw-avatar-text font-size would be ~18-20px
+}
+.adw-avatar.size-large { // Example: 72px
+  width: 72px;
+  height: 72px;
+  // .adw-avatar-text font-size would be ~28-30px
+}
+.adw-avatar.size-huge { // Example: 96px
+  width: 96px;
+  height: 96px;
+  // .adw-avatar-text font-size would be ~38-40px
+}

--- a/scss/_row_types.scss
+++ b/scss/_row_types.scss
@@ -1,0 +1,223 @@
+// scss/_row_types.scss
+@use "variables";
+
+// Common base for specialized rows if needed, but AdwRow already provides some.
+// These rows are typically used within an AdwListBox or a similar container.
+
+// --- AdwActionRow ---
+.adw-action-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m); // Gap between icon, text-content, chevron
+
+  .adw-action-row-icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    // Styling for icon size, color can be added here or come from .icon class
+    // e.g., width: 24px; height: 24px;
+    svg { // Assuming SVG icons
+        width: 16px;
+        height: 16px;
+        fill: currentColor;
+    }
+  }
+
+  .adw-action-row-text-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden; // For text ellipsis on title/subtitle
+  }
+
+  .adw-action-row-title {
+    font-weight: normal; // Libadwaita titles in rows are often normal weight
+    color: var(--view-fg-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .adw-action-row-subtitle {
+    font-size: var(--font-size-small);
+    color: var(--view-fg-color);
+    opacity: 0.7; // Muted subtitle
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .adw-action-row-chevron {
+    flex-shrink: 0;
+    font-size: var(--font-size-large); // Make chevron a bit larger
+    opacity: 0.5;
+    // Example using text chevron, an SVG would be better for consistency
+    &::after {
+      content: "❯";
+    }
+  }
+
+  // When the row itself is interactive (e.g. has an onClick)
+  &.interactive {
+    &:hover {
+        // Standard row hover from AdwRow should apply
+    }
+    &:active {
+        // Standard row active state from AdwRow should apply
+    }
+  }
+}
+
+
+// --- AdwEntryRow ---
+.adw-entry-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+
+  .adw-entry-row-title {
+    // No specific styles needed if it's just an AdwLabel, it will inherit.
+    // font-weight: normal; // If needed to override default label boldness
+  }
+
+  .adw-entry-row-entry {
+    flex-grow: 1;
+    // The AdwEntry component itself will have its styles
+  }
+}
+
+
+// --- AdwExpanderRow ---
+.adw-expander-row-wrapper {
+  // This wrapper contains the clickable row and the collapsible content
+  // It might need listbox styling if used outside a listbox (e.g. border-bottom)
+  &:not(:last-child) {
+    border-bottom: var(--border-width, 1px) solid var(--border-color-light);
+  }
+}
+.dark-theme .adw-expander-row-wrapper:not(:last-child),
+body.dark-theme .adw-expander-row-wrapper:not(:last-child) {
+    border-bottom-color: var(--border-color-dark);
+}
+
+
+.adw-expander-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+  // padding: var(--spacing-m); // Padding is usually on the AdwRow base class
+
+  .adw-expander-row-text-content { // Similar to ActionRow's text content
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+  }
+  .adw-expander-row-title { /* Use AdwLabel styles */ }
+  .adw-expander-row-subtitle { /* Use AdwLabel styles, but ensure opacity is applied if AdwLabel doesn't do it by default */
+    font-size: var(--font-size-small);
+    opacity: 0.7;
+   }
+
+
+  .adw-expander-row-icon {
+    flex-shrink: 0;
+    transition: transform 0.15s ease-in-out;
+    font-size: var(--font-size-large);
+    opacity: 0.7;
+    &::after {
+      content: "❯"; // Default: collapsed state
+    }
+  }
+
+  // When expanded
+  &.expanded .adw-expander-row-icon {
+    transform: rotate(90deg);
+  }
+}
+
+.adw-expander-row-content {
+  // display: none; // JS will toggle this or use max-height
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out, padding 0.2s ease-out, opacity 0.2s ease-out;
+  padding: 0 var(--spacing-m); // Horizontal padding when closed
+  opacity: 0;
+  visibility: hidden;
+
+  // Styles for the content area when expanded
+  &.expanded {
+    // display: block; // If not using max-height animation
+    max-height: 1000px; // Large enough for most content, for animation
+    padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m); // Full padding when open
+    opacity: 1;
+    visibility: visible;
+    // border-top: 1px solid var(--border-color-light); // Optional separator
+    // margin-left: var(--spacing-xl); // Optional indent for content
+  }
+}
+.dark-theme .adw-expander-row-content.expanded,
+body.dark-theme .adw-expander-row-content.expanded {
+    // border-top-color: var(--border-color-dark);
+}
+
+
+// --- AdwComboRow ---
+.adw-combo-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+
+  .adw-combo-row-text-content { // Similar to ActionRow's text content
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+  }
+  .adw-combo-row-title { /* Use AdwLabel styles */ }
+  .adw-combo-row-subtitle { /* Use AdwLabel styles, ensure opacity */
+    font-size: var(--font-size-small);
+    opacity: 0.7;
+  }
+
+  .adw-combo-row-select {
+    // Basic styling, can be enhanced
+    padding: var(--spacing-xs) var(--spacing-s);
+    border: var(--border-width, 1px) solid var(--button-border-color);
+    border-radius: var(--border-radius-default);
+    background-color: var(--button-bg-color);
+    color: var(--button-fg-color);
+    min-width: 150px; // Ensure select has some width
+
+    &:hover {
+      background-color: var(--button-hover-bg-color);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--accent-bg-color);
+      outline-offset: 1px;
+    }
+    &:disabled {
+        opacity: var(--opacity-disabled, 0.5);
+        cursor: not-allowed;
+    }
+  }
+}
+
+// Dark theme for ComboRow select (if not covered by button variables)
+.dark-theme .adw-combo-row .adw-combo-row-select,
+body.dark-theme .adw-combo-row .adw-combo-row-select {
+    border-color: var(--button-border-color);
+    background-color: var(--button-bg-color);
+    color: var(--button-fg-color);
+     &:hover {
+      background-color: var(--button-hover-bg-color);
+    }
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -19,7 +19,9 @@
 @use "radio";
 @use "switch";
 @use "viewswitcher";
-@use "flap"; // Added import
+@use "flap";
+@use "avatar";
+@use "row_types"; // Added import
 @use "window";
 
 // Potentially other components if they exist and were modified:


### PR DESCRIPTION
This commit introduces the AdwAvatar component and several specialized row types for AdwListBox, enhancing the framework's UI capabilities.

New Components:

1.  **AdwAvatar:**
    *   Displays images, text initials (fallback), or custom DOM elements as circular avatars.
    *   Supports configurable size, image source, alt text, and fallback text.
    *   Includes SCSS for styling and theme support.

2.  **Specialized ListBox Rows:**
    *   These components are designed for use within `AdwListBox` to create more structured and interactive list items.
    *   **AdwActionRow:** A row that can be activated, typically to trigger an action. Supports title, subtitle, an optional icon, and an optional chevron.
    *   **AdwEntryRow:** A row containing a label and an `AdwEntry` field, suitable for forms within lists.
    *   **AdwExpanderRow:** A row that can be expanded or collapsed to show/hide additional content. Includes title, subtitle, and an animated expander icon.
    *   **AdwComboRow:** A row containing a label and a dropdown/select menu, allowing you to choose from a list of options.

Updates:

*   **JavaScript (`js/components.js`):** Added creation functions for all new components.
*   **SCSS:**
    *   Added `scss/_avatar.scss` for AdwAvatar styling.
    *   Added `scss/_row_types.scss` for styling the new specialized ListBox rows.
    *   Both new SCSS files are imported into the main `style.scss`.
*   **Documentation (`README.md`):** Updated to include comprehensive documentation for `AdwAvatar` and all new row types, covering their options and usage examples.
*   **Examples (`index.html`):** Added new sections and examples to demonstrate the functionality and appearance of `AdwAvatar` and the specialized ListBox rows.