### PR TITLE
Fix: Correct SCSS sourcemap paths and copy location

### DIFF
--- a/build-adwaita-web.sh
+++ b/build-adwaita-web.sh
@@ -18,7 +18,7 @@ mkdir -p "${JS_OUTPUT_DIR}"
 
 # Compile SASS to CSS
 echo "Compiling SASS: ${SASS_INPUT} to ${CSS_OUTPUT_FILE}"
-sass "${SASS_INPUT}" "${CSS_OUTPUT_FILE}"
+sass --source-map-urls=relative "${SASS_INPUT}" "${CSS_OUTPUT_FILE}"
 
 # Copy JavaScript files
 echo "Copying JavaScript files from ${JS_INPUT_DIR} to ${JS_OUTPUT_DIR}"
@@ -27,7 +27,7 @@ cp "${JS_INPUT_DIR}/components.js" "${JS_OUTPUT_DIR}/components.js"
 # cp "${JS_INPUT_DIR}/another-script.js" "${JS_OUTPUT_DIR}/another-script.js"
 
 # Copy SCSS files
-echo "Copying SCSS files from scss to ${CSS_OUTPUT_DIR}/scss"
-cp -r "scss" "${CSS_OUTPUT_DIR}/scss"
+echo "Copying SCSS files from scss to app-demo/static/scss"
+cp -r "scss" "app-demo/static/scss"
 
 echo "Build complete. Adwaita-Web assets are updated in app-demo."


### PR DESCRIPTION
This commit addresses an issue where SCSS files were still resulting in 404 errors in development mode due to incorrect sourcemap paths and the SCSS files being copied to the wrong directory.

The `build-adwaita-web.sh` script has been updated as follows:

1.  The SASS compilation command now explicitly uses the `--source-map-urls=relative` option. This ensures that the generated sourcemap (`adwaita-web.css.map`) uses paths relative to its own location (e.g., `../scss/_variables.scss`).
2.  The SCSS source files are now copied from the root `scss/` directory to `app-demo/static/scss/`. Previously, they were incorrectly copied into a subdirectory within `app-demo/static/css/`.

With these changes:
- The sourcemap in `app-demo/static/css/adwaita-web.css.map` will reference SCSS files like `../scss/filename.scss`.
- When the browser requests these files, it resolves the path relative to the CSS file's location. For example, a request for `../scss/_variables.scss` relative to `/static/css/adwaita-web.css` becomes `/static/scss/_variables.scss`.
- Flask, by default, serves files from the `app-demo/static/` directory, so requests to `/static/scss/...` will now correctly serve the SCSS files from `app-demo/static/scss/...`.

This should resolve the 404 errors for SCSS files during development.