### PR TITLE
Fix: Ensure app-demo uses the correct project libadwaita styles.

### DIFF
--- a/app-demo/static/css/main.css
+++ b/app-demo/static/css/main.css
@@ -1,27 +1,1852 @@
-@use "variables";
-@use "base";
-@use "action_row";
-@use "avatar";
-@use "banner";
-@use "box";
-@use "button";
-@use "checkbox";
-@use "dialog";
-@use "entry";
-@use "expander_row";
-@use "headerbar";
-@use "label";
-@use "listbox";
-@use "progressbar";
-@use "radio";
-@use "row_types";
-@use "spinner";
-@use "split_button";
-@use "status_page";
-@use "switch";
-@use "viewswitcher";
-@use "flap";
-@use "password_entry_row";
-@use "window";
+@charset "UTF-8";
+:root {
+  --document-font-family: "Cantarell", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --monospace-font-family: "Monaco", "Menlo", "Courier New", monospace;
+  --font-size-base: 10pt;
+  --font-size-small: 8pt;
+  --font-size-large: 12pt;
+  --font-size-h1: 18pt;
+  --font-size-h2: 16pt;
+  --font-size-h3: 14pt;
+  --font-size-h4: 12pt;
+  --border-radius-small: 3px;
+  --border-radius-default: 6px;
+  --border-radius-large: 12px;
+  --window-radius: var(--border-radius-large);
+  --spacing-xxs: 3px;
+  --spacing-xs: 6px;
+  --spacing-s: 9px;
+  --spacing-m: 12px;
+  --spacing-l: 18px;
+  --spacing-xl: 24px;
+  --spacing-xxl: 36px;
+  --opacity-disabled: 0.5;
+  --opacity-hover: 0.8;
+  --opacity-active: 0.6;
+  --border-color-light: rgba(0, 0, 0, 0.12);
+  --border-color-dark: rgba(255, 255, 255, 0.07);
+  --adw-blue-1: #d3e5f7;
+  --adw-blue-3: #3584e4;
+  --adw-blue-5: #1a5fb4;
+  --adw-green-1: #d2f0d4;
+  --adw-green-3: #2ec27e;
+  --adw-green-5: #1b7749;
+  --adw-yellow-1: #fef4d5;
+  --adw-yellow-3: #f8c443;
+  --adw-yellow-5: #b07d0d;
+  --adw-red-1: #f7d4d4;
+  --adw-red-3: #e01b24;
+  --adw-red-5: #a50e17;
+  --adw-blue-4-dark: #2a70c9;
+  --adw-green-4-dark: #218358;
+  --adw-yellow-4-dark: #b07d0d;
+  --adw-red-4-dark: #a50e17;
+  --adw-purple-3: #9141ac;
+  --adw-orange-3: #ff7800;
+  --adw-pink-3: #ffc0cb;
+  --adw-slate-3: #708090;
+  --accent-blue-light-bg: var(--adw-blue-3);
+  --accent-blue-light-fg: #ffffff;
+  --info-bg-color-light: var(--adw-blue-1);
+  --info-border-color-light: var(--adw-blue-3);
+  --info-fg-color-light: var(--adw-blue-5);
+  --success-bg-color-light: var(--adw-green-1);
+  --success-border-color-light: var(--adw-green-3);
+  --success-fg-color-light: var(--adw-green-5);
+  --warning-bg-color-light: var(--adw-yellow-1);
+  --warning-border-color-light: var(--adw-yellow-3);
+  --warning-fg-color-light: var(--adw-yellow-5);
+  --error-bg-color-light: var(--adw-red-1);
+  --error-border-color-light: var(--adw-red-3);
+  --error-fg-color-light: var(--adw-red-5);
+  --accent-green-light-bg: #2ec27e;
+  --accent-green-light-fg: #ffffff;
+  --accent-red-light-bg: var(--adw-red-3);
+  --accent-red-light-fg: #ffffff;
+  --accent-yellow-light-bg: #e5a50a;
+  --accent-yellow-light-fg: rgba(0,0,0,0.87);
+  --accent-purple-light-bg: var(--adw-purple-3);
+  --accent-purple-light-fg: #ffffff;
+  --accent-orange-light-bg: var(--adw-orange-3);
+  --accent-orange-light-fg: #ffffff;
+  --accent-pink-light-bg: var(--adw-pink-3);
+  --accent-pink-light-fg: rgba(0,0,0,0.87);
+  --accent-slate-light-bg: var(--adw-slate-3);
+  --accent-slate-light-fg: #ffffff;
+  --accent-blue-dark-bg: var(--adw-blue-3);
+  --accent-blue-dark-fg: #ffffff;
+  --info-bg-color-dark: var(--adw-blue-4-dark);
+  --info-border-color-dark: var(--adw-blue-3);
+  --info-fg-color-dark: var(--adw-blue-1);
+  --success-bg-color-dark: var(--adw-green-4-dark);
+  --success-border-color-dark: var(--adw-green-3);
+  --success-fg-color-dark: var(--adw-green-1);
+  --warning-bg-color-dark: var(--adw-yellow-4-dark);
+  --warning-border-color-dark: var(--adw-yellow-3);
+  --warning-fg-color-dark: var(--adw-yellow-1);
+  --error-bg-color-dark: var(--adw-red-4-dark);
+  --error-border-color-dark: var(--adw-red-3);
+  --error-fg-color-dark: var(--adw-red-1);
+  --accent-green-dark-bg: #26a269;
+  --accent-green-dark-fg: #ffffff;
+  --accent-red-dark-bg: #c01c28;
+  --accent-red-dark-fg: #ffffff;
+  --accent-yellow-dark-bg: #cd9309;
+  --accent-yellow-dark-fg: rgba(0,0,0,0.87);
+  --accent-purple-dark-bg: #613583;
+  --accent-purple-dark-fg: #ffffff;
+  --accent-orange-dark-bg: #c64600;
+  --accent-orange-dark-fg: #ffffff;
+  --accent-pink-dark-bg: #e6a7b4;
+  --accent-pink-dark-fg: #ffffff;
+  --accent-slate-dark-bg: #5a6773;
+  --accent-slate-dark-fg: #ffffff;
+  --accent-blue-standalone: #1c71d8;
+  --accent-green-standalone: #1b8553;
+  --accent-red-standalone: #c01c28;
+  --accent-yellow-standalone: #9c6e03;
+  --accent-purple-standalone: #813d9c;
+  --accent-orange-standalone: #e66100;
+  --accent-pink-standalone: #e6a7b4;
+  --accent-slate-standalone: #5a6773;
+  --accent-blue-dark-standalone: #78aeed;
+  --accent-green-dark-standalone: #8ff0a4;
+  --accent-red-dark-standalone: #ff7b63;
+  --accent-yellow-dark-standalone: #f8e45c;
+  --accent-purple-dark-standalone: #dc8add;
+  --accent-orange-dark-standalone: #ffbe6f;
+  --accent-pink-dark-standalone: #ff8cc6;
+  --accent-slate-dark-standalone: #8a98a5;
+}
+
+:root {
+  --accent-bg-color: var(--accent-blue-dark-bg);
+  --accent-fg-color: var(--accent-blue-dark-fg);
+  --accent-color: var(--accent-blue-dark-standalone);
+  --destructive-bg-color: var(--accent-red-dark-bg);
+  --destructive-fg-color: var(--accent-red-dark-fg);
+  --destructive-color: var(--accent-red-dark-standalone);
+  --info-bg-color: var(--info-bg-color-dark);
+  --info-fg-color: var(--info-fg-color-dark);
+  --info-border-color: var(--info-border-color-dark);
+  --success-bg-color: var(--success-bg-color-dark);
+  --success-fg-color: var(--success-fg-color-dark);
+  --success-border-color: var(--success-border-color-dark);
+  --success-color: var(--accent-green-dark-standalone);
+  --warning-bg-color: var(--warning-bg-color-dark);
+  --warning-fg-color: var(--warning-fg-color-dark);
+  --warning-border-color: var(--warning-border-color-dark);
+  --warning-color: var(--accent-yellow-dark-standalone);
+  --error-bg-color: var(--error-bg-color-dark);
+  --error-fg-color: var(--error-fg-color-dark);
+  --error-border-color: var(--error-border-color-dark);
+  --error-color: var(--accent-red-dark-standalone);
+  --window-bg-color: #2d2d2d;
+  --window-fg-color: #ffffff;
+  --view-bg-color: #242424;
+  --view-fg-color: #ffffff;
+  --headerbar-bg-color: #3c3c3c;
+  --headerbar-fg-color: #ffffff;
+  --headerbar-border-color: rgba(255, 255, 255, 0.07);
+  --headerbar-backdrop-color: var(--window-bg-color);
+  --headerbar-shade-color: rgba(0, 0, 0, 0.36);
+  --card-bg-color: #383838;
+  --card-fg-color: #ffffff;
+  --card-shade-color: rgba(0, 0, 0, 0.36);
+  --popover-bg-color: #4a4a4a;
+  --popover-fg-color: #ffffff;
+  --popover-shade-color: rgba(0, 0, 0, 0.36);
+  --button-bg-color: #4d4d4d;
+  --button-fg-color: #ffffff;
+  --button-border-color: rgba(255, 255, 255, 0.07);
+  --button-hover-bg-color: #5a5a5a;
+  --button-active-bg-color: #676767;
+  --button-flat-bg-color: transparent;
+  --button-flat-hover-bg-color: rgba(255, 255, 255, 0.08);
+  --button-flat-active-bg-color: rgba(255, 255, 255, 0.12);
+  --sidebar-bg-color: #333333;
+  --sidebar-fg-color: #ffffff;
+  --sidebar-border-color: rgba(255,255,255,0.07);
+  --sidebar-shade-color: rgba(0,0,0,0.36);
+  --secondary-sidebar-bg-color: #3a3a3a;
+  --secondary-sidebar-fg-color: #ffffff;
+  --secondary-sidebar-border-color: rgba(255,255,255,0.07);
+  --secondary-sidebar-shade-color: rgba(0,0,0,0.36);
+  --dialog-bg-color: #2f2f2f;
+  --dialog-fg-color: #ffffff;
+  --thumbnail-bg-color: #242424;
+  --thumbnail-fg-color: #ffffff;
+  --shade-color: rgba(0, 0, 0, 0.36);
+  --scrollbar-outline-color: rgba(0, 0, 0, 0.5);
+  --link-color: var(--accent-bg-color);
+  --link-visited-color: #c0c0c0;
+  --progress-bar-track-color: var(--shade-color);
+  --progress-bar-fill-color: var(--accent-bg-color);
+  --accent-bg-color: var(--accent-blue-dark-bg);
+  --accent-fg-color: var(--accent-blue-dark-fg);
+  --accent-color: var(--accent-blue-dark-standalone);
+}
+
+body.light-theme {
+  --accent-bg-color: var(--accent-blue-light-bg);
+  --accent-fg-color: var(--accent-blue-light-fg);
+  --accent-color: var(--accent-blue-standalone);
+  --destructive-bg-color: var(--accent-red-light-bg);
+  --destructive-fg-color: var(--accent-red-light-fg);
+  --destructive-color: var(--accent-red-standalone);
+  --info-bg-color: var(--info-bg-color-light);
+  --info-fg-color: var(--info-fg-color-light);
+  --info-border-color: var(--info-border-color-light);
+  --success-bg-color: var(--success-bg-color-light);
+  --success-fg-color: var(--success-fg-color-light);
+  --success-border-color: var(--success-border-color-light);
+  --success-color: var(--accent-green-standalone);
+  --warning-bg-color: var(--warning-bg-color-light);
+  --warning-fg-color: var(--warning-fg-color-light);
+  --warning-border-color: var(--warning-border-color-light);
+  --warning-color: var(--accent-yellow-standalone);
+  --error-bg-color: var(--error-bg-color-light);
+  --error-fg-color: var(--error-fg-color-light);
+  --error-border-color: var(--error-border-color-light);
+  --error-color: var(--accent-red-standalone);
+  --window-bg-color: #f6f5f4;
+  --window-fg-color: rgba(0, 0, 0, 0.8);
+  --view-bg-color: #ffffff;
+  --view-fg-color: rgba(0, 0, 0, 0.8);
+  --headerbar-bg-color: #ebeae9;
+  --headerbar-fg-color: rgba(0, 0, 0, 0.8);
+  --headerbar-border-color: rgba(0, 0, 0, 0.12);
+  --headerbar-backdrop-color: var(--window-bg-color);
+  --headerbar-shade-color: rgba(0, 0, 0, 0.07);
+  --card-bg-color: #ffffff;
+  --card-fg-color: rgba(0, 0, 0, 0.8);
+  --card-shade-color: rgba(0, 0, 0, 0.07);
+  --popover-bg-color: #ffffff;
+  --popover-fg-color: rgba(0, 0, 0, 0.8);
+  --popover-shade-color: rgba(0, 0, 0, 0.07);
+  --button-bg-color: #ebeae9;
+  --button-fg-color: rgba(0, 0, 0, 0.8);
+  --button-border-color: rgba(0, 0, 0, 0.12);
+  --button-hover-bg-color: #deddda;
+  --button-active-bg-color: #d1cfce;
+  --button-flat-bg-color: transparent;
+  --button-flat-hover-bg-color: rgba(0, 0, 0, 0.05);
+  --button-flat-active-bg-color: rgba(0, 0, 0, 0.1);
+  --sidebar-bg-color: #f0efee;
+  --sidebar-fg-color: rgba(0,0,0,0.8);
+  --sidebar-border-color: rgba(0,0,0,0.12);
+  --sidebar-shade-color: rgba(0, 0, 0, 0.07);
+  --secondary-sidebar-bg-color: #e4e3e2;
+  --secondary-sidebar-fg-color: rgba(0,0,0,0.8);
+  --secondary-sidebar-border-color: rgba(0,0,0,0.12);
+  --secondary-sidebar-shade-color: rgba(0, 0, 0, 0.07);
+  --dialog-bg-color: #fdfcfb;
+  --dialog-fg-color: rgba(0, 0, 0, 0.8);
+  --thumbnail-bg-color: #ffffff;
+  --thumbnail-fg-color: rgba(0, 0, 0, 0.8);
+  --shade-color: rgba(0, 0, 0, 0.07);
+  --scrollbar-outline-color: #ffffff;
+  --link-color: var(--accent-bg-color);
+  --link-visited-color: #5a5a5a;
+  --progress-bar-track-color: var(--shade-color);
+  --progress-bar-fill-color: var(--accent-bg-color);
+  --accent-bg-color: var(--accent-blue-light-bg);
+  --accent-fg-color: var(--accent-blue-light-fg);
+  --accent-color: var(--accent-blue-standalone);
+}
+
+:root {
+  @define-color accent_bg_color var(--accent-bg-color);
+  @define-color accent_fg_color var(--accent-fg-color);
+  @define-color destructive_bg_color var(--destructive-bg-color);
+  @define-color destructive_fg_color var(--destructive-fg-color);
+  @define-color success_bg_color var(--success-bg-color);
+  @define-color success_fg_color var(--success-fg-color);
+  @define-color warning_bg_color var(--warning-bg-color);
+  @define-color warning_fg_color var(--warning-fg-color);
+  @define-color error_bg_color var(--error-bg-color);
+  @define-color error_fg_color var(--error-fg-color);
+  @define-color window_bg_color var(--window-bg-color);
+  @define-color window_fg_color var(--window-fg-color);
+  @define-color view_bg_color var(--view-bg-color);
+  @define-color view_fg_color var(--view-fg-color);
+  @define-color headerbar_bg_color var(--headerbar-bg-color);
+  @define-color headerbar_fg_color var(--headerbar-fg-color);
+  @define-color headerbar_border_color var(--headerbar-border-color);
+  @define-color headerbar_backdrop_color var(--headerbar-backdrop-color);
+  @define-color headerbar_shade_color var(--headerbar-shade-color);
+  @define-color card_bg_color var(--card-bg-color);
+  @define-color card_fg_color var(--card-fg-color);
+  @define-color card_shade_color var(--card-shade-color);
+  @define-color popover_bg_color var(--popover-bg-color);
+  @define-color popover_fg_color var(--popover-fg-color);
+  @define-color popover_shade_color var(--popover-shade-color);
+  @define-color dialog_bg_color var(--dialog-bg-color);
+  @define-color dialog_fg_color var(--dialog-fg-color);
+  @define-color thumbnail_bg_color var(--thumbnail-bg-color);
+  @define-color thumbnail_fg_color var(--thumbnail-fg-color);
+  @define-color sidebar_bg_color var(--sidebar-bg-color);
+  @define-color sidebar_fg_color var(--sidebar-fg-color);
+  @define-color sidebar_border_color var(--sidebar-border-color);
+  @define-color sidebar_shade_color var(--sidebar-shade-color);
+  @define-color secondary_sidebar_bg_color var(--secondary-sidebar-bg-color);
+  @define-color secondary_sidebar_fg_color var(--secondary-sidebar-fg-color);
+  @define-color secondary_sidebar_border_color var(--secondary-sidebar-border-color);
+  @define-color secondary_sidebar_shade_color var(--secondary-sidebar-shade-color);
+  @define-color shade_color var(--shade-color);
+  @define-color scrollbar_outline_color var(--scrollbar-outline-color);
+  @define-color progress_bar_track_color var(--progress-bar-track-color);
+  @define-color progress_bar_fill_color var(--progress-bar-fill-color);
+  @define-color accent_color var(--accent-color);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--document-font-family);
+  font-size: var(--font-size-base);
+  color: var(--window-fg-color);
+  background-color: var(--window-bg-color);
+  margin: 0;
+  min-height: 100vh;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+a:focus-visible {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 1px;
+  border-radius: var(--border-radius-small);
+}
+
+ul, ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: var(--spacing-m) 0;
+  font-weight: bold;
+  line-height: 1.3;
+}
+
+h1 {
+  font-size: var(--font-size-h1);
+}
+
+h2 {
+  font-size: var(--font-size-h2);
+}
+
+h3 {
+  font-size: var(--font-size-h3);
+}
+
+h4 {
+  font-size: var(--font-size-h4);
+}
+
+img, picture, video, canvas, svg {
+  display: block;
+  max-width: 100%;
+}
+
+input, button, textarea, select {
+  font: inherit;
+}
+
+button, [role=button] {
+  cursor: pointer;
+}
+
+.adw-action-row {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-m) var(--spacing-l);
+  background-color: var(--card-bg-color);
+  border-bottom: var(--border-width, 1px) solid var(--border-color-light);
+  min-height: 48px;
+}
+.adw-action-row.activatable {
+  cursor: pointer;
+}
+.adw-action-row.activatable:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.adw-action-row.activatable:active {
+  background-color: var(--button-active-bg-color);
+}
+.adw-action-row .adw-action-row-prefix {
+  margin-right: var(--spacing-m);
+  display: flex;
+  align-items: center;
+}
+.adw-action-row .adw-action-row-content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+}
+.adw-action-row .adw-action-row-title {
+  font-size: var(--font-size-base);
+  color: var(--card-fg-color);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.adw-action-row .adw-action-row-subtitle {
+  font-size: var(--font-size-small);
+  color: var(--card-fg-color);
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+.adw-action-row .adw-action-row-suffix {
+  margin-left: var(--spacing-m);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.dark-theme .adw-action-row,
+body.dark-theme .adw-action-row {
+  border-bottom-color: var(--border-color-dark);
+}
+
+:root {
+  --avatar-bg-color: var(--shade-color);
+  --avatar-text-color: var(--view-fg-color);
+}
+
+.adw-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--avatar-bg-color);
+  color: var(--avatar-text-color);
+  font-weight: bold;
+  vertical-align: middle;
+  user-select: none;
+  box-sizing: border-box;
+}
+.adw-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.adw-avatar .adw-avatar-text {
+  color: var(--avatar-text-color);
+  text-align: center;
+  line-height: 1;
+}
+
+.adw-avatar.size-tiny {
+  width: 16px;
+  height: 16px;
+}
+
+.adw-avatar.size-small {
+  width: 24px;
+  height: 24px;
+}
+
+.adw-avatar.size-medium {
+  width: 48px;
+  height: 48px;
+}
+
+.adw-avatar.size-large {
+  width: 72px;
+  height: 72px;
+}
+
+.adw-avatar.size-huge {
+  width: 96px;
+  height: 96px;
+}
+
+.adw-banner {
+  padding: var(--spacing-m) var(--spacing-l);
+  border-radius: var(--border-radius-default);
+  border: 1px solid transparent;
+  margin-bottom: var(--spacing-m);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.adw-banner.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.adw-banner.info {
+  background-color: var(--info-bg-color);
+  border-color: var(--info-border-color);
+  color: var(--info-fg-color);
+}
+.adw-banner.success {
+  background-color: var(--success-bg-color);
+  border-color: var(--success-border-color);
+  color: var(--success-fg-color);
+}
+.adw-banner.warning {
+  background-color: var(--warning-bg-color);
+  border-color: var(--warning-border-color);
+  color: var(--warning-fg-color);
+}
+.adw-banner.error {
+  background-color: var(--error-bg-color);
+  border-color: var(--error-border-color);
+  color: var(--error-fg-color);
+}
+.adw-banner .adw-banner-message {
+  flex-grow: 1;
+}
+.adw-banner .adw-banner-close-button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.2em;
+  cursor: pointer;
+  padding: 0 var(--spacing-xs);
+  margin-left: var(--spacing-m);
+}
+
+.adw-box {
+  display: flex;
+}
+.adw-box.adw-box-vertical {
+  flex-direction: column;
+}
+.adw-box.align-start {
+  align-items: flex-start;
+}
+.adw-box.align-center {
+  align-items: center;
+}
+.adw-box.align-end {
+  align-items: flex-end;
+}
+.adw-box.align-stretch {
+  align-items: stretch;
+}
+.adw-box.justify-start {
+  justify-content: flex-start;
+}
+.adw-box.justify-center {
+  justify-content: center;
+}
+.adw-box.justify-end {
+  justify-content: flex-end;
+}
+.adw-box.justify-between {
+  justify-content: space-between;
+}
+.adw-box.justify-around {
+  justify-content: space-around;
+}
+.adw-box.justify-evenly {
+  justify-content: space-evenly;
+}
+.adw-box.adw-box-spacing-xs {
+  gap: var(--spacing-xs);
+}
+.adw-box.adw-box-spacing-s {
+  gap: var(--spacing-s);
+}
+.adw-box.adw-box-spacing-m {
+  gap: var(--spacing-m);
+}
+.adw-box.adw-box-spacing-l {
+  gap: var(--spacing-l);
+}
+.adw-box.adw-box-spacing-xl {
+  gap: var(--spacing-xl);
+}
+.adw-box.adw-box-fill-children > * {
+  flex-grow: 1;
+  flex-basis: 0;
+}
+
+.adw-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--spacing-m);
+  gap: var(--spacing-s);
+}
+.adw-row:last-child {
+  margin-bottom: 0;
+}
+
+.adw-card {
+  background-color: var(--card-bg-color);
+  color: var(--card-fg-color);
+  border-radius: var(--border-radius-large);
+  padding: var(--spacing-l);
+  box-shadow: 0 0 0 1px var(--border-color-light, rgba(0, 0, 0, 0.08)), 0 4px 8px -2px rgba(0, 0, 0, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
+}
+
+.dark-theme .adw-card,
+body.dark-theme .adw-card {
+  box-shadow: 0 0 0 1px var(--border-color-dark, rgba(255, 255, 255, 0.08)), 0 4px 8px -2px rgba(0, 0, 0, 0.25), 0 3px 6px rgba(0, 0, 0, 0.2);
+}
+
+.adw-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-s) var(--spacing-m);
+  border-width: var(--border-width, 1px);
+  border-style: solid;
+  border-color: var(--button-border-color);
+  border-radius: var(--border-radius-default);
+  background-color: var(--button-bg-color);
+  color: var(--button-fg-color);
+  cursor: pointer;
+  text-decoration: none;
+  font-size: var(--font-size-base);
+  text-align: center;
+  transition: background-color 0.1s ease-out, border-color 0.1s ease-out, box-shadow 0.1s ease-out, filter 0.1s ease-out;
+  font-weight: 500;
+}
+.adw-button:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.adw-button:active, .adw-button.active {
+  background-color: var(--button-active-bg-color);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.adw-button:focus-visible {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 2px;
+}
+.adw-button.suggested-action {
+  background-color: var(--accent-bg-color);
+  color: var(--accent-fg-color);
+  border-color: transparent;
+}
+.adw-button.suggested-action:hover {
+  filter: brightness(95%);
+}
+.adw-button.suggested-action:active, .adw-button.suggested-action.active {
+  filter: brightness(90%);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.adw-button.flat {
+  background-color: var(--button-flat-bg-color);
+  color: var(--button-fg-color);
+  border-color: transparent;
+  box-shadow: none;
+}
+.adw-button.flat:hover {
+  background-color: var(--button-flat-hover-bg-color);
+}
+.adw-button.flat:active, .adw-button.flat.active {
+  background-color: var(--button-flat-active-bg-color);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+.adw-button.destructive-action {
+  background-color: var(--destructive-bg-color);
+  color: var(--destructive-fg-color);
+  border-color: transparent;
+}
+.adw-button.destructive-action:hover {
+  filter: brightness(95%);
+}
+.adw-button.destructive-action:active, .adw-button.destructive-action.active {
+  filter: brightness(90%);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.adw-button[disabled], .adw-button:disabled {
+  background-color: var(--button-bg-color);
+  color: var(--button-fg-color);
+  border-color: var(--button-border-color);
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+  pointer-events: none;
+  box-shadow: none;
+}
+.adw-button .icon {
+  margin-right: var(--spacing-xs);
+}
+.adw-button.circular {
+  padding: var(--spacing-s);
+  border-radius: 50%;
+}
+.adw-button.circular .icon {
+  margin-right: 0;
+}
+
+.adw-checkbox {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: var(--spacing-s);
+}
+.adw-checkbox input[type=checkbox] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.adw-checkbox input[type=checkbox]:checked + .adw-checkbox-indicator {
+  background-color: var(--accent-bg-color);
+  border-color: var(--accent-bg-color);
+}
+.adw-checkbox input[type=checkbox]:checked + .adw-checkbox-indicator:before {
+  content: "";
+  display: block;
+  width: 5px;
+  height: 9px;
+  border-style: solid;
+  border-color: var(--accent-fg-color);
+  border-width: 0 2px 2px 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -60%) rotate(45deg);
+}
+.adw-checkbox input[type=checkbox]:disabled + .adw-checkbox-indicator {
+  background-color: var(--shade-color);
+  border-color: var(--border-color-light);
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+}
+.adw-checkbox input[type=checkbox]:disabled:checked + .adw-checkbox-indicator {
+  background-color: var(--accent-bg-color);
+  border-color: var(--accent-bg-color);
+  opacity: var(--opacity-disabled, 0.5);
+}
+.adw-checkbox input[type=checkbox]:disabled:checked + .adw-checkbox-indicator:before {
+  border-color: var(--accent-fg-color);
+}
+.adw-checkbox input[type=checkbox]:focus-visible + .adw-checkbox-indicator {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 2px;
+}
+.adw-checkbox .adw-checkbox-indicator {
+  width: 18px;
+  height: 18px;
+  border-width: var(--border-width, 1px);
+  border-style: solid;
+  border-color: var(--border-color-light);
+  border-radius: var(--border-radius-small);
+  background-color: var(--view-bg-color);
+  position: relative;
+  transition: background-color 0.1s ease-out, border-color 0.1s ease-out;
+  flex-shrink: 0;
+}
+.adw-checkbox .adw-checkbox-label {
+  color: var(--view-fg-color);
+  line-height: 1.2;
+}
+
+.dark-theme .adw-checkbox input[type=checkbox]:disabled + .adw-checkbox-indicator,
+body.dark-theme .adw-checkbox input[type=checkbox]:disabled + .adw-checkbox-indicator {
+  border-color: var(--border-color-dark);
+}
+.dark-theme .adw-checkbox .adw-checkbox-indicator,
+body.dark-theme .adw-checkbox .adw-checkbox-indicator {
+  border-color: var(--border-color-dark);
+  background-color: var(--view-bg-color);
+}
+.dark-theme .adw-checkbox .adw-checkbox-label,
+body.dark-theme .adw-checkbox .adw-checkbox-label {
+  color: var(--view-fg-color);
+}
+
+.adw-dialog {
+  background-color: var(--dialog-bg-color);
+  color: var(--dialog-fg-color);
+  border-radius: var(--window-radius);
+  box-shadow: 0 0 0 1px var(--border-color-light, rgba(0, 0, 0, 0.08)), 0 8px 16px -4px rgba(0, 0, 0, 0.1), 0 6px 12px rgba(0, 0, 0, 0.08);
+  padding: var(--spacing-l);
+  width: 90%;
+  max-width: 550px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+  z-index: 500;
+  opacity: 0;
+  transition: opacity 0.15s ease-out, transform 0.15s ease-out;
+}
+.adw-dialog.open {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+.adw-dialog .adw-dialog-title {
+  font-size: var(--font-size-h3);
+  margin-bottom: var(--spacing-m);
+  font-weight: bold;
+  color: var(--headerbar-fg-color);
+}
+.adw-dialog .adw-dialog-content {
+  margin-bottom: var(--spacing-l);
+}
+.adw-dialog .adw-dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-s);
+}
+.adw-dialog .adw-dialog-buttons .adw-button {
+  margin-left: 0;
+}
+
+.dark-theme .adw-dialog,
+body.dark-theme .adw-dialog {
+  box-shadow: 0 0 0 1px var(--border-color-dark, rgba(255, 255, 255, 0.08)), 0 8px 16px -4px rgba(0, 0, 0, 0.25), 0 6px 12px rgba(0, 0, 0, 0.2);
+}
+
+.adw-dialog-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.25);
+  z-index: 499;
+  opacity: 0;
+  transition: opacity 0.15s ease-out;
+}
+.adw-dialog-backdrop.open {
+  opacity: 1;
+}
+
+.adw-entry {
+  padding: var(--spacing-s) var(--spacing-m);
+  border-width: var(--border-width, 1px);
+  border-style: solid;
+  border-color: var(--border-color-light);
+  border-radius: var(--border-radius-default);
+  background-color: var(--view-bg-color);
+  color: var(--view-fg-color);
+  font-size: var(--font-size-base);
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.03);
+}
+.adw-entry:focus, .adw-entry:focus-within {
+  outline: none;
+  border-color: var(--accent-bg-color);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.03), 0 0 0 2px rgba(var(--accent-bg-color), 0.3);
+}
+.adw-entry::placeholder {
+  color: var(--window-fg-color);
+  opacity: 0.6;
+}
+.adw-entry[disabled], .adw-entry:disabled {
+  opacity: var(--opacity-disabled, 0.5);
+  pointer-events: none;
+  background-color: var(--shade-color);
+  border-color: var(--border-color-light);
+  box-shadow: none;
+}
+
+.dark-theme .adw-entry,
+body.dark-theme .adw-entry {
+  border-color: var(--border-color-dark);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.03);
+}
+.dark-theme .adw-entry[disabled], .dark-theme .adw-entry:disabled,
+body.dark-theme .adw-entry[disabled],
+body.dark-theme .adw-entry:disabled {
+  border-color: var(--border-color-dark);
+  background-color: var(--shade-color);
+}
+
+.adw-expander-row > .adw-action-row {
+  cursor: pointer;
+  position: relative;
+}
+.adw-expander-row > .adw-action-row .adw-expander-row-arrow {
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid var(--window-fg-color);
+  transition: transform 0.15s ease-in-out;
+  margin-left: var(--spacing-s);
+  opacity: 0.7;
+}
+.adw-expander-row > .adw-action-row.expanded .adw-expander-row-arrow {
+  transform: rotate(90deg);
+}
+.adw-expander-row > .adw-action-row .adw-action-row-suffix .adw-expander-row-arrow {
+  margin-left: 0;
+}
+.adw-expander-row .adw-expander-row-content-area {
+  padding: var(--spacing-m) var(--spacing-l);
+  padding-left: calc(var(--spacing-l) + var(--spacing-m) + 5px);
+  background-color: var(--shade-color);
+  border-bottom: var(--border-width, 1px) solid var(--border-color-light);
+  display: none;
+}
+.adw-expander-row .adw-expander-row-content-area.visible {
+  display: block;
+}
+.adw-expander-row:last-child > .adw-expander-row-content-area {
+  border-bottom-left-radius: var(--border-radius-default);
+  border-bottom-right-radius: var(--border-radius-default);
+}
+
+.dark-theme .adw-expander-row .adw-expander-row-content-area,
+body.dark-theme .adw-expander-row .adw-expander-row-content-area {
+  border-bottom-color: var(--border-color-dark);
+}
+
+.adw-header-bar {
+  background-color: var(--headerbar-bg-color);
+  color: var(--headerbar-fg-color);
+  border-bottom: var(--border-width, 1px) solid var(--headerbar-border-color);
+  padding: var(--spacing-xs) var(--spacing-m);
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+}
+.adw-header-bar .adw-header-bar-start,
+.adw-header-bar .adw-header-bar-end {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.adw-header-bar .adw-header-bar-start > *,
+.adw-header-bar .adw-header-bar-start adw-button,
+.adw-header-bar .adw-header-bar-start a,
+.adw-header-bar .adw-header-bar-end > *,
+.adw-header-bar .adw-header-bar-end adw-button,
+.adw-header-bar .adw-header-bar-end a {
+  color: var(--headerbar-fg-color);
+}
+.adw-header-bar .adw-header-bar-start > *.adw-button.circular,
+.adw-header-bar .adw-header-bar-start adw-button.adw-button.circular,
+.adw-header-bar .adw-header-bar-start a.adw-button.circular,
+.adw-header-bar .adw-header-bar-end > *.adw-button.circular,
+.adw-header-bar .adw-header-bar-end adw-button.adw-button.circular,
+.adw-header-bar .adw-header-bar-end a.adw-button.circular {
+  padding: var(--spacing-xxs);
+}
+.adw-header-bar .adw-header-bar-start > *, .adw-header-bar .adw-header-bar-start adw-button, .adw-header-bar .adw-header-bar-start a {
+  margin-right: var(--spacing-xs);
+}
+.adw-header-bar .adw-header-bar-start > *:last-child, .adw-header-bar .adw-header-bar-start adw-button:last-child, .adw-header-bar .adw-header-bar-start a:last-child {
+  margin-right: 0;
+}
+.adw-header-bar .adw-header-bar-end {
+  margin-left: auto;
+}
+.adw-header-bar .adw-header-bar-end > *, .adw-header-bar .adw-header-bar-end adw-button, .adw-header-bar .adw-header-bar-end a {
+  margin-left: var(--spacing-xs);
+  margin-right: 0;
+}
+.adw-header-bar .adw-header-bar-end > *:first-child, .adw-header-bar .adw-header-bar-end adw-button:first-child, .adw-header-bar .adw-header-bar-end a:first-child {
+  margin-left: 0;
+}
+.adw-header-bar .adw-header-bar-center-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+  flex-shrink: 1;
+  min-width: 0;
+  text-align: center;
+  margin: 0 var(--spacing-m);
+}
+.adw-header-bar .adw-header-bar-title {
+  font-size: var(--font-size-large);
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+.adw-header-bar .adw-header-bar-subtitle {
+  font-size: var(--font-size-small);
+  color: var(--headerbar-fg-color);
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+  margin-top: 2px;
+}
+.adw-header-bar.scrolled {
+  box-shadow: 0 2px 4px -2px var(--headerbar-shade-color);
+}
+.adw-header-bar a,
+.adw-header-bar adw-button,
+.adw-header-bar .adw-button {
+  color: var(--headerbar-fg-color);
+  text-decoration: none;
+}
+.adw-header-bar a:hover,
+.adw-header-bar adw-button:hover,
+.adw-header-bar .adw-button:hover {
+  color: var(--headerbar-fg-color);
+}
+
+.adw-label {
+  color: var(--view-fg-color);
+  font-family: var(--document-font-family);
+  line-height: 1.5;
+}
+.adw-label::selection {
+  background-color: var(--accent-bg-color);
+  color: var(--accent-fg-color);
+}
+.adw-label.h1, .adw-label.title-1 {
+  font-size: var(--font-size-h1);
+  font-weight: bold;
+  line-height: 1.3;
+}
+.adw-label.h2, .adw-label.title-2 {
+  font-size: var(--font-size-h2);
+  font-weight: bold;
+  line-height: 1.3;
+}
+.adw-label.h3, .adw-label.title-3 {
+  font-size: var(--font-size-h3);
+  font-weight: bold;
+  line-height: 1.4;
+}
+.adw-label.h4, .adw-label.title-4 {
+  font-size: var(--font-size-h4);
+  font-weight: bold;
+  line-height: 1.4;
+}
+.adw-label.body {
+  font-size: var(--font-size-base);
+  font-weight: normal;
+}
+.adw-label.small, .adw-label.caption {
+  font-size: var(--font-size-small);
+  color: var(--view-fg-color);
+  opacity: 0.75;
+}
+.adw-label.em {
+  font-style: italic;
+}
+.adw-label.strong {
+  font-weight: bold;
+}
+.adw-label.disabled {
+  color: var(--view-fg-color);
+  opacity: var(--opacity-disabled, 0.5);
+  user-select: none;
+}
+.adw-label.link {
+  color: var(--link-color);
+  cursor: pointer;
+  text-decoration: none;
+}
+.adw-label.link:hover {
+  text-decoration: underline;
+}
+
+.dark-theme .adw-label,
+body.dark-theme .adw-label {
+  color: var(--view-fg-color);
+}
+.dark-theme .adw-label.small, .dark-theme .adw-label.caption,
+body.dark-theme .adw-label.small,
+body.dark-theme .adw-label.caption {
+  color: var(--view-fg-color);
+  opacity: 0.75;
+}
+.dark-theme .adw-label.disabled,
+body.dark-theme .adw-label.disabled {
+  color: var(--view-fg-color);
+  opacity: var(--opacity-disabled, 0.5);
+}
+.dark-theme .adw-label.link,
+body.dark-theme .adw-label.link {
+  color: var(--link-color);
+}
+.dark-theme .adw-label::selection,
+body.dark-theme .adw-label::selection {
+  background-color: var(--accent-bg-color);
+  color: var(--accent-fg-color);
+}
+
+.adw-list-box {
+  background-color: var(--view-bg-color);
+  border: var(--border-width, 1px) solid var(--border-color-light);
+  border-radius: var(--border-radius-default);
+  overflow: hidden;
+}
+.adw-list-box .adw-list-row {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-m);
+  border-bottom: var(--border-width, 1px) solid var(--border-color-light);
+  transition: background-color 0.1s ease-out, color 0.1s ease-out;
+  cursor: default;
+}
+.adw-list-box .adw-list-row:last-child {
+  border-bottom: none;
+}
+.adw-list-box .adw-list-row:hover {
+  background-color: var(--shade-color);
+}
+.adw-list-box .adw-list-row.interactive {
+  cursor: pointer;
+}
+.adw-list-box .adw-list-row.activatable:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.adw-list-box .adw-list-row.activated, .adw-list-box .adw-list-row.selected {
+  background-color: var(--accent-bg-color);
+  color: var(--accent-fg-color);
+}
+.adw-list-box .adw-list-row.activated .adw-label, .adw-list-box .adw-list-row.activated .icon,
+.adw-list-box .adw-list-row.activated > *, .adw-list-box .adw-list-row.selected .adw-label, .adw-list-box .adw-list-row.selected .icon,
+.adw-list-box .adw-list-row.selected > * {
+  color: var(--accent-fg-color);
+}
+.adw-list-box .adw-list-row[disabled], .adw-list-box .adw-list-row:disabled {
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+  background-color: transparent;
+}
+.adw-list-box .adw-list-row[disabled]:hover, .adw-list-box .adw-list-row:disabled:hover {
+  background-color: transparent;
+}
+.adw-list-box .adw-list-row .title {
+  font-weight: 500;
+  color: var(--view-fg-color);
+}
+.adw-list-box .adw-list-row .subtitle {
+  font-size: var(--font-size-small);
+  color: var(--view-fg-color);
+  opacity: 0.7;
+}
+.adw-list-box .adw-list-row.activated .title, .adw-list-box .adw-list-row.activated .subtitle {
+  color: var(--accent-fg-color);
+  opacity: 1;
+}
+
+.dark-theme .adw-list-box,
+body.dark-theme .adw-list-box {
+  border-color: var(--border-color-dark);
+}
+.dark-theme .adw-list-box .adw-list-row,
+body.dark-theme .adw-list-box .adw-list-row {
+  border-bottom-color: var(--border-color-dark);
+}
+.dark-theme .adw-list-box .adw-list-row:hover,
+body.dark-theme .adw-list-box .adw-list-row:hover {
+  background-color: var(--shade-color);
+}
+.dark-theme .adw-list-box .adw-list-row.activatable:hover,
+body.dark-theme .adw-list-box .adw-list-row.activatable:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.dark-theme .adw-list-box .adw-list-row .title,
+body.dark-theme .adw-list-box .adw-list-row .title {
+  color: var(--view-fg-color);
+}
+.dark-theme .adw-list-box .adw-list-row .subtitle,
+body.dark-theme .adw-list-box .adw-list-row .subtitle {
+  color: var(--view-fg-color);
+}
+
+.adw-list-box.flat {
+  border: none;
+  border-radius: 0;
+}
+
+.adw-progress-bar {
+  width: 100%;
+  height: 6px;
+  background-color: var(--progress-bar-track-color, var(--shade-color));
+  border-radius: 3px;
+  overflow: hidden;
+  position: relative;
+}
+.adw-progress-bar .adw-progress-bar-value {
+  height: 100%;
+  background-color: var(--progress-bar-fill-color, var(--accent-bg-color));
+  width: 0%;
+  transition: width 0.15s ease-out;
+  border-radius: 3px;
+}
+.adw-progress-bar[disabled] {
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+}
+.adw-progress-bar.indeterminate .adw-progress-bar-value {
+  width: 100% !important;
+  background-color: transparent;
+}
+.adw-progress-bar.indeterminate:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 30%;
+  background-color: var(--accent-bg-color);
+  border-radius: 3px;
+  animation: adw-progress-indeterminate 1.5s infinite ease-in-out;
+}
+
+@keyframes adw-progress-indeterminate {
+  0% {
+    left: -35%;
+    width: 30%;
+  }
+  50% {
+    left: 50%;
+    width: 40%;
+  }
+  100% {
+    left: 105%;
+    width: 30%;
+  }
+}
+.adw-radio {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: var(--spacing-s);
+}
+.adw-radio input[type=radio] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.adw-radio input[type=radio]:checked + .adw-radio-indicator {
+  border-color: var(--accent-bg-color);
+}
+.adw-radio input[type=radio]:checked + .adw-radio-indicator:before {
+  content: "";
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--accent-bg-color);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.adw-radio input[type=radio]:disabled + .adw-radio-indicator {
+  background-color: var(--shade-color);
+  border-color: var(--border-color-light);
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+}
+.adw-radio input[type=radio]:disabled + .adw-radio-indicator:before {
+  background-color: transparent;
+}
+.adw-radio input[type=radio]:disabled:checked + .adw-radio-indicator {
+  border-color: var(--accent-bg-color);
+  opacity: var(--opacity-disabled, 0.5);
+}
+.adw-radio input[type=radio]:disabled:checked + .adw-radio-indicator:before {
+  background-color: var(--accent-bg-color);
+}
+.adw-radio input[type=radio]:focus-visible + .adw-radio-indicator {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 2px;
+}
+.adw-radio .adw-radio-indicator {
+  width: 18px;
+  height: 18px;
+  border-width: var(--border-width, 1px);
+  border-style: solid;
+  border-color: var(--border-color-light);
+  border-radius: 50%;
+  background-color: var(--view-bg-color);
+  position: relative;
+  transition: background-color 0.1s ease-out, border-color 0.1s ease-out;
+  flex-shrink: 0;
+}
+.adw-radio .adw-radio-label {
+  color: var(--view-fg-color);
+  line-height: 1.2;
+}
+
+.dark-theme .adw-radio input[type=radio]:disabled + .adw-radio-indicator,
+body.dark-theme .adw-radio input[type=radio]:disabled + .adw-radio-indicator {
+  border-color: var(--border-color-dark);
+}
+.dark-theme .adw-radio input[type=radio]:disabled:checked + .adw-radio-indicator,
+body.dark-theme .adw-radio input[type=radio]:disabled:checked + .adw-radio-indicator {
+  border-color: var(--accent-bg-color);
+}
+.dark-theme .adw-radio .adw-radio-indicator,
+body.dark-theme .adw-radio .adw-radio-indicator {
+  border-color: var(--border-color-dark);
+  background-color: var(--view-bg-color);
+}
+.dark-theme .adw-radio .adw-radio-label,
+body.dark-theme .adw-radio .adw-radio-label {
+  color: var(--view-fg-color);
+}
+
+.adw-action-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+}
+.adw-action-row .adw-action-row-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.adw-action-row .adw-action-row-icon svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+.adw-action-row .adw-action-row-text-content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+}
+.adw-action-row .adw-action-row-title {
+  font-weight: normal;
+  color: var(--view-fg-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.adw-action-row .adw-action-row-subtitle {
+  font-size: var(--font-size-small);
+  color: var(--view-fg-color);
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.adw-action-row .adw-action-row-chevron {
+  flex-shrink: 0;
+  font-size: var(--font-size-large);
+  opacity: 0.5;
+}
+.adw-action-row .adw-action-row-chevron::after {
+  content: "❯";
+}
+.adw-entry-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+}
+.adw-entry-row .adw-entry-row-entry {
+  flex-grow: 1;
+}
+
+.adw-expander-row-wrapper:not(:last-child) {
+  border-bottom: var(--border-width, 1px) solid var(--border-color-light);
+}
+
+.dark-theme .adw-expander-row-wrapper:not(:last-child),
+body.dark-theme .adw-expander-row-wrapper:not(:last-child) {
+  border-bottom-color: var(--border-color-dark);
+}
+
+.adw-expander-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+}
+.adw-expander-row .adw-expander-row-text-content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+}
+.adw-expander-row .adw-expander-row-title { /* Use AdwLabel styles */ }
+.adw-expander-row .adw-expander-row-subtitle { /* Use AdwLabel styles, but ensure opacity is applied if AdwLabel doesn't do it by default */
+  font-size: var(--font-size-small);
+  opacity: 0.7;
+}
+.adw-expander-row .adw-expander-row-icon {
+  flex-shrink: 0;
+  transition: transform 0.15s ease-in-out;
+  font-size: var(--font-size-large);
+  opacity: 0.7;
+}
+.adw-expander-row .adw-expander-row-icon::after {
+  content: "❯";
+}
+.adw-expander-row.expanded .adw-expander-row-icon {
+  transform: rotate(90deg);
+}
+
+.adw-expander-row-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out, padding 0.2s ease-out, opacity 0.2s ease-out;
+  padding: 0 var(--spacing-m);
+  opacity: 0;
+  visibility: hidden;
+}
+.adw-expander-row-content.expanded {
+  max-height: 1000px;
+  padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m);
+  opacity: 1;
+  visibility: visible;
+}
+
+.adw-combo-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-m);
+}
+.adw-combo-row .adw-combo-row-text-content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+}
+.adw-combo-row .adw-combo-row-title { /* Use AdwLabel styles */ }
+.adw-combo-row .adw-combo-row-subtitle { /* Use AdwLabel styles, ensure opacity */
+  font-size: var(--font-size-small);
+  opacity: 0.7;
+}
+.adw-combo-row .adw-combo-row-select {
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: var(--border-width, 1px) solid var(--button-border-color);
+  border-radius: var(--border-radius-default);
+  background-color: var(--button-bg-color);
+  color: var(--button-fg-color);
+  min-width: 150px;
+}
+.adw-combo-row .adw-combo-row-select:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.adw-combo-row .adw-combo-row-select:focus-visible {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 1px;
+}
+.adw-combo-row .adw-combo-row-select:disabled {
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+}
+
+.dark-theme .adw-combo-row .adw-combo-row-select,
+body.dark-theme .adw-combo-row .adw-combo-row-select {
+  border-color: var(--button-border-color);
+  background-color: var(--button-bg-color);
+  color: var(--button-fg-color);
+}
+.dark-theme .adw-combo-row .adw-combo-row-select:hover,
+body.dark-theme .adw-combo-row .adw-combo-row-select:hover {
+  background-color: var(--button-hover-bg-color);
+}
+
+:root {
+  --spinner-color: var(--accent-color);
+  --spinner-track-color: var(--shade-color);
+}
+
+.adw-spinner {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border-width: 3px;
+  border-style: solid;
+  border-color: var(--spinner-track-color);
+  border-top-color: var(--spinner-color);
+  animation: adw-spinner-spin 0.75s linear infinite;
+  vertical-align: middle;
+}
+.adw-spinner.small {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+.adw-spinner.large {
+  width: 36px;
+  height: 36px;
+  border-width: 4px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .adw-spinner {
+    animation: none;
+  }
+}
+
+@keyframes adw-spinner-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+.adw-split-button {
+  display: inline-flex;
+  align-items: stretch;
+  border-radius: var(--border-radius-default);
+  background-color: var(--button-bg-color);
+  border: var(--border-width, 1px) solid var(--button-border-color);
+  font-size: var(--font-size-base);
+  color: var(--button-fg-color);
+  box-shadow: none;
+}
+.adw-split-button:focus-within {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 2px;
+}
+.adw-split-button .adw-split-button-action {
+  padding: var(--spacing-s) var(--spacing-m);
+  cursor: pointer;
+  text-align: center;
+  flex-grow: 1;
+  border-right: var(--border-width, 1px) solid var(--button-border-color);
+  border-radius: var(--border-radius-default) 0 0 var(--border-radius-default);
+  transition: background-color 0.1s ease-out;
+  color: inherit;
+}
+.adw-split-button .adw-split-button-action:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.adw-split-button .adw-split-button-action:active {
+  background-color: var(--button-active-bg-color);
+}
+.adw-split-button .adw-split-button-action:focus-visible {
+  outline: none;
+}
+.adw-split-button .adw-split-button-dropdown {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-s) var(--spacing-xs);
+  cursor: pointer;
+  border-radius: 0 var(--border-radius-default) var(--border-radius-default) 0;
+  transition: background-color 0.1s ease-out;
+  color: inherit;
+}
+.adw-split-button .adw-split-button-dropdown .adw-split-button-arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid currentColor;
+}
+.adw-split-button .adw-split-button-dropdown:hover {
+  background-color: var(--button-hover-bg-color);
+}
+.adw-split-button .adw-split-button-dropdown:active {
+  background-color: var(--button-active-bg-color);
+}
+.adw-split-button .adw-split-button-dropdown:focus-visible {
+  outline: none;
+}
+.adw-split-button.suggested-action {
+  background-color: var(--accent-bg-color);
+  color: var(--accent-fg-color);
+  border-color: transparent;
+}
+.adw-split-button.suggested-action .adw-split-button-action {
+  border-right-color: transparent;
+}
+.adw-split-button.suggested-action .adw-split-button-action:hover {
+  background-color: rgba(var(--accent-fg-color-rgb, 255, 255, 255), 0.1);
+}
+.adw-split-button.suggested-action .adw-split-button-action:active {
+  background-color: rgba(var(--accent-fg-color-rgb, 255, 255, 255), 0.2);
+}
+.adw-split-button.suggested-action .adw-split-button-dropdown:hover {
+  background-color: rgba(var(--accent-fg-color-rgb, 255, 255, 255), 0.1);
+}
+.adw-split-button.suggested-action .adw-split-button-dropdown:active {
+  background-color: rgba(var(--accent-fg-color-rgb, 255, 255, 255), 0.2);
+}
+.adw-split-button.suggested-action .adw-split-button-dropdown .adw-split-button-arrow {
+  border-top-color: var(--accent-fg-color);
+}
+.adw-split-button[disabled], .adw-split-button:disabled {
+  background-color: var(--button-bg-color);
+  color: var(--button-fg-color);
+  border-color: var(--button-border-color);
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.adw-split-button[disabled] .adw-split-button-action,
+.adw-split-button[disabled] .adw-split-button-dropdown, .adw-split-button:disabled .adw-split-button-action,
+.adw-split-button:disabled .adw-split-button-dropdown {
+  pointer-events: none;
+}
+.adw-split-button[disabled].suggested-action, .adw-split-button:disabled.suggested-action {
+  background-color: var(--accent-bg-color);
+  color: var(--accent-fg-color);
+  border-color: transparent;
+}
+.adw-split-button[disabled].suggested-action .adw-split-button-action, .adw-split-button:disabled.suggested-action .adw-split-button-action {
+  border-right-color: transparent;
+}
+
+.adw-status-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--spacing-xxl) var(--spacing-xl);
+  height: 100%;
+  box-sizing: border-box;
+  color: var(--window-fg-color);
+}
+.adw-status-page .adw-status-page-icon {
+  font-size: 4.5rem;
+  margin-bottom: var(--spacing-l);
+  opacity: 0.7;
+}
+.adw-status-page .adw-status-page-title {
+  font-size: var(--font-size-h2);
+  font-weight: bold;
+  margin-bottom: var(--spacing-s);
+  color: var(--window-fg-color);
+}
+.adw-status-page .adw-status-page-description {
+  font-size: var(--font-size-large);
+  color: var(--window-fg-color);
+  opacity: 0.7;
+  max-width: 450px;
+  line-height: 1.5;
+  margin-bottom: var(--spacing-xl);
+}
+.adw-status-page .adw-status-page-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.adw-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+}
+.adw-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.adw-switch input:checked + .adw-switch-slider {
+  background-color: var(--accent-bg-color);
+}
+.adw-switch input:checked + .adw-switch-slider:before {
+  transform: translateX(20px);
+}
+.adw-switch input:disabled + .adw-switch-slider {
+  background-color: var(--shade-color);
+  opacity: var(--opacity-disabled, 0.5);
+  cursor: not-allowed;
+}
+.adw-switch input:disabled + .adw-switch-slider:before {
+  background-color: var(--window-bg-color);
+  opacity: 0.7;
+}
+.adw-switch input:disabled:checked + .adw-switch-slider {
+  background-color: var(--accent-bg-color);
+  opacity: var(--opacity-disabled, 0.5);
+}
+.adw-switch input:disabled:checked + .adw-switch-slider:before {
+  background-color: #ffffff;
+}
+.adw-switch input:focus-visible + .adw-switch-slider {
+  outline: 2px solid var(--accent-bg-color);
+  outline-offset: 3px;
+}
+.adw-switch .adw-switch-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--shade-color);
+  border-radius: 12px;
+  transition: background-color 0.15s ease-out, transform 0.15s ease-out;
+}
+.adw-switch .adw-switch-slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #ffffff;
+  border-radius: 50%;
+  transition: transform 0.15s ease-out;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.adw-view-switcher {
+  display: flex;
+  flex-direction: column;
+}
+
+.adw-view-switcher-bar {
+  display: flex;
+  justify-content: flex-start;
+  background-color: transparent;
+  border-bottom: var(--border-width, 1px) solid var(--border-color, var(--headerbar-border-color));
+}
+.adw-view-switcher-bar .adw-button {
+  background-color: transparent;
+  border: var(--border-width, 1px) solid transparent;
+  border-bottom: none;
+  border-radius: var(--border-radius-default) var(--border-radius-default) 0 0;
+  padding: var(--spacing-s) var(--spacing-m);
+  margin-right: var(--spacing-xs);
+  margin-bottom: calc(-1 * var(--border-width, 1px));
+  box-shadow: none;
+  color: var(--secondary-text-color, var(--window-fg-color));
+  opacity: 0.8;
+}
+.adw-view-switcher-bar .adw-button:hover {
+  background-color: var(--button-hover-bg-color);
+  color: var(--window-fg-color);
+  opacity: 1;
+}
+.adw-view-switcher-bar .adw-button.active {
+  background-color: var(--window-bg-color);
+  color: var(--accent-color, var(--window-fg-color));
+  font-weight: bold;
+  border-color: var(--border-color, var(--headerbar-border-color));
+  border-bottom-color: transparent;
+  opacity: 1;
+}
+
+.adw-view-switcher-content {
+  padding: var(--spacing-m);
+  background-color: var(--window-bg-color);
+  border: var(--border-width, 1px) solid var(--border-color, var(--headerbar-border-color));
+  border-top: none;
+  border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
+}
+.adw-view-switcher-content > * {
+  display: none;
+}
+.adw-view-switcher-content > *.active-view {
+  display: block;
+}
+
+.adw-flap {
+  display: flex;
+  overflow: hidden;
+  position: relative;
+  --adw-flap-width: 280px;
+  --adw-flap-transition-speed: 0.25s;
+}
+
+.adw-flap-flap-content {
+  width: var(--adw-flap-width);
+  flex-shrink: 0;
+  transition: width var(--adw-flap-transition-speed) ease-in-out, visibility var(--adw-flap-transition-speed) ease-in-out, opacity var(--adw-flap-transition-speed) ease-in-out;
+  background-color: var(--sidebar-bg-color);
+  border-right: var(--border-width, 1px) solid var(--sidebar-border-color);
+  overflow: hidden;
+  opacity: 1;
+  visibility: visible;
+}
+
+.adw-flap-main-content {
+  flex-grow: 1;
+  transition: margin-left var(--adw-flap-transition-speed) ease-in-out;
+  overflow-x: auto;
+}
+
+.adw-flap.folded .adw-flap-flap-content {
+  width: 0;
+  opacity: 0;
+  visibility: hidden;
+  border-right-width: 0;
+}
+
+.dark-theme .adw-flap-flap-content,
+body.dark-theme .adw-flap-flap-content {
+  background-color: var(--sidebar-bg-color);
+  border-right-color: var(--sidebar-border-color);
+}
+
+.adw-password-entry-row {
+  gap: var(--spacing-s);
+}
+.adw-password-entry-row .adw-entry-row-title {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+.adw-password-entry-row .adw-entry-row-entry {
+  flex-grow: 1;
+}
+.adw-password-entry-row .adw-button.circular.flat {
+  flex-shrink: 0;
+}
+.adw-password-entry-row .adw-button.circular.flat .icon svg {
+  width: var(--icon-size-inline, 16px);
+  height: var(--icon-size-inline, 16px);
+}
+
+.adw-window {
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+  border-radius: var(--window-radius);
+  box-shadow: 0 0 0 1px var(--border-color-light, rgba(0, 0, 0, 0.12)), 0 8px 16px -4px rgba(0, 0, 0, 0.15), 0 6px 12px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.adw-window > .adw-header-bar:first-child {
+  border-top-left-radius: var(--window-radius);
+  border-top-right-radius: var(--window-radius);
+}
+.adw-window .adw-window-content {
+  padding: var(--spacing-l);
+  flex-grow: 1;
+}
+
+.dark-theme .adw-window,
+body.dark-theme .adw-window {
+  box-shadow: 0 0 0 1px var(--border-color-dark, rgba(255, 255, 255, 0.12)), 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 6px 12px rgba(0, 0, 0, 0.25);
+}
 
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
The app-demo was previously linking to a SASS source file (app-demo/static/css/main.css) instead of the compiled project stylesheet. This caused libadwaita widgets to not render correctly as they were missing the necessary CSS definitions.

This commit replaces the SASS file at app-demo/static/css/main.css with the content of the compiled project root style.css. The link in app-demo/templates/base.html already pointed to app-demo/static/css/main.css, so it now correctly loads the compiled libadwaita styles.

This ensures that the app-demo utilizes the current and correct styling for libadwaita components as intended.