### PR TITLE
fix: Remove type=module from components.js script tag

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}My Libadwaita Blog{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='libadwaita-web/style.css') }}">
-    <script src="{{ url_for('static', filename='libadwaita-web/js/components.js') }}" type="module"></script>
+        <script src="{{ url_for('static', filename='libadwaita-web/js/components.js') }}"></script>
 </head>
 <body class="adw-colorscheme-light"> {# Or adw-colorscheme-dark #}
     <adw-application-window>


### PR DESCRIPTION
This is an attempt to see if libadwaita-web's components.js registers custom elements when loaded as a regular script instead of an ES module.

Part of debugging why Adwaita widgets are not rendering.