### PR TITLE
Feat: Implement categories and further UI refinements for app-demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Generated Adwaita-Web assets
 app-demo/static/css/adwaita-web.css
 app-demo/static/css/adwaita-web.css.map
-app-demo/static/js/components.js
+app-demo/static/js/*
 
 # Python
 __pycache__/

--- a/app-demo/templates/about.html
+++ b/app-demo/templates/about.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}About Us - {{ super() }}{% endblock %}
+{% block content %}
+<adw-clamp style="max-width: 800px; margin: 20px auto; padding: var(--spacing-l);">
+    <adw-box orientation="vertical" spacing="l">
+        <h1 class="adw-title-1" style="text-align: center;">About This Application</h1>
+
+        <adw-preferences-group>
+            <adw-action-row title="Purpose" subtitle="This is a demonstration application showcasing the Adwaita-Web UI library integration with a Flask backend."></adw-action-row>
+            <adw-action-row title="Features" subtitle="It includes a basic blog, user profiles, and various examples of Adwaita widgets in action."></adw-action-row>
+            <adw-expander-row title="Technology Stack" subtitle="Learn more about the tech used.">
+                <div slot="rows" style="padding: var(--spacing-m);">
+                    <p><adw-label is_body="true"><strong>Frontend:</strong> Adwaita-Web (Custom JS/SCSS), Flask Templates (Jinja2)</adw-label></p>
+                    <p><adw-label is_body="true"><strong>Backend:</strong> Flask (Python)</adw-label></p>
+                    <p><adw-label is_body="true"><strong>Database:</strong> SQLAlchemy with PostgreSQL (default)</adw-label></p>
+                    <p><adw-label is_body="true"><strong>UI Library:</strong> Adwaita-Web (toplevel scss & js)</adw-label></p>
+                </div>
+            </adw-expander-row>
+        </adw-preferences-group>
+
+        <div style="text-align: center; margin-top: var(--spacing-xl);">
+            <adw-button href="{{ url_for('index') }}">Back to Home</adw-button>
+        </div>
+    </adw-box>
+</adw-clamp>
+{% endblock %}

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -21,6 +21,8 @@
         <adw-header-bar>
             <adw-window-title slot="title">Blog CMS</adw-window-title>
             <a href="{{ url_for('index') }}" class="adw-button" slot="start">Home</a>
+            <a href="{{ url_for('about_page') }}" class="adw-button" slot="start">About</a>
+            <a href="{{ url_for('contact_page') }}" class="adw-button" slot="start">Contact</a>
 
         {% if current_user.is_authenticated %}
             <a href="{{ url_for('profile', username=current_user.username) }}" slot="start" class="adw-button flat circular" title="View Profile" style="padding: var(--spacing-xxs); margin-right: var(--spacing-xs);">

--- a/app-demo/templates/contact.html
+++ b/app-demo/templates/contact.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Contact Us - {{ super() }}{% endblock %}
+{% block content %}
+<adw-clamp style="max-width: 700px; margin: 20px auto; padding: var(--spacing-l);">
+    <adw-box orientation="vertical" spacing="l">
+        <h1 class="adw-title-1" style="text-align: center;">Contact Us</h1>
+
+        <adw-preferences-group title="Get in Touch">
+            <adw-action-row title="Email" subtitle="For general inquiries, please email us at: demo@example.com (not a real address)."></adw-action-row>
+            <adw-action-row title="Issues" subtitle="If you find a bug or have a feature request for Adwaita-Web, please check the main project repository."></adw-action-row>
+        </adw-preferences-group>
+
+        {# Placeholder for a future contact form #}
+        <adw-preferences-group title="Send a Message (Placeholder)">
+            <adw-entry-row title="Your Name" name="contact_name" placeholder="Enter your name"></adw-entry-row>
+            <adw-entry-row title="Your Email" name="contact_email" type="email" placeholder="Enter your email"></adw-entry-row>
+            <adw-action-row title="Message" class="content-entry-row">
+                 <textarea class="adw-entry" name="contact_message" rows="5" placeholder="Your message here..." style="width: 100%; margin-top: var(--spacing-xs);"></textarea>
+            </adw-action-row>
+            <div style="display: flex; justify-content: flex-end; padding: var(--spacing-m) 0;">
+                <adw-button appearance="suggested" disabled>Send (Disabled)</adw-button>
+            </div>
+        </adw-preferences-group>
+
+        <div style="text-align: center; margin-top: var(--spacing-xl);">
+            <adw-button href="{{ url_for('index') }}">Back to Home</adw-button>
+        </div>
+    </adw-box>
+</adw-clamp>
+{% endblock %}

--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -31,6 +31,19 @@
                             </div>
                         {% endif %}
                     </div>
+
+                    {# Categories Field #}
+                    <div class="adw-row" style="padding: var(--spacing-s) var(--spacing-m); display: flex; flex-direction: column;">
+                        {{ form.categories.label(class_='adw-label', style='margin-bottom: var(--spacing-s); font-weight: bold;') }}
+                        <div class="adw-checkbox-group" style="display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                            {{ form.categories() }} {# Renders as a list of checkboxes #}
+                        </div>
+                        {% if form.categories.errors %}
+                            <div class="errors" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xs);">
+                                {% for error in form.categories.errors %}{{ error }}<br>{% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
                 </adw-list-box>
                 <div style="display: flex; justify-content: flex-end; padding: var(--spacing-m) var(--spacing-m) 0 var(--spacing-m);">
                     {{ form.submit(class_='adw-button suggested-action') }}

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -31,6 +31,19 @@
                             </div>
                         {% endif %}
                     </div>
+
+                    {# Categories Field #}
+                    <div class="adw-row" style="padding: var(--spacing-s) var(--spacing-m); display: flex; flex-direction: column;">
+                        {{ form.categories.label(class_='adw-label', style='margin-bottom: var(--spacing-s); font-weight: bold;') }}
+                        <div class="adw-checkbox-group" style="display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                            {{ form.categories() }} {# Renders as a list of checkboxes, pre-selected by WTForms obj=post #}
+                        </div>
+                        {% if form.categories.errors %}
+                            <div class="errors" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xs);">
+                                {% for error in form.categories.errors %}{{ error }}<br>{% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
                 </adw-list-box>
                 <div style="display: flex; justify-content: flex-end; gap: var(--spacing-s); padding: var(--spacing-m) var(--spacing-m) 0 var(--spacing-m);">
                     <a href="{{ url_for('view_post', post_id=post.id) }}" class="adw-button">Cancel</a>

--- a/app-demo/templates/edit_profile.html
+++ b/app-demo/templates/edit_profile.html
@@ -3,7 +3,7 @@
 {% block title %}Edit Profile - {{ super() }}{% endblock %}
 
 {% block content %}
-<adw-preferences-view style="max-width: 700px; margin: 20px auto;">
+<adw-clamp class="profile-edit-view" style="max-width: 700px; margin: 20px auto;">
   <adw-preferences-page title="Edit Your Profile">
     <form method="POST" action="" enctype="multipart/form-data"> {# action="" to post to current URL #}
       {{ form.hidden_tag() }}
@@ -12,54 +12,58 @@
         {# Display Name #}
         <adw-entry-row title="{{ form.full_name.label.text }}"
                        name="{{ form.full_name.name }}"
-                       value="{{ form.full_name.data or '' }}">
+                       value="{{ form.full_name.data or '' }}"
+                       subtitle="{{ form.full_name.errors[0] if form.full_name.errors else (form.full_name.description or '') }}">
         </adw-entry-row>
-        {# TODO: Add {{ form.full_name.errors }} display if needed #}
 
         {# Bio #}
         <adw-expander-row title="{{ form.profile_info.label.text }}" subtitle="Tell us a bit about yourself. Supports basic HTML.">
-          {# Using a standard textarea within the slot for multi-line input.
-             The 'adw-entry' class can be added for styling if it's defined in SCSS for textareas.
-             For Adwaita Web Components, a dedicated <adw-textarea-row> might be preferred if available,
-             but <adw-expander-row> with a <textarea> in the slot is a valid pattern. #}
           <textarea name="{{ form.profile_info.name }}" slot="rows" rows="5" style="width: 100%; min-height: 100px; margin-top: var(--spacing-s); margin-bottom: var(--spacing-s); padding: var(--spacing-s); border: 1px solid var(--border-color); border-radius: var(--border-radius-default); background-color: var(--input-bg-color, white); color: var(--text-color);" class="adw-entry">{{ form.profile_info.data or '' }}</textarea>
+          {% if form.profile_info.errors %}
+          <div class="adw-input-error" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xs); padding-left: var(--spacing-m); slot: rows;">
+              {% for error in form.profile_info.errors %}{{ error }}<br>{% endfor %}
+          </div>
+          {% endif %}
         </adw-expander-row>
-        {# TODO: Add {{ form.profile_info.errors }} display if needed #}
 
         {# Location #}
         <adw-entry-row title="{{ form.location.label.text }}"
                        name="{{ form.location.name }}"
-                       value="{{ form.location.data or '' }}">
+                       value="{{ form.location.data or '' }}"
+                       subtitle="{{ form.location.errors[0] if form.location.errors else '' }}">
         </adw-entry-row>
-        {# TODO: Add {{ form.location.errors }} display if needed #}
 
         {# Website URL #}
         <adw-entry-row title="{{ form.website_url.label.text }}"
                        name="{{ form.website_url.name }}"
                        type="url"
                        placeholder="https://example.com"
-                       value="{{ form.website_url.data or '' }}">
+                       value="{{ form.website_url.data or '' }}"
+                       subtitle="{{ form.website_url.errors[0] if form.website_url.errors else '' }}">
         </adw-entry-row>
-        {# TODO: Add {{ form.website_url.errors }} display if needed #}
 
         {# Make Profile Public #}
-        {# Hidden input will be created/managed by JS to ensure correct form submission for the boolean value #}
         <adw-switch-row title="{{ form.is_profile_public.label.text }}"
                         subtitle="Allow others to see your profile page"
-                        name="is_profile_public_display" {# Name changed to avoid conflict with hidden input if JS fails early #}
+                        name="is_profile_public_display"
                         {% if form.is_profile_public.data %}active{% endif %}>
         </adw-switch-row>
-        {# Actual input for WTForms is form.is_profile_public, which we'll manage with a hidden field via JS #}
-        {# TODO: Add {{ form.is_profile_public.errors }} display if needed #}
-
+        {% if form.is_profile_public.errors %}
+        <div class="adw-row-error" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xxs); padding-left: calc(var(--spacing-m) + 24px + var(--spacing-s));">
+            {% for error in form.is_profile_public.errors %}{{ error }}<br>{% endfor %}
+        </div>
+        {% endif %}
       </adw-preferences-group>
 
       <adw-preferences-group title="Profile Photo">
         <adw-action-row title="{{ form.profile_photo.label.text }}" subtitle="Upload a new photo. Max 2MB.">
-          {# Standard file input. For better Adwaita styling, this might need a custom component or more CSS. #}
-          {# For now, using the direct WTForms field rendering. #}
           <div style="display: flex; flex-direction: column; gap: var(--spacing-s); padding-top: var(--spacing-s); padding-bottom: var(--spacing-s);">
-            {{ form.profile_photo() }} {# This will render <input type="file"> #}
+            {{ form.profile_photo(class_="adw-entry") }} {# Added adw-entry for potential styling #}
+            {% if form.profile_photo.errors %}
+            <div class="adw-input-error" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xs);">
+                {% for error in form.profile_photo.errors %}{{ error }}<br>{% endfor %}
+            </div>
+            {% endif %}
             {% if user_profile and user_profile.profile_photo_url %}
               <div style="margin-top: var(--spacing-m);">
                 <p style="font-size: var(--font-size-small); color: var(--secondary-text-color); margin-bottom: var(--spacing-xs);">Current photo:</p>
@@ -68,7 +72,6 @@
             {% endif %}
           </div>
         </adw-action-row>
-         {# TODO: Add {{ form.profile_photo.errors }} display if needed #}
       </adw-preferences-group>
 
       <div style="margin-top: var(--spacing-xl); display: flex; justify-content: flex-end; gap: var(--spacing-s);">
@@ -77,7 +80,7 @@
       </div>
     </form>
   </adw-preferences-page>
-</adw-preferences-view>
+</adw-clamp>
 {% endblock %}
 
 {% block scripts %}
@@ -86,23 +89,16 @@
   document.addEventListener('DOMContentLoaded', function() {
     const publicSwitchRow = document.querySelector('adw-switch-row[name="is_profile_public_display"]');
     if (publicSwitchRow) {
-      // Create a hidden input to ensure correct boolean value is submitted for WTForms
       let hiddenInput = document.querySelector('input[type="hidden"][name="is_profile_public"]');
       if (!hiddenInput) {
         hiddenInput = document.createElement('input');
         hiddenInput.type = 'hidden';
-        hiddenInput.name = 'is_profile_public'; // This name must match the WTForms field name
-        // Insert before the form's submit button or at the end of the form for simplicity,
-        // or more precisely before the switch row if it's part of a specific group.
-        // For ProfileEditForm, it's fine to append to the form.
+        hiddenInput.name = 'is_profile_public';
         publicSwitchRow.closest('form').appendChild(hiddenInput);
       }
-
-      // Set initial value for hidden input based on the switch's state
-      // WTForms BooleanField by default expects 'y' for True, and '' or no value for False
-      // when using the standard CheckboxInput widget.
-      // However, if data is directly populated, it might handle True/False.
-      // To be safe, we'll submit 'y' or an empty string.
+      // Set initial value for hidden input. WTForms BooleanField default handling:
+      // 'y', 'true', 't', '1' are True. Others False.
+      // An empty string or missing value is False.
       hiddenInput.value = publicSwitchRow.active ? 'y' : '';
 
       publicSwitchRow.addEventListener('state-set', function(event) {

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -16,6 +16,16 @@
         </p>
     </div>
 
+    {% if post.categories %}
+    <div class="post-categories" style="margin-bottom: var(--spacing-m);">
+        <adw-label is_body="true"><strong>Categories:</strong></adw-label>
+        {% for category in post.categories %}
+            {# Later, this will link to the category view page #}
+            <a href="{{ url_for('posts_by_category', category_slug=category.slug) }}" class="adw-button flat small" style="margin-left: var(--spacing-xs);">{{ category.name }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+
     <div class="post-content" style="margin-bottom: var(--spacing-xl); white-space: pre-wrap;">
         {{ post.content | safe }}
     </div>

--- a/app-demo/templates/posts_by_category.html
+++ b/app-demo/templates/posts_by_category.html
@@ -1,17 +1,22 @@
 {% extends "base.html" %}
 
-{% block title %}Blog Posts{% endblock %}
+{% block title %}Posts in {{ category.name }} - {{ super() }}{% endblock %}
 
 {% block content %}
-<div style="margin-bottom: var(--spacing-xl, 32px);"> {# Provides some top/bottom margin #}
-    <h1 class="page-title" style="text-align: center; margin-bottom: var(--spacing-l, 24px); font-size: var(--font-size-xxl, 1.5rem);">All Blog Posts</h1>
+<div style="margin-bottom: var(--spacing-xl, 32px);">
+    <h1 class="page-title" style="text-align: center; margin-bottom: var(--spacing-l, 24px); font-size: var(--font-size-xxl, 1.5rem);">
+        Posts in Category: {{ category.name }}
+    </h1>
+
+    {# Re-use the spinner from index.html, hidden by default #}
     <div style="text-align: center; margin-bottom: var(--spacing-m);">
-        <adw-spinner size="large" id="index-loading-spinner" style="display: none;"></adw-spinner>
+      <adw-spinner size="large" id="category-loading-spinner" style="display: none;"></adw-spinner>
     </div>
 
     {% if posts %}
-        <div class="blog-posts-container"> {# More semantic container name #}
+        <div class="blog-posts-container">
             {% for post in posts %}
+            {# Re-use the card structure from index.html #}
             <adw-box orientation="vertical" class="blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); box-shadow: var(--box-shadow-sm);">
                 <h3><a href="{{ url_for('view_post', post_id=post.id) }}" class="post-title">{{ post.title }}</a></h3>
                 <p class="post-meta" style="font-size: var(--font-size-small); color: var(--secondary-text-color);">
@@ -20,15 +25,14 @@
                 </p>
                 {% if post.content %}
                 <p class="post-excerpt">
-                    {{ post.content | truncate(100, True) }} {# Show first 100 characters as excerpt #}
+                    {{ post.content | truncate(100, True) }}
                 </p>
                 {% endif %}
-
                 {% if post.categories %}
                 <div class="post-categories-list" style="margin-top: var(--spacing-s); display: flex; flex-wrap: wrap; gap: var(--spacing-xxs);">
                     <adw-label is_caption="true" style="font-weight: bold; margin-right: var(--spacing-xs);">Categories:</adw-label>
-                    {% for category in post.categories %}
-                        <a href="{{ url_for('posts_by_category', category_slug=category.slug) }}" class="adw-button flat small" style="font-size: var(--font-size-small); padding: var(--spacing-xxs) var(--spacing-xs);">{{ category.name }}</a>
+                    {% for cat in post.categories %} {# Changed loop var to avoid conflict with outer category #}
+                        <a href="{{ url_for('posts_by_category', category_slug=cat.slug) }}" class="adw-button flat small" style="font-size: var(--font-size-small); padding: var(--spacing-xxs) var(--spacing-xs);">{{ cat.name }}</a>
                     {% endfor %}
                 </div>
                 {% endif %}
@@ -39,42 +43,37 @@
             {% endfor %}
         </div>
     {% else %}
-        <adw-status-page title="No Posts Yet" description="Be the first to create a post and share your thoughts!">
-            <div slot="icon" style="font-size: 4.5rem; margin-bottom: var(--spacing-l); opacity: 0.7;">📄</div> {# Using an emoji as a placeholder icon #}
+        <adw-status-page title="No Posts Found" description="There are no posts in the category '{{ category.name }}'.">
+            <div slot="icon" style="font-size: 4.5rem; margin-bottom: var(--spacing-l); opacity: 0.7;">📄</div>
             <div slot="actions">
-                <adw-button href="{{ url_for('create_post') }}" appearance="suggested">Create a Post</adw-button>
+                <adw-button href="{{ url_for('index') }}">View All Posts</adw-button>
             </div>
         </adw-status-page>
     {% endif %}
 
-    {# Pagination Links #}
+    {# Pagination Links - Re-use from index.html, ensuring url_for points to posts_by_category #}
     {% if pagination and pagination.pages > 1 %}
     <nav aria-label="Page navigation" class="pagination-nav" style="margin-top: var(--spacing-xl); display: flex; justify-content: center; align-items: center; gap: var(--spacing-xs);">
-        {# Previous Page Link #}
         {% if pagination.has_prev %}
-            <a href="{{ url_for('index', page=pagination.prev_num) }}" class="adw-button">
+            <a href="{{ url_for('posts_by_category', category_slug=category.slug, page=pagination.prev_num) }}" class="adw-button">
                 &laquo; Previous
             </a>
         {% else %}
             <adw-button disabled>&laquo; Previous</adw-button>
         {% endif %}
-
-        {# Page Numbers #}
         {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
             {% if page_num %}
                 {% if page_num == pagination.page %}
                     <adw-button class="active" appearance="suggested" aria-current="page">{{ page_num }}</adw-button>
                 {% else %}
-                    <a href="{{ url_for('index', page=page_num) }}" class="adw-button">{{ page_num }}</a>
+                    <a href="{{ url_for('posts_by_category', category_slug=category.slug, page=page_num) }}" class="adw-button">{{ page_num }}</a>
                 {% endif %}
             {% else %}
                 <span class="adw-button flat disabled" style="cursor: default;">&hellip;</span>
             {% endif %}
         {% endfor %}
-
-        {# Next Page Link #}
         {% if pagination.has_next %}
-            <a href="{{ url_for('index', page=pagination.next_num) }}" class="adw-button">
+            <a href="{{ url_for('posts_by_category', category_slug=category.slug, page=pagination.next_num) }}" class="adw-button">
                 Next &raquo;
             </a>
         {% else %}


### PR DESCRIPTION
This commit introduces blog post categorization and continues the process of enhancing the app-demo with Adwaita widgets and improved UX.

Key changes since last commit:

1.  **.gitignore Update:**
    - Ignored all JavaScript build artifacts in `app-demo/static/js/*` to ensure build products are not tracked in the repository. `app-demo/static/css/adwaita-web.css` was already ignored.

2.  **User Profile Management Refinements:**
    - Updated `app-demo/templates/edit_profile.html` to use `<adw-clamp>` for consistent page width.
    - Implemented display of WTForms validation errors for all fields in the edit profile form, integrating them with Adwaita row widgets.

3.  **Static Pages Added:**
    - Created "About" and "Contact" static pages (`about.html`, `contact.html`) with basic Adwaita widget layouts.
    - Added corresponding routes in `app.py`.
    - Added navigation links for these pages in `base.html`'s header bar.

4.  **Category Functionality for Blog Posts:**
    - Defined `Category` SQLAlchemy model and a many-to-many relationship with the `Post` model in `app.py`.
    - Updated `PostForm` in `app.py` to include a `QuerySelectMultipleField` for category selection, rendered as checkboxes. (Note: This introduces a new dependency: `WTForms-SQLAlchemy`).
    - Modified `create_post` and `edit_post` routes to handle category assignment and updates.
    - Updated `create_post.html` and `edit_post.html` templates to include the category selection UI.
    - Categories are now displayed on the single post page (`post.html`) and on the main post listing (`index.html`).
    - Added a new route and template (`posts_by_category.html`) to view all posts associated with a specific category.

This commit prepares your app for testing of the category feature and the UI enhancements made so far.