### PR TITLE
fix: Add test page for Adwaita widget rendering

### DIFF
--- a/app-demo/app.py
+++ b/app-demo/app.py
@@ -46,5 +46,9 @@ def create_post():
         # For simplicity, just re-rendering for now.
     return render_template('create_post.html')
 
+@app.route('/test-widget')
+def test_widget_page():
+    return render_template('test_widget.html')
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/app-demo/templates/test_widget.html
+++ b/app-demo/templates/test_widget.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Test Adwaita Widget{% endblock %}
+
+{% block content %}
+    <adw-preferences-page>
+        <adw-preferences-group title="Testing a Single Widget">
+            <p>This page attempts to render a single Adwaita button:</p>
+            <adw-button appearance="suggested">Test Button</adw-button>
+            <p>If you see a styled button above, the component is working. If you only see 'Test Button' as plain text, it is not.</p>
+        </adw-preferences-group>
+    </adw-preferences-page>
+{% endblock %}


### PR DESCRIPTION
Adds a new route /test-widget and a corresponding template templates/test_widget.html to isolate and test the rendering of a single Adwaita component (adw-button).

This is part of the debugging process to understand why Adwaita widgets are not rendering correctly in the Flask application.