### PR TITLE
Alright, I've added some targeted logging to help figure out that `Ty…

### DIFF
--- a/js/adw-initializer.js
+++ b/js/adw-initializer.js
@@ -313,6 +313,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     options.labelForEntry = passwordEntryRowElement.getAttribute('label-for-entry') !== "false";
 
+    // Logging before calling createAdwPasswordEntryRow
+    console.log('[Debug] Initializer: Attempting to process <adw-password-entry-row>. Options prepared:', options);
+    console.log('[Debug] Initializer: About to call window.Adw.createAdwPasswordEntryRow. Checking window.Adw object keys:');
+    if (window.Adw) {
+        console.log(Object.keys(window.Adw).join(', '));
+        if (typeof window.Adw.createAdwPasswordEntryRow === 'function') {
+            console.log('[Debug] Initializer: window.Adw.createAdwPasswordEntryRow IS a function.');
+        } else {
+            console.error('[Debug] Initializer: window.Adw.createAdwPasswordEntryRow IS NOT a function just before calling it!');
+        }
+    } else {
+        console.error('[Debug] Initializer: window.Adw object is NOT defined just before calling createAdwPasswordEntryRow!');
+    }
+
     const newPasswordEntryRow = window.Adw.createAdwPasswordEntryRow(options);
     for (const attrName in originalAttrs) {
       if (!['title', 'class', ...commonInputAttrs, 'label-for-entry'].includes(attrName) && !newPasswordEntryRow.hasAttribute(attrName)) {

--- a/js/components.js
+++ b/js/components.js
@@ -1548,6 +1548,7 @@ function createAdwSpinner(options = {}) {
  * @returns {HTMLDivElement} The created PasswordEntryRow element (which is an AdwRow).
  */
 function createAdwPasswordEntryRow(options = {}) {
+    console.log('[Debug] createAdwPasswordEntryRow factory function was called with options:', options);
     const opts = options || {};
     const entryOptions = { ...(opts.entryOptions || {}) };
 


### PR DESCRIPTION
…peError` you're seeing with `Adw.createAdwPasswordEntryRow`.

I've placed `console.log` statements in a couple of key spots:
- Inside the `createAdwPasswordEntryRow` factory in `js/components.js`.
- Right before the call to `Adw.createAdwPasswordEntryRow` in `js/adw-initializer.js`.

This logging should help us:
- See if the factory function is actually being called.
- Check the options being passed into it.
- Understand the state of the `window.Adw` object as `adw-initializer.js` sees it when it makes the call.
- Confirm if `window.Adw.createAdwPasswordEntryRow` is indeed recognized as a function just before it's used.

This should give us a clearer picture of why `adw-initializer.js` is reporting that `window.Adw.createAdwPasswordEntryRow is not a function`.