### PR TITLE
Fix: Ensure all defined routes are reachable in app-demo

### DIFF
--- a/app-demo/templates/settings.html
+++ b/app-demo/templates/settings.html
@@ -20,6 +20,11 @@
             </div>
         </adw-action-row>
     </adw-preferences-group>
+
+    <adw-preferences-group title="Test Pages">
+        <adw-action-row title="Test Widget Page" clickable href="{{ url_for('test_widget_page') }}"></adw-action-row>
+        <adw-action-row title="Test New Widgets Page" clickable href="{{ url_for('test_new_widgets_page') }}"></adw-action-row>
+    </adw-preferences-group>
 </adw-preferences-page>
 
 <script>


### PR DESCRIPTION
The routes /test-widget and /test-new-widgets were defined in app.py but were not linked from any templates, making them unreachable through the UI.

This commit adds links to these two pages within the settings page (app-demo/templates/settings.html) under a new "Test Pages" group. This makes all defined routes accessible via user navigation, addressing the issue report.

The core navigation links in the header (Home, Settings, Profile) and other page-specific links were verified to be unaffected and remain functional.