### PR TITLE
Fix: Copy SCSS files to app-demo during build

### DIFF
--- a/build-adwaita-web.sh
+++ b/build-adwaita-web.sh
@@ -26,4 +26,8 @@ cp "${JS_INPUT_DIR}/components.js" "${JS_OUTPUT_DIR}/components.js"
 # If there are other JS files to copy, add them here. e.g.:
 # cp "${JS_INPUT_DIR}/another-script.js" "${JS_OUTPUT_DIR}/another-script.js"
 
+# Copy SCSS files
+echo "Copying SCSS files from scss to ${CSS_OUTPUT_DIR}/scss"
+cp -r "scss" "${CSS_OUTPUT_DIR}/scss"
+
 echo "Build complete. Adwaita-Web assets are updated in app-demo."


### PR DESCRIPTION
The build script was previously only compiling SCSS to CSS and copying JavaScript files. This commit updates the build script (`build-adwaita-web.sh`) to also copy the raw SCSS source files from the `scss` directory to `app-demo/static/scss`.

This is necessary because the Flask application, when in debug mode, attempts to serve these SCSS files (likely due to sourcemaps), leading to 404 errors if they are not present. Copying the SCSS files resolves these errors.