### PR TITLE
feat: Implement initial batch of Adwaita widgets

### DIFF
--- a/js/components.js
+++ b/js/components.js
@@ -75,6 +75,98 @@ function createAdwButton(text, options = {}) {
   return button;
 }
 
+/**
+ * Creates an AdwBottomSheet element.
+ * @param {object} [options={}] Configuration options.
+ * @param {HTMLElement} options.content The content to display within the bottom sheet.
+ * @param {boolean} [options.isOpen=false] Initial open state.
+ * @param {function} [options.onOpen] Callback when sheet opens.
+ * @param {function} [options.onClose] Callback when sheet closes.
+ * @param {boolean} [options.closeOnBackdropClick=true] If true, clicking backdrop closes the sheet.
+ * @returns {{ sheet: HTMLDivElement, backdrop: HTMLDivElement, open: function, close: function }}
+ */
+function createAdwBottomSheet(options = {}) {
+    const opts = options || {};
+    if (!opts.content) {
+        console.error("AdwBottomSheet: options.content is required.");
+        // Return a dummy object or throw error
+        return { sheet: document.createElement('div'), backdrop: document.createElement('div'), open: ()=>{}, close: ()=>{} };
+    }
+
+    const backdrop = document.createElement('div');
+    backdrop.classList.add('adw-bottom-sheet-backdrop');
+
+    const sheet = document.createElement('div');
+    sheet.classList.add('adw-bottom-sheet');
+    sheet.setAttribute('role', 'dialog'); // Or 'complementary' depending on usage
+    sheet.setAttribute('aria-modal', 'true'); // If it behaves like a modal
+
+    sheet.appendChild(opts.content);
+
+    let currentIsOpen = false;
+
+    function openSheet() {
+        if (currentIsOpen) return;
+        document.body.appendChild(backdrop);
+        document.body.appendChild(sheet);
+        document.body.style.overflow = 'hidden'; // Prevent body scroll when sheet is open
+
+        // Trigger animations
+        setTimeout(() => {
+            backdrop.classList.add('visible');
+            sheet.classList.add('visible');
+        }, 10); // Small delay for CSS transitions
+
+        currentIsOpen = true;
+        if (typeof opts.onOpen === 'function') {
+            opts.onOpen();
+        }
+    }
+
+    function closeSheet() {
+        if (!currentIsOpen) return;
+        backdrop.classList.remove('visible');
+        sheet.classList.remove('visible');
+
+        setTimeout(() => {
+            if (backdrop.parentNode) backdrop.remove();
+            if (sheet.parentNode) sheet.remove();
+            document.body.style.overflow = ''; // Restore body scroll
+        }, 300); // Match CSS transition time
+
+        currentIsOpen = false;
+        if (typeof opts.onClose === 'function') {
+            opts.onClose();
+        }
+    }
+
+    if (opts.closeOnBackdropClick !== false) {
+        backdrop.addEventListener('click', closeSheet);
+    }
+
+    // Add Escape key listener to the sheet itself, or globally when open
+    // For simplicity, adding to sheet. It needs to be focusable or have focusable content.
+    sheet.setAttribute('tabindex', '-1'); // Make sheet focusable for key events
+    sheet.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && currentIsOpen) {
+            closeSheet();
+        }
+    });
+
+
+    if (opts.isOpen) {
+        openSheet();
+    }
+
+    return {
+        sheet,
+        backdrop,
+        open: openSheet,
+        close: closeSheet,
+        get isOpen() { return currentIsOpen; }
+    };
+}
+
 
 /**
  * Creates an Adwaita-style text entry.
@@ -586,1045 +678,1572 @@ function createAdwDialog(options = {}) {
 }
 
 /**
- * Creates an Adwaita-style progress bar.
+ * Creates and displays an Adwaita-style Alert Dialog.
+ * This is a specialized version of AdwDialog for common alert patterns.
+ * @param {string} body - The main message/body of the alert.
  * @param {object} [options={}] - Configuration options.
- * @param {number} [options.value] - Progress value (0-100).
- * @param {boolean} [options.isIndeterminate=false] - If true, shows an indeterminate progress animation.
- * @param {boolean} [options.disabled=false] - If true, disables the progress bar (visually).
- * @returns {HTMLDivElement} The created progress bar element.
+ * @param {string} [options.heading] - Optional heading for the alert.
+ * @param {Array<{label: string, value: string, style?: 'default'|'suggested'|'destructive'}>} [options.choices=[]] -
+ *        Array of choice objects to create buttons. E.g., {label: "OK", value: "ok", style: "suggested"}.
+ * @param {function(string)} [options.onResponse] - Callback function when a choice button is clicked, receives the 'value'.
+ * @param {boolean} [options.closeOnBackdropClick=false] - Whether clicking backdrop closes (usually false for alerts).
+ * @param {HTMLElement} [options.customContent] - Optional custom HTML element to use as content instead of the body string.
+ * @returns {{dialog: HTMLDivElement, open: function, close: function}} Object with dialog element and methods.
  */
-function createAdwProgressBar(options = {}) {
+function createAdwAlertDialog(body, options = {}) {
   const opts = options || {};
-  const progressBar = document.createElement("div");
-  progressBar.classList.add("adw-progress-bar");
-  progressBar.setAttribute("role", "progressbar");
-  progressBar.setAttribute("aria-valuemin", "0");
-  progressBar.setAttribute("aria-valuemax", "100");
+  const dialogId = adwGenerateId('adw-alert-dialog');
 
-  const progressBarValue = document.createElement("div");
-  progressBarValue.classList.add("adw-progress-bar-value");
-  progressBar.appendChild(progressBarValue);
+  const contentEl = document.createElement('div');
+  contentEl.classList.add('adw-alert-dialog-content-wrapper');
 
-  if (typeof opts.value === 'number' && !opts.isIndeterminate) {
-    const clampedValue = Math.max(0, Math.min(100, opts.value));
-    progressBarValue.style.width = `${clampedValue}%`;
-    progressBar.setAttribute("aria-valuenow", clampedValue);
-  }
-  if (opts.isIndeterminate) {
-    progressBar.classList.add("indeterminate");
-    progressBar.removeAttribute("aria-valuenow");
-  }
-  if (opts.disabled) {
-    progressBar.setAttribute("disabled", "");
-    progressBar.setAttribute("aria-disabled", "true");
-  }
-  return progressBar;
-}
-
-/**
- * Creates an Adwaita-style checkbox with a label.
- * @param {object} [options={}] - Configuration options.
- * @param {string} [options.label=""] - Text label for the checkbox.
- * @param {boolean} [options.checked=false] - Initial checked state.
- * @param {function} [options.onChanged] - Callback for state change.
- * @param {boolean} [options.disabled=false] - If true, disables the checkbox.
- * @returns {HTMLLabelElement} The created checkbox component (label wrapper).
- */
-function createAdwCheckbox(options = {}) {
-  const opts = options || {};
-  const wrapper = document.createElement("label");
-  wrapper.classList.add("adw-checkbox");
-
-  const input = document.createElement("input");
-  input.type = "checkbox";
-  if(typeof opts.onChanged === 'function') {
-    input.addEventListener("change", opts.onChanged);
-  }
-
-  const indicator = document.createElement("span");
-  indicator.classList.add("adw-checkbox-indicator");
-  indicator.setAttribute("aria-hidden", "true");
-
-  const labelSpan = document.createElement("span");
-  labelSpan.classList.add("adw-checkbox-label");
-  labelSpan.textContent = opts.label || "";
-
-  wrapper.appendChild(input);
-  wrapper.appendChild(indicator);
-  wrapper.appendChild(labelSpan);
-
-  if (opts.checked) {
-    input.checked = true;
-  }
-  if (opts.disabled) {
-    input.setAttribute("disabled", "");
-    wrapper.setAttribute("aria-disabled", "true");
-    wrapper.classList.add("disabled");
-  }
-  if (opts.name) {
-    input.name = opts.name;
-  }
-  return wrapper;
-}
-
-/**
- * Creates an Adwaita-style radio button with a label.
- * @param {object} [options={}] - Configuration options.
- * @param {string} options.name - Name attribute, essential for grouping radio buttons.
- * @param {string} [options.label=""] - Text label for the radio button.
- * @param {boolean} [options.checked=false] - Initial checked state.
- * @param {function} [options.onChanged] - Callback for state change.
- * @param {boolean} [options.disabled=false] - If true, disables the radio button.
- * @returns {HTMLLabelElement} The created radio button component (label wrapper).
- */
-function createAdwRadioButton(options = {}) {
-  const opts = options || {};
-  if (!opts.name) {
-    console.error("AdwRadioButton: 'name' option is required.");
-    return document.createElement("div");
-  }
-  const wrapper = document.createElement("label");
-  wrapper.classList.add("adw-radio");
-
-  const input = document.createElement("input");
-  input.type = "radio";
-  input.name = opts.name;
-  if(typeof opts.onChanged === 'function') {
-    input.addEventListener("change", opts.onChanged);
-  }
-
-  const indicator = document.createElement("span");
-  indicator.classList.add("adw-radio-indicator");
-  indicator.setAttribute("aria-hidden", "true");
-
-  const labelSpan = document.createElement("span");
-  labelSpan.classList.add("adw-radio-label");
-  labelSpan.textContent = opts.label || "";
-
-  wrapper.appendChild(input);
-  wrapper.appendChild(indicator);
-  wrapper.appendChild(labelSpan);
-
-  if (opts.checked) {
-    input.checked = true;
-  }
-  if (opts.disabled) {
-    input.setAttribute("disabled", "");
-    wrapper.setAttribute("aria-disabled", "true");
-    wrapper.classList.add("disabled");
-  }
-  // Name is already set for radio button in its factory: input.name = opts.name;
-  // Value needs to be set.
-  if (opts.value) {
-    input.value = opts.value;
-  }
-  return wrapper;
-}
-
-/**
- * Creates an Adwaita-style list box.
- * @param {object} [options={}] - Configuration options.
- * @param {HTMLElement[]} [options.children] - Child elements (typically AdwRow).
- *                                             SECURITY: Ensure children are trusted or sanitized.
- * @param {boolean} [options.isFlat=false] - If true, applies 'flat' class for borderless style.
- * @param {boolean} [options.selectable=false] - If true, sets ARIA role to 'listbox'.
- * @returns {HTMLDivElement} The created list box element.
- */
-function createAdwListBox(options = {}) {
-  const opts = options || {};
-  const listBox = document.createElement("div");
-  listBox.classList.add("adw-list-box");
-
-  if (opts.isFlat) {
-    listBox.classList.add("flat");
-  }
-  if (opts.selectable) {
-    listBox.setAttribute("role", "listbox");
-  }
-  opts.children?.forEach((child) => {
-    if (child instanceof Node) listBox.appendChild(child);
-  });
-  return listBox;
-}
-
-// Note: This function is renamed to _originalToggleTheme and wrapped later
-function _originalToggleTheme() {
-  const body = document.body;
-  body.classList.toggle("light-theme");
-  const isLight = body.classList.contains("light-theme");
-  localStorage.setItem("theme", isLight ? "light" : "dark");
-}
-
-const AVAILABLE_ACCENT_COLORS = ['blue', 'green', 'red', 'yellow', 'purple', 'orange', 'pink', 'slate'];
-const DEFAULT_ACCENT_COLOR = 'blue';
-
-/**
- * Returns the list of available accent color names.
- * @returns {string[]}
- */
-function getAccentColors() {
-    return [...AVAILABLE_ACCENT_COLORS];
-}
-
-/**
- * Sets the accent color for the application.
- * Updates CSS variables on the root element and saves the choice to localStorage.
- * @param {string} colorName - The name of the accent color (e.g., 'blue', 'green').
- */
-function setAccentColor(colorName) {
-    if (!AVAILABLE_ACCENT_COLORS.includes(colorName)) {
-        console.warn(`Adw: Accent color "${colorName}" is not available. Defaulting to ${DEFAULT_ACCENT_COLOR}.`);
-        colorName = DEFAULT_ACCENT_COLOR;
-    }
-
-    const isLightTheme = document.body.classList.contains('light-theme');
-    // Always target documentElement's style for theme-wide variables
-    const styleTarget = document.documentElement.style;
-
-    // Suffixes for background/foreground properties
-    const themeSuffixBgFg = isLightTheme ? '-light' : '-dark';
-
-    // Construct variable names for background and foreground colors
-    const accentBgVar = `var(--accent-${colorName}${themeSuffixBgFg}-bg)`;
-    const accentFgVar = `var(--accent-${colorName}${themeSuffixBgFg}-fg)`;
-
-    // Suffix for standalone accent color property (used for text, icons on neutral backgrounds)
-    // SCSS variables are --accent-{color}-standalone (light) and --accent-{color}-dark-standalone (dark)
-    const standaloneColorVar = isLightTheme ?
-        `var(--accent-${colorName}-standalone)` :
-        `var(--accent-${colorName}-dark-standalone)`;
-
-    styleTarget.setProperty('--accent-bg-color', accentBgVar);
-    styleTarget.setProperty('--accent-fg-color', accentFgVar);
-    styleTarget.setProperty('--accent-color', standaloneColorVar);
-
-    localStorage.setItem('accentColor', colorName);
-}
-
-/**
- * Loads the saved accent color from localStorage or defaults.
- * This should be called after the main theme (light/dark) is established.
- */
-function loadSavedAccentColor() {
-    let accentColorName = localStorage.getItem('accentColor');
-    if (!accentColorName || !AVAILABLE_ACCENT_COLORS.includes(accentColorName)) {
-        accentColorName = DEFAULT_ACCENT_COLOR;
-    }
-    setAccentColor(accentColorName);
-}
-
-/** Toggles the theme between light and dark AND updates accent colors. */
-function toggleTheme() {
-    _originalToggleTheme();
-    loadSavedAccentColor();
-    document.dispatchEvent(new CustomEvent('adwThemeChanged', {
-        detail: { isLight: document.body.classList.contains('light-theme') }
-    }));
-}
-
-
-/** Loads the saved theme from localStorage or detects system preference. Also loads accent color. */
-function loadSavedTheme() {
-  const body = document.body;
-  const savedTheme = localStorage.getItem("theme");
-
-  if (savedTheme === "light") {
-    body.classList.add("light-theme");
-  } else if (savedTheme === "dark") {
-    body.classList.remove("light-theme");
-  } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-    body.classList.add("light-theme");
-  } else {
-    body.classList.remove("light-theme");
-  }
-  loadSavedAccentColor();
-}
-
-/**
- * Creates an Adwaita-style ViewSwitcher.
- * @param {object} [options={}] - Configuration options.
- * @param {Array<{name: string, content: HTMLElement|string}>} [options.views=[]] - Array of view objects.
- *        Each object: { name: "View Name", content: HTMLElement or HTML string for the view's content }
- *        SECURITY: If content is an HTML string, ensure it's trusted/sanitized by the caller.
- * @param {string} [options.activeViewName] - The name of the initially active view. Defaults to the first view.
- * @param {function} [options.onViewChanged] - Callback function when the active view changes, receives view name.
- * @returns {HTMLDivElement & {setActiveView: function(string): void}} The ViewSwitcher element with a method to set view.
- */
-function createAdwViewSwitcher(options = {}) {
-  const opts = options || {};
-  const switcherElement = document.createElement("div");
-  switcherElement.classList.add("adw-view-switcher");
-
-  const bar = document.createElement("div");
-  bar.classList.add("adw-view-switcher-bar");
-  bar.setAttribute("role", "tablist");
-  if (opts.label) {
-    bar.setAttribute("aria-label", opts.label);
-  }
-
-  const contentContainer = document.createElement("div");
-  contentContainer.classList.add("adw-view-switcher-content");
-
-  const views = Array.isArray(opts.views) ? opts.views : [];
-  if (views.length === 0) {
-    console.warn("AdwViewSwitcher: No views provided.");
+  if (opts.customContent instanceof Node) {
+    contentEl.appendChild(opts.customContent);
+  } else if (body) {
+    const bodyP = document.createElement('p');
+    bodyP.classList.add('adw-alert-dialog-body');
+    bodyP.textContent = body;
+    contentEl.appendChild(bodyP);
   }
 
   const buttons = [];
-
-  views.forEach((view, index) => {
-    if (!view || typeof view.name !== 'string' || !view.content) {
-        console.warn("AdwViewSwitcher: Invalid view object at index", index, view);
-        return;
-    }
-
-    const viewId = view.id || adwGenerateId('adw-view-panel');
-    const buttonId = adwGenerateId('adw-view-tab');
-
-    const viewContentElement = view.content instanceof Node ? view.content : document.createElement('div');
-    if (!(view.content instanceof Node) && typeof view.content === 'string') {
-        // SECURITY: Caller is responsible for sanitizing HTML strings.
-        viewContentElement.innerHTML = view.content;
-    }
-    viewContentElement.id = viewId;
-    viewContentElement.setAttribute("role", "tabpanel");
-    viewContentElement.setAttribute("aria-labelledby", buttonId);
-    viewContentElement.classList.add("adw-view-panel");
-    viewContentElement.setAttribute("tabindex", "0");
-    contentContainer.appendChild(viewContentElement);
-
-    const button = Adw.createButton(view.name, {
-      // Let setActiveView handle class changes and ARIA attributes
-      onClick: () => switcherElement.setActiveView(view.name, true),
-      ...(view.buttonOptions || {})
-    });
-    button.id = buttonId;
-    button.setAttribute("role", "tab");
-    button.setAttribute("aria-controls", viewId);
-    button.setAttribute("aria-selected", "false");
-    button.dataset.viewName = view.name;
-    bar.appendChild(button);
-    buttons.push(button);
-
-    const isActive = (opts.activeViewName && view.name === opts.activeViewName) || (!opts.activeViewName && index === 0);
-    if (isActive) {
-      button.classList.add("active");
-      button.setAttribute("aria-selected", "true");
-      viewContentElement.classList.add("active-view");
-    } else {
-      viewContentElement.setAttribute("hidden", "");
-    }
-  });
-
-  switcherElement.appendChild(bar);
-  switcherElement.appendChild(contentContainer);
-
-  switcherElement.setActiveView = (viewName, focusButton = false) => {
-    let newActiveButton = null;
-
-    buttons.forEach(btn => {
-        const isButtonForView = btn.dataset.viewName === viewName;
-        btn.classList.toggle("active", isButtonForView);
-        btn.setAttribute("aria-selected", isButtonForView ? "true" : "false");
-        if (isButtonForView) {
-            newActiveButton = btn;
-        }
-    });
-
-    Array.from(contentContainer.children).forEach(panel => {
-        const isPanelForView = panel.id === newActiveButton?.getAttribute("aria-controls");
-        panel.classList.toggle("active-view", isPanelForView);
-        if (isPanelForView) {
-            panel.removeAttribute("hidden");
-        } else {
-            panel.setAttribute("hidden", "");
-        }
-    });
-
-    if (newActiveButton && focusButton) {
-        newActiveButton.focus();
-    }
-
-    if (newActiveButton && typeof opts.onViewChanged === 'function') {
-        opts.onViewChanged(viewName, newActiveButton.id, newActiveButton.getAttribute("aria-controls"));
-    }
-  };
-
-  bar.addEventListener("keydown", (event) => {
-    const currentIndex = buttons.findIndex(btn => btn === document.activeElement || btn.contains(document.activeElement));
-
-    // If focus is not within a tab button and key is not a navigation key, do nothing.
-    // This allows Tab key to move focus out of the tablist.
-    if (currentIndex === -1 && !(event.key === "ArrowRight" || event.key === "ArrowLeft" || event.key === "Home" || event.key === "End")) {
-      return;
-    }
-
-    let newIndex = currentIndex;
-    let shouldPreventDefault = false;
-
-    if (event.key === "ArrowRight") {
-        newIndex = (currentIndex + 1) % buttons.length;
-        shouldPreventDefault = true;
-    } else if (event.key === "ArrowLeft") {
-        newIndex = (currentIndex - 1 + buttons.length) % buttons.length;
-        shouldPreventDefault = true;
-    } else if (event.key === "Home") {
-        newIndex = 0;
-        shouldPreventDefault = true;
-    } else if (event.key === "End") {
-        newIndex = buttons.length - 1;
-        shouldPreventDefault = true;
-    }
-
-    if (shouldPreventDefault) {
-        event.preventDefault();
-        buttons[newIndex].focus();
-    }
-  });
-
-  return switcherElement;
-}
-
-/**
- * Creates an Adwaita-style Flap component.
- * @param {object} [options={}] - Configuration options.
- * @param {HTMLElement} [options.flapContent] - The content for the flap area.
- *                                              SECURITY: Ensure this content is trusted/sanitized.
- * @param {HTMLElement} [options.mainContent] - The content for the main area.
- *                                              SECURITY: Ensure this content is trusted/sanitized.
- * @param {boolean} [options.isFolded=false] - Initial folded state.
- * @param {string} [options.flapWidth] - Custom width for the flap (e.g., "250px"). Sets CSS variable.
- * @param {string} [options.transitionSpeed] - Custom transition speed (e.g., "0.3s"). Sets CSS variable.
- * @returns {{element: HTMLDivElement, toggleFlap: function(boolean?): void, isFolded: function(): boolean, setFolded: function(boolean): void}}
- */
-function createAdwFlap(options = {}) {
-  const opts = options || {};
-  const flapElement = document.createElement("div");
-  flapElement.classList.add("adw-flap");
-
-  const flapContentElement = document.createElement("div");
-  flapContentElement.classList.add("adw-flap-flap-content");
-  if (opts.flapContent instanceof Node) {
-    flapContentElement.appendChild(opts.flapContent);
-  } else if (opts.flapContent) {
-    console.warn("AdwFlap: options.flapContent should be a DOM element.");
-  }
-
-  const mainContentElement = document.createElement("div");
-  mainContentElement.classList.add("adw-flap-main-content");
-  if (opts.mainContent instanceof Node) {
-    mainContentElement.appendChild(opts.mainContent);
-  } else if (opts.mainContent) {
-     console.warn("AdwFlap: options.mainContent should be a DOM element.");
-  }
-
-  flapElement.appendChild(flapContentElement);
-  flapElement.appendChild(mainContentElement);
-
-  let currentIsFolded = !!opts.isFolded;
-  if (currentIsFolded) {
-    flapElement.classList.add("folded");
-  }
-
-  function setFoldState(newState) {
-    currentIsFolded = newState;
-    if (currentIsFolded) {
-      flapElement.classList.add("folded");
-    } else {
-      flapElement.classList.remove("folded");
-    }
-    const event = new CustomEvent('foldchanged', { detail: { folded: currentIsFolded } });
-    flapElement.dispatchEvent(event);
-  }
-
-  function toggleFlap(explicitState) {
-    if (typeof explicitState === 'boolean') {
-        setFoldState(explicitState);
-    } else {
-        setFoldState(!currentIsFolded);
-    }
-  }
-
-  if (opts.flapWidth) {
-    flapElement.style.setProperty('--adw-flap-width', opts.flapWidth);
-  }
-  if (opts.transitionSpeed) {
-    flapElement.style.setProperty('--adw-flap-transition-speed', opts.transitionSpeed);
-  }
-
-  return {
-    element: flapElement,
-    toggleFlap: toggleFlap,
-    isFolded: () => currentIsFolded,
-    setFolded: setFoldState
-  };
-}
-
-/**
- * Creates an Adwaita-style Avatar.
- * @param {object} [options={}] - Configuration options for the avatar.
- * @param {number} [options.size=48] - Diameter of the avatar in pixels.
- * @param {string} [options.imageSrc] - URL for an image.
- * @param {string} [options.text] - Fallback text (e.g., initials), used if imageSrc is missing or fails to load.
- * @param {HTMLElement} [options.customFallback] - Custom DOM element for fallback if image fails and text is not desired.
- * @param {string} [options.alt] - Alt text for the image. Defaults to `options.text` or "User avatar" if not provided.
- * @returns {HTMLSpanElement} The created avatar element.
- */
-function createAdwAvatar(options = {}) {
-  const opts = options || {};
-  const avatarElement = document.createElement("span");
-  avatarElement.classList.add("adw-avatar");
-
-  const size = typeof opts.size === 'number' && opts.size > 0 ? opts.size : 48;
-  avatarElement.style.width = `${size}px`;
-  avatarElement.style.height = `${size}px`;
-
-  function showFallback() {
-    while (avatarElement.firstChild) {
-        avatarElement.removeChild(avatarElement.firstChild);
-    }
-
-    if (opts.customFallback instanceof Node) {
-      avatarElement.appendChild(opts.customFallback);
-    } else if (opts.text && typeof opts.text === 'string' && opts.text.trim() !== "") {
-      const textSpan = document.createElement("span");
-      textSpan.classList.add("adw-avatar-text");
-
-      let initials = "";
-      const words = opts.text.trim().split(/\s+/);
-      if (words.length >= 2) {
-        initials = (words[0][0] || "") + (words[1][0] || "");
-      } else if (words.length === 1 && words[0].length > 0) {
-        initials = words[0].substring(0, 2);
-      } else {
-        initials = opts.text.substring(0,2);
-      }
-      initials = initials.toUpperCase();
-
-      textSpan.textContent = initials;
-
-      const fontSize = Math.max(8, Math.floor(size / 2.5));
-      textSpan.style.fontSize = `${fontSize}px`;
-
-      avatarElement.appendChild(textSpan);
-    }
-  }
-
-  if (opts.imageSrc && typeof opts.imageSrc === 'string') {
-    const img = document.createElement("img");
-    img.src = opts.imageSrc;
-    img.alt = opts.alt || opts.text || "User avatar";
-
-    img.onload = () => {
-      while (avatarElement.firstChild) {
-          avatarElement.removeChild(avatarElement.firstChild);
-      }
-      avatarElement.appendChild(img);
-    };
-    img.onerror = () => {
-      console.warn(`AdwAvatar: Image failed to load from ${opts.imageSrc}. Using fallback.`);
-      showFallback();
-    };
-  } else {
-    showFallback();
-  }
-
-  return avatarElement;
-}
-
-/**
- * Creates an Adwaita-style Action Row.
- * Typically used within a ListBox for navigation or actions.
- * @param {object} [options={}] - Configuration options.
- * @param {string} options.title - The main title text for the row.
- * @param {string} [options.subtitle] - Optional subtitle text displayed below the title.
- * @param {string} [options.iconHTML] - Optional HTML string for an SVG icon.
- *                                      SECURITY: Ensure this HTML is trusted/sanitized by the caller.
- * @param {function} [options.onClick] - Optional click handler. If provided, row becomes interactive.
- * @param {boolean} [options.showChevron=true] - If true and onClick is present, shows a chevron icon.
- * @returns {HTMLDivElement} The created ActionRow element (which is an AdwRow).
- */
-function createAdwActionRow(options = {}) {
-    const opts = options || {};
-    const rowChildren = [];
-
-    if (opts.iconHTML && typeof opts.iconHTML === 'string') {
-        const iconSpan = document.createElement("span");
-        iconSpan.classList.add("adw-action-row-icon");
-        // SECURITY: User of the framework is responsible for sanitizing HTML if opts.iconHTML can be user-supplied.
-        iconSpan.innerHTML = opts.iconHTML;
-        rowChildren.push(iconSpan);
-    }
-
-    const textContentDiv = document.createElement("div");
-    textContentDiv.classList.add("adw-action-row-text-content");
-
-    const titleLabel = Adw.createLabel(opts.title || "", { htmlTag: "span" });
-    titleLabel.classList.add("adw-action-row-title");
-    textContentDiv.appendChild(titleLabel);
-
-    if (opts.subtitle && typeof opts.subtitle === 'string') {
-        const subtitleLabel = Adw.createLabel(opts.subtitle, { htmlTag: "span" });
-        subtitleLabel.classList.add("adw-action-row-subtitle");
-        textContentDiv.appendChild(subtitleLabel);
-    }
-    rowChildren.push(textContentDiv);
-
-    const showChevron = opts.showChevron !== false;
-    if (typeof opts.onClick === 'function' && showChevron) {
-        const chevronSpan = document.createElement("span");
-        chevronSpan.classList.add("adw-action-row-chevron");
-        // Chevron content is typically handled by CSS ::after pseudo-element in SCSS
-        rowChildren.push(chevronSpan);
-    }
-
-    const rowOptions = {
-        children: rowChildren,
-        interactive: typeof opts.onClick === 'function',
-        onClick: opts.onClick // Pass onClick to AdwRow for interactive styling and ARIA
-    };
-
-    const actionRow = Adw.createRow(rowOptions);
-    actionRow.classList.add("adw-action-row");
-    // AdwRow's interactive option already handles tabindex and role="button"
-
-    return actionRow;
-}
-
-/**
- * Creates an Adwaita-style Entry Row.
- * Displays a title label alongside an AdwEntry.
- * @param {object} [options={}] - Configuration options.
- * @param {string} options.title - The title label for the entry.
- * @param {object} [options.entryOptions={}] - Options object to pass to `Adw.createEntry`.
- * @param {boolean} [options.labelForEntry=true] - If true, associates the title label with the entry using `for` attribute.
- * @returns {HTMLDivElement} The created EntryRow element (which is an AdwRow).
- */
-function createAdwEntryRow(options = {}) {
-    const opts = options || {};
-    const rowChildren = [];
-    const entryOptions = opts.entryOptions || {};
-
-    let entryId;
-    if (opts.labelForEntry !== false) {
-        entryId = entryOptions.id || `adw-entry-${Date.now()}-${Math.random().toString(36).substring(2,7)}`;
-        if (!entryOptions.id) {
-            entryOptions.id = entryId;
-        }
-    }
-
-    const titleLabel = Adw.createLabel(opts.title || "", {
-        htmlTag: "label",
-        for: entryId
-    });
-    titleLabel.classList.add("adw-entry-row-title");
-    rowChildren.push(titleLabel);
-
-    const entryElement = Adw.createEntry(entryOptions);
-    entryElement.classList.add("adw-entry-row-entry");
-    rowChildren.push(entryElement);
-
-    const entryRow = Adw.createRow({ children: rowChildren });
-    entryRow.classList.add("adw-entry-row");
-
-    return entryRow;
-}
-
-/**
- * Creates an Adwaita-style Expander Row.
- * A row that can be clicked to expand/collapse and show more content.
- * @param {object} [options={}] - Configuration options.
- * @param {string} options.title - The main title text for the row.
- * @param {string} [options.subtitle] - Optional subtitle text.
- * @param {boolean} [options.expanded=false] - Initial expanded state.
- * @param {HTMLElement} options.content - The DOM element to show/hide.
- *                                        SECURITY: Ensure this content is trusted/sanitized by the caller.
- * @returns {HTMLDivElement} The created ExpanderRow wrapper element.
- */
-function createAdwExpanderRow(options = {}) {
-    const opts = options || {};
-    const wrapper = document.createElement("div");
-    wrapper.classList.add("adw-expander-row-wrapper");
-
-    const rowChildren = [];
-
-    const textContentDiv = document.createElement("div");
-    textContentDiv.classList.add("adw-expander-row-text-content");
-
-    const titleLabel = Adw.createLabel(opts.title || "", { htmlTag: "span" });
-    titleLabel.classList.add("adw-expander-row-title");
-    textContentDiv.appendChild(titleLabel);
-
-    if (opts.subtitle && typeof opts.subtitle === 'string') {
-        const subtitleLabel = Adw.createLabel(opts.subtitle, { htmlTag: "span" });
-        subtitleLabel.classList.add("adw-expander-row-subtitle");
-        textContentDiv.appendChild(subtitleLabel);
-    }
-    rowChildren.push(textContentDiv);
-
-    const expanderIcon = document.createElement("span");
-    expanderIcon.classList.add("adw-expander-row-icon");
-    expanderIcon.setAttribute("aria-hidden", "true");
-    rowChildren.push(expanderIcon);
-
-    const contentId = `adw-expander-content-${Date.now()}-${Math.random().toString(36).substring(2,7)}`;
-
-    const clickableRow = Adw.createRow({
-        children: rowChildren,
-        interactive: true,
-        onClick: () => toggleExpansion()
-    });
-    clickableRow.classList.add("adw-expander-row");
-    clickableRow.setAttribute("aria-expanded", opts.expanded ? "true" : "false");
-    clickableRow.setAttribute("aria-controls", contentId);
-
-    const contentDiv = document.createElement("div");
-    contentDiv.classList.add("adw-expander-row-content");
-    contentDiv.id = contentId;
-    if (opts.content instanceof Node) {
-        contentDiv.appendChild(opts.content);
-    } else if (opts.content) {
-        // SECURITY: User responsible for sanitizing HTML string if passed
-        console.warn("AdwExpanderRow: content should be an HTMLElement. String content might be insecure if not sanitized.");
-        const tempContent = document.createElement('div');
-        tempContent.innerHTML = opts.content; // This line is the security concern if opts.content is untrusted.
-        contentDiv.appendChild(tempContent);
-    }
-
-    let isExpanded = !!opts.expanded;
-
-    function toggleExpansion() {
-        isExpanded = !isExpanded;
-        clickableRow.setAttribute("aria-expanded", isExpanded ? "true" : "false");
-        if (isExpanded) {
-            clickableRow.classList.add("expanded");
-            contentDiv.classList.add("expanded");
-        } else {
-            clickableRow.classList.remove("expanded");
-            contentDiv.classList.remove("expanded");
-        }
-    }
-
-    if (isExpanded) {
-        clickableRow.classList.add("expanded");
-        contentDiv.classList.add("expanded");
-    }
-
-    wrapper.appendChild(clickableRow);
-    wrapper.appendChild(contentDiv);
-
-    return wrapper;
-}
-
-/**
- * Creates an Adwaita-style Combo Row.
- * Displays a title label alongside an HTML <select> element.
- * @param {object} [options={}] - Configuration options.
- * @param {string} options.title - The title label for the combo row.
- * @param {string} [options.subtitle] - Optional subtitle text.
- * @param {Array<string|{label: string, value: string}>} [options.selectOptions=[]] -
- *        Array of options for the select element. Can be strings or objects {label, value}.
- * @param {string} [options.selectedValue] - The initially selected value.
- * @param {function} [options.onChanged] - Callback function when the select value changes.
- * @param {boolean} [options.disabled=false] - If true, disables the select element.
- * @returns {HTMLDivElement} The created ComboRow element (which is an AdwRow).
- */
-function createAdwComboRow(options = {}) {
-    const opts = options || {};
-    const rowChildren = [];
-
-    const textContentDiv = document.createElement("div");
-    textContentDiv.classList.add("adw-combo-row-text-content");
-
-    const titleLabel = Adw.createLabel(opts.title || "", { htmlTag: "span" });
-    titleLabel.classList.add("adw-combo-row-title");
-    textContentDiv.appendChild(titleLabel);
-
-    if (opts.subtitle && typeof opts.subtitle === 'string') {
-        const subtitleLabel = Adw.createLabel(opts.subtitle, { htmlTag: "span" });
-        subtitleLabel.classList.add("adw-combo-row-subtitle");
-        textContentDiv.appendChild(subtitleLabel);
-    }
-    rowChildren.push(textContentDiv);
-
-    const selectElement = document.createElement("select");
-    selectElement.classList.add("adw-combo-row-select");
-
-    if (Array.isArray(opts.selectOptions)) {
-        opts.selectOptions.forEach(opt => {
-            const optionElement = document.createElement("option");
-            if (typeof opt === 'string') {
-                optionElement.value = opt;
-                optionElement.textContent = opt;
-            } else if (typeof opt === 'object' && opt !== null && opt.hasOwnProperty('value') && opt.hasOwnProperty('label')) {
-                optionElement.value = opt.value;
-                optionElement.textContent = opt.label;
-            }
-            if (opts.selectedValue === optionElement.value) {
-                optionElement.selected = true;
-            }
-            selectElement.appendChild(optionElement);
-        });
-    }
-
-    if (typeof opts.onChanged === 'function') {
-        selectElement.addEventListener("change", (event) => {
-            opts.onChanged(event.target.value, event);
-        });
-    }
-
-    if (opts.disabled) {
-        selectElement.setAttribute("disabled", "");
-        selectElement.setAttribute("aria-disabled", "true");
-    }
-
-    rowChildren.push(selectElement);
-
-    const comboRow = Adw.createRow({ children: rowChildren });
-    comboRow.classList.add("adw-combo-row");
-    // Typically, the row itself isn't interactive like an ActionRow, interaction is with the <select>
-    // So, no 'interactive' class or onClick on the row itself by default.
-
-    return comboRow;
-}
-
-// SVG Icons for Password Visibility Toggle
-const ADW_ICON_VISIBILITY_SHOW = `<svg viewBox="0 0 24 24" fill="currentColor" style="width: 1em; height: 1em; display: inline-block; vertical-align: middle;"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>`;
-const ADW_ICON_VISIBILITY_HIDE = `<svg viewBox="0 0 24 24" fill="currentColor" style="width: 1em; height: 1em; display: inline-block; vertical-align: middle;"><path d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.44-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"/></svg>`;
-
-/**
- * Creates an Adwaita-style Split Button.
- * @param {object} [options={}] - Configuration options.
- * @param {string} [options.actionText="Action"] - Text for the main action part.
- * @param {string} [options.actionHref] - URL for the main action part (makes it an <a> tag).
- * @param {function} [options.onActionClick] - Click handler for the main action part (if not a link).
- * @param {function} [options.onDropdownClick] - Click handler for the dropdown part.
- * @param {boolean} [options.suggested=false] - If true, applies 'suggested-action' style.
- * @param {boolean} [options.disabled=false] - If true, disables the button.
- * @param {string} [options.id] - Optional ID for the main wrapper.
- * @param {string} [options.dropdownAriaLabel="More options"] - ARIA label for the dropdown button.
- * @returns {HTMLDivElement} The created split button element.
- */
-function createAdwSplitButton(options = {}) {
-  const opts = options || {};
-  const splitButton = document.createElement("div");
-  splitButton.classList.add("adw-split-button");
-  if (opts.id) {
-    splitButton.id = opts.id;
-  }
-
-  if (opts.suggested) {
-    splitButton.classList.add("suggested-action");
-  }
-  if (opts.disabled) {
-    splitButton.setAttribute("disabled", "");
-    splitButton.setAttribute("aria-disabled", "true");
-  }
-
-  const isActionLink = !!opts.actionHref;
-  const actionPart = document.createElement(isActionLink ? "a" : "button");
-  actionPart.classList.add("adw-split-button-action");
-  actionPart.textContent = opts.actionText || "Action";
-
-  if (isActionLink) {
-    actionPart.href = opts.actionHref;
-    if (opts.disabled) {
-        actionPart.classList.add("disabled");
-        actionPart.setAttribute("aria-disabled", "true");
-        actionPart.style.pointerEvents = "none";
-    }
-  } else {
-    if (typeof opts.onActionClick === 'function' && !opts.disabled) {
-      actionPart.addEventListener("click", opts.onActionClick);
-    }
-    if (opts.disabled) {
-      actionPart.setAttribute("disabled", "");
-    }
-  }
-
-  const dropdownPart = document.createElement("button");
-  dropdownPart.classList.add("adw-split-button-dropdown");
-  dropdownPart.setAttribute("aria-haspopup", "true");
-  dropdownPart.setAttribute("aria-label", opts.dropdownAriaLabel || "More options");
-
-  const arrow = document.createElement("span");
-  arrow.classList.add("adw-split-button-arrow");
-  dropdownPart.appendChild(arrow);
-
-  if (typeof opts.onDropdownClick === 'function' && !opts.disabled) {
-    dropdownPart.addEventListener("click", opts.onDropdownClick);
-  }
-  if (opts.disabled) {
-    dropdownPart.setAttribute("disabled", "");
-  }
-
-  splitButton.appendChild(actionPart);
-  splitButton.appendChild(dropdownPart);
-
-  return splitButton;
-}
-
-/**
- * Creates an Adwaita-style Status Page.
- * @param {object} [options={}] - Configuration options.
- * @param {string} [options.title] - The main title for the status page.
- * @param {string} [options.description] - The descriptive text.
- * @param {string} [options.iconHTML] - HTML string for an icon (e.g., SVG).
- *                                      SECURITY: Ensure trusted/sanitized if user-supplied.
- * @param {HTMLElement[]} [options.actions] - Array of action elements (e.g., buttons).
- * @returns {HTMLDivElement} The created status page element.
- */
-function createAdwStatusPage(options = {}) {
-  const opts = options || {};
-  const statusPage = document.createElement("div");
-  statusPage.classList.add("adw-status-page");
-
-  if (opts.iconHTML) {
-    const iconDiv = document.createElement("div");
-    iconDiv.classList.add("adw-status-page-icon");
-    // SECURITY: User of the framework is responsible for sanitizing HTML.
-    iconDiv.innerHTML = opts.iconHTML;
-    statusPage.appendChild(iconDiv);
-  }
-
-  if (opts.title) {
-    const titleDiv = document.createElement("div");
-    titleDiv.classList.add("adw-status-page-title");
-    titleDiv.textContent = opts.title;
-    statusPage.appendChild(titleDiv);
-  }
-
-  if (opts.description) {
-    const descriptionDiv = document.createElement("div");
-    descriptionDiv.classList.add("adw-status-page-description");
-    descriptionDiv.textContent = opts.description;
-    statusPage.appendChild(descriptionDiv);
-  }
-
-  if (opts.actions && Array.isArray(opts.actions) && opts.actions.length > 0) {
-    const actionsDiv = document.createElement("div");
-    actionsDiv.classList.add("adw-status-page-actions");
-    opts.actions.forEach(action => {
-      if (action instanceof Node) actionsDiv.appendChild(action);
-    });
-    statusPage.appendChild(actionsDiv);
-  }
-  return statusPage;
-}
-
-/**
- * Creates an Adwaita-style spinner.
- * @param {object} [options={}] - Configuration options for the spinner.
- * @param {'small'|'large'} [options.size] - Optional size for the spinner. Default is medium.
- * @param {string} [options.id] - Optional ID for the spinner element.
- * @returns {HTMLDivElement} The created spinner element.
- */
-function createAdwSpinner(options = {}) {
-  const opts = options || {};
-  const spinner = document.createElement("div");
-  spinner.classList.add("adw-spinner");
-  spinner.setAttribute("role", "status");
-
-  if (opts.size === 'small') {
-    spinner.classList.add("small");
-  } else if (opts.size === 'large') {
-    spinner.classList.add("large");
-  }
-
-  if (opts.id) {
-    spinner.id = opts.id;
-  }
-  return spinner;
-}
-
-/**
- * Creates an Adwaita-style Entry Row specifically for passwords.
- * Includes a label, a password input, and a visibility toggle button.
- * @param {object} [options={}] - Configuration options.
- * @param {string} options.title - The title label for the entry row.
- * @param {object} [options.entryOptions={}] - Options object to pass to `Adw.createEntry` for the password input.
- *                                             Ensure `type` is not set here, as it will be managed.
- * @param {boolean} [options.labelForEntry=true] - If true, associates the title label with the entry using `for` attribute.
- * @returns {HTMLDivElement} The created PasswordEntryRow element (which is an AdwRow).
- */
-function createAdwPasswordEntryRow(options = {}) {
-    console.log('[Debug] createAdwPasswordEntryRow factory function was called with options:', options);
-    const opts = options || {};
-    const entryOptions = { ...(opts.entryOptions || {}) };
-
-    // Ensure type is password, overriding if necessary. Adw.createEntry defaults to 'text'.
-    entryOptions.type = 'password';
-    if (opts.entryOptions && opts.entryOptions.hasOwnProperty('type') && opts.entryOptions.type !== 'password') {
-        console.warn("createAdwPasswordEntryRow: entryOptions.type was specified but will be overridden to 'password'.");
-    }
-
-
-    let entryId;
-    if (opts.labelForEntry !== false) {
-        entryId = entryOptions.id || `adw-password-entry-${Date.now()}-${Math.random().toString(36).substring(2,7)}`;
-        if (!entryOptions.id) {
-            entryOptions.id = entryId;
-        }
-    }
-
-    const titleLabel = Adw.createLabel(opts.title || "Password", {
-        htmlTag: "label",
-        for: entryId
-    });
-    titleLabel.classList.add("adw-entry-row-title");
-
-
-    const passwordEntry = Adw.createEntry(entryOptions);
-    // Explicitly set type to password as createAdwEntry might default to text or other types.
-    passwordEntry.type = 'password';
-    passwordEntry.classList.add("adw-entry-row-entry");
-
-    let passwordVisible = false;
-    const visibilityButton = Adw.createButton("", {
-        icon: ADW_ICON_VISIBILITY_SHOW,
-        isCircular: true,
-        flat: true,
-        ariaLabel: "Show password",
+  if (Array.isArray(opts.choices) && opts.choices.length > 0) {
+    opts.choices.forEach(choice => {
+      const button = createAdwButton(choice.label, {
+        suggested: choice.style === 'suggested',
+        destructive: choice.style === 'destructive',
         onClick: () => {
-            passwordVisible = !passwordVisible;
-            if (passwordVisible) {
-                passwordEntry.type = "text";
-                visibilityButton.setIcon(ADW_ICON_VISIBILITY_HIDE); // Assumes setIcon method exists or is polyfilled
-                visibilityButton.setAttribute("aria-label", "Hide password");
-            } else {
-                passwordEntry.type = "password";
-                visibilityButton.setIcon(ADW_ICON_VISIBILITY_SHOW);
-                visibilityButton.setAttribute("aria-label", "Show password");
+          if (typeof opts.onResponse === 'function') {
+            opts.onResponse(choice.value);
+          }
+          // Automatically close the dialog when a choice is made
+          alertDialog.close();
+        }
+      });
+      buttons.push(button);
+    });
+  } else {
+    // Default "OK" button if no choices provided
+    buttons.push(createAdwButton("OK", {
+      suggested: true,
+      onClick: () => {
+        if (typeof opts.onResponse === 'function') {
+          opts.onResponse("ok"); // Default response value
+        }
+        alertDialog.close();
+      }
+    }));
+  }
+
+  const dialogOptions = {
+    title: opts.heading || undefined, // AdwDialog handles title
+    content: contentEl,
+    buttons: buttons,
+    closeOnBackdropClick: opts.closeOnBackdropClick === true, // Default to false for alerts
+    onClose: () => {
+      // Any specific onClose logic for alert dialog itself, if needed in future
+    }
+  };
+
+  const alertDialog = createAdwDialog(dialogOptions);
+  alertDialog.dialog.classList.add('adw-alert-dialog'); // Add specific class for styling
+  if(opts.heading) alertDialog.dialog.setAttribute('aria-label', opts.heading);
+  else if(body) alertDialog.dialog.setAttribute('aria-label', body.substring(0, 50));
+
+
+  // Ensure the dialog is announced by screen readers
+  alertDialog.dialog.setAttribute('aria-live', 'assertive');
+  alertDialog.dialog.setAttribute('aria-atomic', 'true');
+
+
+  return alertDialog;
+}
+
+/**
+ * Creates an Adwaita-style About Dialog.
+ * @param {object} options - Configuration options for the about dialog.
+ * @param {string} [options.appName] - The name of the application.
+ * @param {string} [options.appIcon] - URL or class for the application icon.
+ * @param {string} [options.logo] - URL for a larger logo image.
+ * @param {string} [options.version] - Application version.
+ * @param {string} [options.copyright] - Copyright information.
+ * @param {string|string[]} [options.developerName] - Main developer(s).
+ * @param {string} [options.website] - Application website URL.
+ * @param {string} [options.websiteLabel] - Label for the website link.
+ * @param {string} [options.licenseType] - SPDX license identifier (e.g., "MIT", "GPL-3.0-or-later").
+ * @param {string} [options.licenseText] - Custom license text (can be long).
+ * @param {string} [options.comments] - General comments about the application.
+ * @param {string[]} [options.developers] - List of developers.
+ * @param {string[]} [options.designers] - List of designers.
+ * @param {string[]} [options.documenters] - List of documenters.
+ * @param {string} [options.translatorCredits] - Translator credits.
+ * @param {string[]} [options.artists] - List of artists.
+ * @param {Array<string|{title: string, names: string[]}>} [options.acknowledgements] - Acknowledgements.
+ * @returns {{dialog: HTMLDivElement, open: function, close: function}} Object with dialog element and methods.
+ */
+function createAdwAboutDialog(options = {}) {
+  const opts = options || {};
+  const dialogId = adwGenerateId('adw-about-dialog');
+
+  const aboutDialogContent = document.createElement('div');
+  aboutDialogContent.classList.add('adw-about-dialog-content');
+
+  // Header section: Icon, App Name, Version
+  const headerSection = document.createElement('header');
+  headerSection.classList.add('adw-about-dialog-header');
+
+  if (opts.logo) {
+    const logoImg = document.createElement('img');
+    logoImg.src = opts.logo;
+    logoImg.alt = `${opts.appName || 'Application'} Logo`;
+    logoImg.classList.add('adw-about-dialog-logo');
+    headerSection.appendChild(logoImg);
+  } else if (opts.appIcon) {
+    // Simple icon if no full logo
+    if (opts.appIcon.includes('.') || opts.appIcon.startsWith('data:')) { // Basic check for URL
+        const iconImg = document.createElement('img');
+        iconImg.src = opts.appIcon;
+        iconImg.alt = `${opts.appName || 'Application'} Icon`;
+        iconImg.classList.add('adw-about-dialog-app-icon-img');
+        headerSection.appendChild(iconImg);
+    } else { // Assume it's a class name
+        const iconSpan = document.createElement('span');
+        iconSpan.className = `adw-about-dialog-app-icon ${opts.appIcon}`;
+        headerSection.appendChild(iconSpan);
+    }
+  }
+
+
+  const appInfoDiv = document.createElement('div');
+  appInfoDiv.classList.add('adw-about-dialog-app-info');
+  if (opts.appName) {
+    const appNameEl = document.createElement('h1');
+    appNameEl.classList.add('adw-about-dialog-app-name');
+    appNameEl.textContent = opts.appName;
+    appInfoDiv.appendChild(appNameEl);
+  }
+  if (opts.version) {
+    const versionEl = document.createElement('p');
+    versionEl.classList.add('adw-about-dialog-version');
+    versionEl.textContent = `Version ${opts.version}`;
+    appInfoDiv.appendChild(versionEl);
+  }
+  headerSection.appendChild(appInfoDiv);
+  aboutDialogContent.appendChild(headerSection);
+
+
+  // Main content: comments, copyright, website etc.
+  const mainContentSection = document.createElement('div');
+  mainContentSection.classList.add('adw-about-dialog-main-content');
+
+  if (opts.comments) {
+    const commentsEl = document.createElement('p');
+    commentsEl.classList.add('adw-about-dialog-comments');
+    commentsEl.textContent = opts.comments;
+    mainContentSection.appendChild(commentsEl);
+  }
+
+  if (opts.developerName) {
+    const devEl = document.createElement('p');
+    devEl.classList.add('adw-about-dialog-developer');
+    const names = Array.isArray(opts.developerName) ? opts.developerName.join(', ') : opts.developerName;
+    devEl.innerHTML = `Developed by: <strong>${names}</strong>`;
+    mainContentSection.appendChild(devEl);
+  }
+
+  if (opts.copyright) {
+    const copyrightEl = document.createElement('p');
+    copyrightEl.classList.add('adw-about-dialog-copyright');
+    copyrightEl.textContent = opts.copyright;
+    mainContentSection.appendChild(copyrightEl);
+  }
+
+  if (opts.website) {
+    const websiteEl = document.createElement('p');
+    websiteEl.classList.add('adw-about-dialog-website');
+    const websiteLink = document.createElement('a');
+    websiteLink.href = opts.website;
+    websiteLink.target = '_blank';
+    websiteLink.rel = 'noopener noreferrer';
+    websiteLink.textContent = opts.websiteLabel || opts.website;
+    websiteEl.appendChild(websiteLink);
+    mainContentSection.appendChild(websiteEl);
+  }
+  aboutDialogContent.appendChild(mainContentSection);
+
+  // Credits & License Section (often in an expander or separate view in native Adwaita)
+  // For web, we can use an AdwExpanderRow or just list them.
+  // Let's create an expander for "Details" which can contain license and credits.
+
+  const detailsContent = document.createElement('div');
+  detailsContent.classList.add('adw-about-dialog-details-content');
+  let hasDetails = false;
+
+  function createListSection(title, items) {
+    if (items && items.length > 0) {
+      hasDetails = true;
+      const sectionEl = document.createElement('div');
+      sectionEl.classList.add('adw-about-dialog-credits-section');
+      const titleEl = document.createElement('h3');
+      titleEl.textContent = title;
+      sectionEl.appendChild(titleEl);
+      const listEl = document.createElement('ul');
+      items.forEach(item => {
+        const listItem = document.createElement('li');
+        if (typeof item === 'object' && item.title && Array.isArray(item.names)) { // For acknowledgements
+            listItem.innerHTML = `<strong>${item.title}:</strong> ${item.names.join(', ')}`;
+        } else {
+            listItem.textContent = item;
+        }
+        listEl.appendChild(listItem);
+      });
+      sectionEl.appendChild(listEl);
+      return sectionEl;
+    }
+    return null;
+  }
+
+  const devList = createListSection("Developers", opts.developers);
+  if (devList) detailsContent.appendChild(devList);
+
+  const designerList = createListSection("Designers", opts.designers);
+  if (designerList) detailsContent.appendChild(designerList);
+
+  const docList = createListSection("Documenters", opts.documenters);
+  if (docList) detailsContent.appendChild(docList);
+
+  const artistList = createListSection("Artists", opts.artists);
+  if (artistList) detailsContent.appendChild(artistList);
+
+  if (opts.translatorCredits) {
+    hasDetails = true;
+    const translatorEl = document.createElement('div');
+    translatorEl.classList.add('adw-about-dialog-credits-section');
+    const titleEl = document.createElement('h3');
+    titleEl.textContent = "Translators";
+    translatorEl.appendChild(titleEl);
+    const pEl = document.createElement('p');
+    pEl.textContent = opts.translatorCredits;
+    translatorEl.appendChild(pEl);
+    detailsContent.appendChild(translatorEl);
+  }
+
+  const ackList = createListSection("Acknowledgements", opts.acknowledgements);
+  if (ackList) detailsContent.appendChild(ackList);
+
+
+  if (opts.licenseType || opts.licenseText) {
+    hasDetails = true;
+    const licenseSection = document.createElement('div');
+    licenseSection.classList.add('adw-about-dialog-license-section');
+    const licenseTitle = document.createElement('h3');
+    licenseTitle.textContent = "License";
+    licenseSection.appendChild(licenseTitle);
+
+    if (opts.licenseType) {
+        const licenseTypeP = document.createElement('p');
+        // Simple link for common licenses - could be expanded
+        const spdxUrl = `https://spdx.org/licenses/${opts.licenseType}.html`;
+        licenseTypeP.innerHTML = `This program is distributed under the terms of the <a href="${spdxUrl}" target="_blank" rel="noopener noreferrer">${opts.licenseType}</a>.`;
+        licenseSection.appendChild(licenseTypeP);
+    }
+    if (opts.licenseText) {
+        const licenseTextEl = document.createElement('pre');
+        licenseTextEl.classList.add('adw-about-dialog-license-text');
+        licenseTextEl.textContent = opts.licenseText;
+        licenseSection.appendChild(licenseTextEl);
+    }
+    detailsContent.appendChild(licenseSection);
+  }
+
+  if (hasDetails) {
+    const expander = createAdwExpanderRow({
+        title: "Details",
+        content: detailsContent,
+        expanded: false // Start collapsed
+    });
+    aboutDialogContent.appendChild(expander);
+  }
+
+  const dialog = createAdwDialog({
+    title: `About ${opts.appName || ''}`,
+    content: aboutDialogContent,
+    buttons: [createAdwButton("Close", { suggested: true, onClick: () => dialog.close() })],
+    closeOnBackdropClick: true
+  });
+
+  dialog.dialog.classList.add('adw-about-dialog');
+  dialog.dialog.style.maxWidth = '600px'; // About dialogs can be a bit wider
+
+  return dialog;
+}
+
+/**
+ * Creates an Adwaita-style Preferences Dialog.
+ * @param {object} [options={}] - Configuration options.
+ * @param {string} [options.title="Preferences"] - Title for the dialog window.
+ * @param {Array<{name: string, title: string, pageElement: HTMLElement}>} [options.pages=[]] -
+ *        Array of page objects. Each object: { name: "internalName", title: "Display Title", pageElement: HTMLElement }.
+ *        The pageElement should be an AdwPreferencesPage or similarly structured element.
+ * @param {function} [options.onClose] - Callback when the dialog is closed.
+ * @param {string} [options.initialPageName] - Optional name of the page to show initially. Defaults to the first page.
+ * @returns {{dialog: HTMLDivElement, open: function, close: function}} Object with dialog element and methods.
+ */
+function createAdwPreferencesDialog(options = {}) {
+  const opts = options || {};
+  const dialogTitle = opts.title || "Preferences";
+
+  const preferencesDialogContent = document.createElement('div');
+  preferencesDialogContent.classList.add('adw-preferences-dialog-content');
+
+  const viewsForSwitcher = (opts.pages || []).map(page => ({
+    name: page.name,
+    // title: page.title, // The button text for ViewSwitcher is page.title
+    content: page.pageElement, // This is the AdwPreferencesPage element
+    buttonOptions: { text: page.title } // Pass title as button text
+  }));
+
+  if (viewsForSwitcher.length === 0) {
+    console.warn("AdwPreferencesDialog: No pages provided.");
+    const emptyState = Adw.createStatusPage({ title: "No Preferences", description: "There are no preference pages configured."});
+    preferencesDialogContent.appendChild(emptyState);
+  } else {
+    const viewSwitcher = createAdwViewSwitcher({
+      views: viewsForSwitcher,
+      activeViewName: opts.initialPageName || (viewsForSwitcher[0] ? viewsForSwitcher[0].name : undefined),
+      label: "Preference Pages" // ARIA label for the view switcher bar
+    });
+    // Preferences dialogs often have the view switcher bar with a different style, or integrated.
+    // For now, use default view switcher. Could add a class for specific styling.
+    viewSwitcher.classList.add('adw-preferences-dialog-view-switcher');
+    preferencesDialogContent.appendChild(viewSwitcher);
+  }
+
+  const dialog = createAdwDialog({
+    title: dialogTitle,
+    content: preferencesDialogContent,
+    // Preferences dialogs usually don't have explicit global action buttons like "OK", "Cancel"
+    // Actions are within the pages, or it's just closed.
+    // A close button is often part of the dialog's title bar (handled by AdwDialog default structure if applicable)
+    // or implicitly by pressing Escape.
+    buttons: [Adw.createButton("Close", { onClick: () => dialog.close(), suggested: true })], // Added a close button for now
+    closeOnBackdropClick: true, // Standard for preferences
+    onClose: opts.onClose
+  });
+
+  dialog.dialog.classList.add('adw-preferences-dialog');
+  // Preferences dialogs are often larger
+  dialog.dialog.style.minWidth = '600px';
+  dialog.dialog.style.minHeight = '400px';
+  // Ensure content area can scroll if pages are tall
+  const adwDialogContent = dialog.dialog.querySelector('.adw-dialog-content');
+  if (adwDialogContent) {
+      adwDialogContent.style.maxHeight = '70vh';
+      adwDialogContent.style.overflowY = 'auto';
+  }
+
+
+  return dialog;
+}
+
+/**
+ * Creates an Adwaita-style SpinButton control.
+ * @param {object} [options={}] - Configuration options.
+ * @param {number} [options.value=0] - Initial value.
+ * @param {number} [options.min=0] - Minimum value.
+ * @param {number} [options.max=100] - Maximum value.
+ * @param {number} [options.step=1] - Step increment/decrement.
+ * @param {function(number)} [options.onValueChanged] - Callback when the value changes.
+ * @param {boolean} [options.disabled=false] - If true, disables the control.
+ * @returns {HTMLDivElement} The created spin button element.
+ */
+function createAdwSpinButton(options = {}) {
+  const opts = options || {};
+  const spinButtonWrapper = document.createElement('div');
+  spinButtonWrapper.classList.add('adw-spin-button');
+  if (opts.disabled) {
+    spinButtonWrapper.classList.add('disabled');
+  }
+
+  const currentValue = typeof opts.value === 'number' ? opts.value : 0;
+  const min = typeof opts.min === 'number' ? opts.min : 0;
+  const max = typeof opts.max === 'number' ? opts.max : 100;
+  const step = typeof opts.step === 'number' ? opts.step : 1;
+
+  const entry = createAdwEntry({
+    value: currentValue.toString(),
+    disabled: opts.disabled,
+    // Consider making the input type="number" and handling its native spinners
+    // or using inputmode="numeric" for better mobile experience.
+    // For now, a text input with manual validation.
+    onInput: (event) => {
+      let numValue = parseFloat(event.target.value);
+      if (isNaN(numValue)) numValue = min; // Or keep old value / show error
+      numValue = Math.max(min, Math.min(max, numValue));
+      event.target.value = numValue; // Correct input if invalid
+      if (typeof opts.onValueChanged === 'function') {
+        opts.onValueChanged(numValue);
+      }
+    }
+  });
+  entry.classList.add('adw-spin-button-entry');
+  // Restrict width of entry in a spin button
+  entry.style.maxWidth = '80px'; // Adjust as needed
+  entry.setAttribute('aria-live', 'assertive');
+  entry.setAttribute('aria-valuenow', currentValue);
+  if (typeof opts.min === 'number') entry.setAttribute('aria-valuemin', min);
+  if (typeof opts.max === 'number') entry.setAttribute('aria-valuemax', max);
+
+
+  const btnContainer = document.createElement('div');
+  btnContainer.classList.add('adw-spin-button-buttons');
+
+  const downButton = createAdwButton('', { // Icon handled by SCSS
+    icon: '<svg viewBox="0 0 16 16" fill="currentColor" style="width:1em;height:1em;"><path d="M4 6h8L8 11z"/></svg>', // Simple down caret
+    disabled: opts.disabled || currentValue <= min,
+    flat: true,
+    onClick: () => {
+      let numValue = parseFloat(entry.value) - step;
+      numValue = Math.max(min, numValue);
+      entry.value = numValue;
+      updateButtonsState(numValue);
+      entry.setAttribute('aria-valuenow', numValue);
+      if (typeof opts.onValueChanged === 'function') {
+        opts.onValueChanged(numValue);
+      }
+      entry.focus();
+    }
+  });
+  downButton.classList.add('adw-spin-button-down');
+  downButton.setAttribute('aria-label', 'Decrement');
+
+  const upButton = createAdwButton('', { // Icon handled by SCSS
+    icon: '<svg viewBox="0 0 16 16" fill="currentColor" style="width:1em;height:1em;"><path d="M4 10h8L8 5z"/></svg>', // Simple up caret
+    disabled: opts.disabled || currentValue >= max,
+    flat: true,
+    onClick: () => {
+      let numValue = parseFloat(entry.value) + step;
+      numValue = Math.min(max, numValue);
+      entry.value = numValue;
+      updateButtonsState(numValue);
+      entry.setAttribute('aria-valuenow', numValue);
+      if (typeof opts.onValueChanged === 'function') {
+        opts.onValueChanged(numValue);
+      }
+      entry.focus();
+    }
+  });
+  upButton.classList.add('adw-spin-button-up');
+  upButton.setAttribute('aria-label', 'Increment');
+
+  function updateButtonsState(currentVal) {
+    downButton.disabled = opts.disabled || currentVal <= min;
+    upButton.disabled = opts.disabled || currentVal >= max;
+  }
+
+  updateButtonsState(currentValue);
+
+
+  btnContainer.appendChild(upButton);
+  btnContainer.appendChild(downButton);
+
+  spinButtonWrapper.appendChild(entry);
+  spinButtonWrapper.appendChild(btnContainer);
+
+  // Allow keyboard up/down arrows on the entry
+  entry.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if(!upButton.disabled) upButton.click();
+    } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if(!downButton.disabled) downButton.click();
+    }
+  });
+
+
+  return spinButtonWrapper;
+}
+
+/**
+ * Creates an Adwaita-style Spin Row.
+ * Displays a title, subtitle (optional), and an AdwSpinButton.
+ * @param {object} [options={}] - Configuration options.
+ * @param {string} options.title - The title label for the row.
+ * @param {string} [options.subtitle] - Optional subtitle text.
+ * @param {object} [options.spinButtonOptions={}] - Options object to pass to `Adw.createSpinButton`.
+ * @param {function(number)} [options.onValueChanged] - Callback when the spin button's value changes.
+ * @returns {HTMLDivElement} The created SpinRow element (which is an AdwRow).
+ */
+function createAdwSpinRow(options = {}) {
+  const opts = options || {};
+  const rowChildren = [];
+
+  const textContentDiv = document.createElement("div");
+  textContentDiv.classList.add("adw-spin-row-text-content"); // Use a specific class or generic action-row class
+
+  const titleLabel = Adw.createLabel(opts.title || "", { htmlTag: "span" });
+  titleLabel.classList.add("adw-spin-row-title"); // Or generic action-row title class
+  textContentDiv.appendChild(titleLabel);
+
+  if (opts.subtitle && typeof opts.subtitle === 'string') {
+    const subtitleLabel = Adw.createLabel(opts.subtitle, { htmlTag: "span" });
+    subtitleLabel.classList.add("adw-spin-row-subtitle"); // Or generic action-row subtitle
+    textContentDiv.appendChild(subtitleLabel);
+  }
+  rowChildren.push(textContentDiv);
+
+  const spinButtonOptions = { ...(opts.spinButtonOptions || {}) };
+  if (typeof opts.onValueChanged === 'function' && !spinButtonOptions.onValueChanged) {
+    spinButtonOptions.onValueChanged = opts.onValueChanged;
+  }
+
+
+  const spinButtonElement = createAdwSpinButton(spinButtonOptions);
+  spinButtonElement.classList.add("adw-spin-row-spin-button");
+  rowChildren.push(spinButtonElement);
+
+  const spinRow = Adw.createRow({ children: rowChildren });
+  spinRow.classList.add("adw-spin-row");
+  // Spin rows are not typically interactive themselves; interaction is with the spinbutton.
+  return spinRow;
+}
+
+/**
+ * Creates an Adwaita-style Button Row.
+ * A row designed to hold one or more buttons.
+ * @param {object} [options={}] - Configuration options.
+ * @param {HTMLElement[]} [options.buttons=[]] - An array of button elements to add to the row.
+ *        Alternatively, can be an array of options objects for `Adw.createButton`.
+ * @param {boolean} [options.centered=false] - If true, centers the buttons within the row.
+ * @returns {HTMLDivElement} The created ButtonRow element (which is an AdwRow).
+ */
+function createAdwButtonRow(options = {}) {
+  const opts = options || {};
+  const buttonElements = (opts.buttons || []).map(btnOrOpts => {
+    if (btnOrOpts instanceof Node) {
+      return btnOrOpts;
+    }
+    return Adw.createButton(btnOrOpts.label || '', btnOrOpts);
+  });
+
+  const row = Adw.createRow({
+    // AdwRow doesn't have its own children param in current sig, pass them after creation
+  });
+  row.classList.add("adw-button-row");
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.classList.add('adw-button-row-container');
+  buttonElements.forEach(btnEl => buttonContainer.appendChild(btnEl));
+
+  row.appendChild(buttonContainer);
+
+
+  if (opts.centered) {
+    row.classList.add("centered");
+    buttonContainer.style.justifyContent = 'center'; // Simple centering for the container
+  } else {
+    // Default might be start or end, depending on typical usage (e.g. form actions often end)
+    buttonContainer.style.justifyContent = 'flex-end';
+  }
+
+  // Button rows are generally not interactive themselves.
+  // They might not need the default padding of other AdwRows if buttons have their own.
+  // row.style.paddingTop = 'var(--spacing-s)'; // Example: reduce padding
+  // row.style.paddingBottom = 'var(--spacing-s)';
+
+  return row;
+}
+
+/**
+ * Creates an AdwTabButton element.
+ * @param {object} [options={}] Configuration options.
+ * @param {string} [options.label="Tab"] Text label for the tab.
+ * @param {string} [options.iconHTML] Optional HTML string for an icon.
+ * @param {string} options.pageName Unique identifier for the page this tab controls.
+ * @param {boolean} [options.isActive=false] If true, tab is styled as active.
+ * @param {boolean} [options.isClosable=true] If true, shows a close button.
+ * @param {function(string)} [options.onSelect] Callback when tab is selected: `onSelect(pageName)`.
+ * @param {function(string)} [options.onClose] Callback when close button is clicked: `onClose(pageName)`.
+ * @returns {HTMLDivElement} The created tab button element.
+ */
+function createAdwTabButton(options = {}) {
+    const opts = options || {};
+    if (!opts.pageName) {
+        console.error("AdwTabButton: options.pageName is required.");
+        return document.createElement('div'); // Return empty div on error
+    }
+
+    const tabButton = document.createElement('div');
+    tabButton.classList.add('adw-tab-button');
+    tabButton.dataset.pageName = opts.pageName;
+    tabButton.setAttribute('role', 'tab');
+    tabButton.setAttribute('aria-selected', opts.isActive ? 'true' : 'false');
+    tabButton.setAttribute('tabindex', opts.isActive ? '0' : '-1');
+
+
+    if (opts.isActive) {
+        tabButton.classList.add('active');
+    }
+
+    const contentWrapper = document.createElement('div');
+    contentWrapper.classList.add('adw-tab-button-content-wrapper');
+
+    if (opts.iconHTML) {
+        const iconSpan = document.createElement('span');
+        iconSpan.classList.add('adw-tab-button-icon');
+        iconSpan.innerHTML = opts.iconHTML; // SECURITY: Ensure trusted HTML
+        contentWrapper.appendChild(iconSpan);
+    }
+
+    const labelSpan = document.createElement('span');
+    labelSpan.classList.add('adw-tab-button-label');
+    labelSpan.textContent = opts.label || 'Tab';
+    contentWrapper.appendChild(labelSpan);
+    tabButton.appendChild(contentWrapper);
+
+
+    if (opts.isClosable !== false) {
+        const closeButton = createAdwButton('', {
+            icon: '<svg viewBox="0 0 16 16" fill="currentColor" style="width:0.8em;height:0.8em;"><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/></svg>', // Simple 'x'
+            flat: true,
+            isCircular: true,
+            onClick: (e) => {
+                e.stopPropagation(); // Prevent tab selection when clicking close
+                if (typeof opts.onClose === 'function') {
+                    opts.onClose(opts.pageName);
+                }
+            }
+        });
+        closeButton.classList.add('adw-tab-button-close');
+        closeButton.setAttribute('aria-label', `Close tab ${opts.label || ''}`);
+        tabButton.appendChild(closeButton);
+    }
+
+    tabButton.addEventListener('click', () => {
+        if (typeof opts.onSelect === 'function') {
+            opts.onSelect(opts.pageName);
+        }
+    });
+
+    tabButton.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+             if (typeof opts.onSelect === 'function') {
+                opts.onSelect(opts.pageName);
             }
         }
     });
-    // Polyfill setIcon for the button if it's a basic button from createAdwButton
-    if (!visibilityButton.setIcon) {
-        visibilityButton.setIcon = function(iconHTML) {
-            const iconSpan = this.querySelector('.icon');
-            if (iconSpan) {
-                iconSpan.innerHTML = iconHTML;
-            } else {
-                 const newIconSpan = document.createElement("span");
-                 newIconSpan.classList.add("icon");
-                 newIconSpan.innerHTML = iconHTML;
-                 this.insertBefore(newIconSpan, this.firstChild);
+
+    return tabButton;
+}
+
+/**
+ * Creates an AdwTabBar element.
+ * @param {object} [options={}] Configuration options.
+ * @param {Array<object>} [options.tabsData=[]] Array of data objects for initial tabs.
+ *        Each object: { label: string, iconHTML?: string, pageName: string, isClosable?: boolean }
+ * @param {string} [options.activeTabName] The pageName of the initially active tab.
+ * @param {function(string)} [options.onTabSelect] Callback when a tab is selected: `onTabSelect(pageName)`.
+ * @param {function(string)} [options.onTabClose] Callback when a tab's close button is clicked: `onTabClose(pageName)`.
+ * @param {boolean} [options.showNewTabButton=false] If true, shows a '+' button to request a new tab.
+ * @param {function} [options.onNewTabRequested] Callback when the new tab button is clicked.
+ * @returns {HTMLDivElement & { setActiveTab: function(string): void, addTab: function(object, boolean?): void, removeTab: function(string): void }}
+ *          The tab bar element with methods to manage tabs.
+ */
+function createAdwTabBar(options = {}) {
+    const opts = options || {};
+    const tabBar = document.createElement('div');
+    tabBar.classList.add('adw-tab-bar');
+    tabBar.setAttribute('role', 'tablist');
+    // Consider aria-label for the tab bar itself if it's not obvious from context.
+
+    const tabButtonContainer = document.createElement('div');
+    tabButtonContainer.classList.add('adw-tab-bar-button-container');
+    tabBar.appendChild(tabButtonContainer);
+
+    let currentActiveTabName = opts.activeTabName;
+
+    function _updateTabStates(newActivePageName) {
+        currentActiveTabName = newActivePageName;
+        Array.from(tabButtonContainer.children).forEach(btn => {
+            const isActive = btn.dataset.pageName === currentActiveTabName;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            btn.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+    }
+
+    function _handleTabSelect(pageName) {
+        _updateTabStates(pageName);
+        if (typeof opts.onTabSelect === 'function') {
+            opts.onTabSelect(pageName);
+        }
+    }
+
+    function _handleTabClose(pageName) {
+        if (typeof opts.onTabClose === 'function') {
+            opts.onTabClose(pageName);
+            // The coordinator (AdwTabView) will be responsible for actually removing the tab
+            // and deciding which tab to activate next.
+        }
+    }
+
+    tabBar.addTab = (tabData, makeActive = false) => {
+        const tabButton = createAdwTabButton({
+            label: tabData.label,
+            iconHTML: tabData.iconHTML,
+            pageName: tabData.pageName,
+            isClosable: tabData.isClosable,
+            isActive: makeActive || (tabData.pageName === currentActiveTabName),
+            onSelect: _handleTabSelect,
+            onClose: _handleTabClose
+        });
+        tabButtonContainer.appendChild(tabButton);
+        if (makeActive) {
+            _updateTabStates(tabData.pageName);
+        } else if (!currentActiveTabName && tabButtonContainer.children.length === 1) {
+            // If no active tab yet and this is the first one, make it active.
+            _updateTabStates(tabData.pageName);
+             if (typeof opts.onTabSelect === 'function') { // Also fire event for initial auto-selection
+                opts.onTabSelect(tabData.pageName);
+            }
+        }
+        return tabButton;
+    };
+
+    tabBar.removeTab = (pageName) => {
+        const tabButtonToRemove = tabButtonContainer.querySelector(`.adw-tab-button[data-page-name="${pageName}"]`);
+        if (tabButtonToRemove) {
+            const wasActive = tabButtonToRemove.classList.contains('active');
+            const siblings = Array.from(tabButtonContainer.children);
+            const index = siblings.indexOf(tabButtonToRemove);
+            tabButtonToRemove.remove();
+
+            if (wasActive && tabButtonContainer.children.length > 0) {
+                // Activate previous or first tab
+                const newActiveIndex = Math.max(0, index -1);
+                const newActiveButton = tabButtonContainer.children[newActiveIndex];
+                if(newActiveButton) {
+                     _handleTabSelect(newActiveButton.dataset.pageName);
+                }
+            } else if (tabButtonContainer.children.length === 0) {
+                currentActiveTabName = null; // No tabs left
+            }
+        }
+    };
+
+    tabBar.setActiveTab = (pageName) => {
+        // Don't fire onTabSelect here, as this is a programmatic change.
+        // The expectation is that the content view will be updated by the caller.
+        _updateTabStates(pageName);
+    };
+
+
+    (opts.tabsData || []).forEach(tabData => {
+        tabBar.addTab(tabData, tabData.pageName === currentActiveTabName);
+    });
+
+    // Initialize active tab if not set by tabsData being active
+    if(currentActiveTabName && tabButtonContainer.children.length > 0){
+        _updateTabStates(currentActiveTabName);
+    } else if (!currentActiveTabName && tabButtonContainer.children.length > 0) {
+        // Default to first tab if no active one specified
+        const firstTabName = tabButtonContainer.children[0].dataset.pageName;
+         _updateTabStates(firstTabName);
+         // No onTabSelect here, this is initial state. Coordinator will handle initial content.
+    }
+
+
+    if (opts.showNewTabButton) {
+        const newTabButton = createAdwButton('', {
+            icon: '<svg viewBox="0 0 16 16" fill="currentColor" style="width:1em;height:1em;"><path fill-rule="evenodd" d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2Z"/></svg>', // Plus icon
+            flat: true,
+            isCircular: true,
+            onClick: () => {
+                if (typeof opts.onNewTabRequested === 'function') {
+                    opts.onNewTabRequested();
+                }
+            }
+        });
+        newTabButton.classList.add('adw-tab-bar-new-tab-button');
+        newTabButton.setAttribute('aria-label', 'New tab');
+        tabBar.appendChild(newTabButton);
+    }
+
+    // Keyboard navigation for tabs
+    tabBar.addEventListener('keydown', (e) => {
+        const tabs = Array.from(tabButtonContainer.querySelectorAll('.adw-tab-button'));
+        const currentIndex = tabs.findIndex(tab => tab === document.activeElement);
+
+        if (currentIndex === -1 && (e.key === 'ArrowRight' || e.key === 'ArrowLeft')) {
+            // If focus is on the bar itself, move to the active tab or first tab
+            const activeTab = tabs.find(tab => tab.classList.contains('active')) || tabs[0];
+            if (activeTab) activeTab.focus();
+            e.preventDefault();
+            return;
+        }
+
+        let newIndex = currentIndex;
+        if (e.key === 'ArrowRight') {
+            newIndex = (currentIndex + 1) % tabs.length;
+        } else if (e.key === 'ArrowLeft') {
+            newIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        } else if (e.key === 'Home') {
+            newIndex = 0;
+        } else if (e.key === 'End') {
+            newIndex = tabs.length - 1;
+        } else {
+            return; // Not a navigation key we handle here
+        }
+
+        e.preventDefault();
+        if (tabs[newIndex]) {
+            tabs[newIndex].focus();
+            // Optionally, could also select the tab on arrow navigation if desired (like some native tabs)
+            // _handleTabSelect(tabs[newIndex].dataset.pageName);
+        }
+    });
+
+
+    return tabBar;
+}
+
+/**
+ * Creates an AdwTabPage container.
+ * @param {object} [options={}] Configuration options.
+ * @param {HTMLElement} options.content The main content element for this tab page.
+ * @param {string} options.pageName Unique identifier for this page.
+ * @returns {HTMLDivElement} The created tab page container.
+ */
+function createAdwTabPage(options = {}) {
+    const opts = options || {};
+    if (!opts.pageName) {
+        console.error("AdwTabPage: options.pageName is required.");
+        return document.createElement('div');
+    }
+    if (!opts.content) {
+        console.error("AdwTabPage: options.content is required.");
+        return document.createElement('div');
+    }
+
+    const tabPage = document.createElement('div');
+    tabPage.classList.add('adw-tab-page');
+    tabPage.dataset.pageName = opts.pageName;
+    tabPage.setAttribute('role', 'tabpanel');
+    // aria-labelledby will be set by the AdwTabView to link to the tab button
+    tabPage.setAttribute('tabindex', '0'); // Make page focusable for scroll, etc.
+    tabPage.style.display = 'none'; // Initially hidden
+
+    if (opts.content instanceof Node) {
+        tabPage.appendChild(opts.content);
+    } else {
+        // Should ideally be a node, but as a fallback:
+        const contentWrapper = document.createElement('div');
+        contentWrapper.innerHTML = opts.content; // SECURITY: Ensure trusted HTML
+        tabPage.appendChild(contentWrapper);
+    }
+    return tabPage;
+}
+
+/**
+ * Creates an AdwTabView element, which coordinates an AdwTabBar and AdwTabPages.
+ * @param {object} [options={}] Configuration options.
+ * @param {Array<{name: string, title: string, content: HTMLElement, isClosable?: boolean}>} [options.pages=[]]
+ *        Initial pages data. `name` is unique ID, `title` for tab button, `content` is the page's HTMLElement.
+ * @param {string} [options.activePageName] Name of the page to be initially active.
+ * @param {boolean} [options.showNewTabButton=false] If true, tab bar shows a '+' button.
+ * @param {function} [options.onNewTabRequested] Callback when new tab button is clicked.
+ *        This callback should typically call `adwTabView.addPage(...)`.
+ * @param {function(string)} [options.onPageChanged] Callback when active page changes: `onPageChanged(pageName)`.
+ * @param {function(string): boolean} [options.onBeforePageClose] Optional callback before a page is closed.
+ *        `onBeforePageClose(pageName)`. Return false to prevent closing.
+ * @param {function(string)} [options.onPageClosed] Callback after a page is closed: `onPageClosed(pageName)`.
+ * @returns {HTMLDivElement & { addPage: function(pageData, boolean?): void, removePage: function(string): void, setActivePage: function(string): void, getActivePageName: function(): string|null }}
+ *          The tab view element with methods to manage pages.
+ */
+function createAdwTabView(options = {}) {
+    const opts = options || {};
+    const tabView = document.createElement('div');
+    tabView.classList.add('adw-tab-view');
+
+    const pagesContainer = document.createElement('div');
+    pagesContainer.classList.add('adw-tab-view-pages-container');
+
+    let pageMap = new Map(); // pageName -> { button: HTMLElement, page: HTMLElement }
+    let currentActivePageName = opts.activePageName || null;
+
+    const tabBar = createAdwTabBar({
+        activeTabName: currentActivePageName,
+        showNewTabButton: opts.showNewTabButton,
+        onNewTabRequested: () => {
+            if (typeof opts.onNewTabRequested === 'function') {
+                opts.onNewTabRequested(); // The app should then call adwTabView.addPage()
+            }
+        },
+        onTabSelect: (pageName) => {
+            tabView.setActivePage(pageName, false); // Don't re-fire onPageChanged from here if already active
+        },
+        onTabClose: (pageName) => {
+            if (typeof opts.onBeforePageClose === 'function') {
+                if (opts.onBeforePageClose(pageName) === false) {
+                    return; // Prevent close
+                }
+            }
+            tabView.removePage(pageName);
+            if (typeof opts.onPageClosed === 'function') {
+                opts.onPageClosed(pageName);
+            }
+        }
+    });
+
+    tabView.appendChild(tabBar);
+    tabView.appendChild(pagesContainer);
+
+    tabView.addPage = (pageData, makeActive = false) => {
+        if (!pageData || !pageData.name || !pageData.title || !pageData.content) {
+            console.error("AdwTabView.addPage: Invalid pageData.", pageData);
+            return;
+        }
+        if (pageMap.has(pageData.name)) {
+            console.warn(`AdwTabView: Page with name "${pageData.name}" already exists.`);
+            tabView.setActivePage(pageData.name); // Just activate if it exists
+            return;
+        }
+
+        const tabPage = createAdwTabPage({ content: pageData.content, pageName: pageData.name });
+        pagesContainer.appendChild(tabPage);
+
+        const tabButton = tabBar.addTab({
+            label: pageData.title,
+            pageName: pageData.name,
+            isClosable: pageData.isClosable
+        }, makeActive);
+
+        // Link tab button and tab panel for ARIA
+        const buttonId = tabButton.id || adwGenerateId('adw-tab-btn');
+        const panelId = tabPage.id || adwGenerateId('adw-tab-panel');
+        tabButton.id = buttonId;
+        tabPage.id = panelId;
+        tabButton.setAttribute('aria-controls', panelId);
+        tabPage.setAttribute('aria-labelledby', buttonId);
+
+        pageMap.set(pageData.name, { button: tabButton, page: tabPage });
+
+        if (makeActive || pageMap.size === 1) {
+            tabView.setActivePage(pageData.name);
+        } else if(currentActivePageName) {
+            // Ensure current active tab is still visibly active if new tab not made active
+            tabBar.setActiveTab(currentActivePageName);
+        }
+    };
+
+    tabView.removePage = (pageName) => {
+        if (pageMap.has(pageName)) {
+            const { page } = pageMap.get(pageName);
+            page.remove();
+            pageMap.delete(pageName);
+            tabBar.removeTab(pageName); // This will handle activating another tab if needed
+
+            // Update currentActivePageName from tabBar as it might have changed
+            const activeTabButton = tabBar.querySelector('.adw-tab-button.active');
+            const newActivePageName = activeTabButton ? activeTabButton.dataset.pageName : null;
+
+            if (newActivePageName !== currentActivePageName) {
+                 currentActivePageName = newActivePageName;
+                 // Show the new active page (if any)
+                 pageMap.forEach((p, name) => {
+                    p.page.style.display = (name === currentActivePageName) ? '' : 'none';
+                 });
+                 if (typeof opts.onPageChanged === 'function' && currentActivePageName) {
+                    opts.onPageChanged(currentActivePageName);
+                 }
+            } else if (!newActivePageName && currentActivePageName) {
+                // No tabs left, or no active tab decided by tabBar
+                currentActivePageName = null;
+            }
+        }
+    };
+
+    tabView.setActivePage = (pageName, fireEvent = true) => {
+        if (pageMap.has(pageName)) {
+            const oldActivePageName = currentActivePageName;
+            currentActivePageName = pageName;
+
+            tabBar.setActiveTab(pageName); // Update tab bar's visual state
+
+            pageMap.forEach((p, name) => {
+                p.page.style.display = (name === pageName) ? '' : 'none';
+            });
+
+            if (fireEvent && typeof opts.onPageChanged === 'function' && oldActivePageName !== pageName) {
+                opts.onPageChanged(pageName);
+            }
+        }
+    };
+
+    tabView.getActivePageName = () => currentActivePageName;
+
+    // Initialize with provided pages
+    (opts.pages || []).forEach(pageData => {
+        tabView.addPage(pageData, pageData.name === currentActivePageName);
+    });
+
+    // If activePageName was provided but didn't match any initial pages,
+    // or if no activePageName and there are pages, ensure first one is active.
+    if (currentActivePageName && !pageMap.has(currentActivePageName) && pageMap.size > 0) {
+        currentActivePageName = pageMap.keys().next().value;
+    }
+    if (!currentActivePageName && pageMap.size > 0) {
+        currentActivePageName = pageMap.keys().next().value;
+    }
+    if (currentActivePageName) {
+        // This final setActivePage ensures the correct page content is shown initially
+        // and fires the onPageChanged if it's the first active setting.
+        tabView.setActivePage(currentActivePageName, true);
+    }
+
+
+    return tabView;
+}
+
+/**
+ * Creates an AdwNavigationView element.
+ * Manages a stack of views with navigation (push/pop) and an updating HeaderBar.
+ * @param {object} [options={}] Configuration options.
+ * @param {Array<{name: string, element: HTMLElement, header?: {title?: string, subtitle?: string, start?: HTMLElement[], end?: HTMLElement[]}}>} [options.initialPages=[]]
+ *        Initial pages to add to the stack. The first page is shown.
+ * @returns {HTMLDivElement & { push: function(pageData): void, pop: function(): void, getVisiblePageName: function(): string|null }}
+ *          The navigation view element.
+ */
+function createAdwNavigationView(options = {}) {
+    const opts = options || {};
+    const navigationView = document.createElement('div');
+    navigationView.classList.add('adw-navigation-view');
+
+    const headerBar = createAdwHeaderBar({ title: "" }); // Initial empty title
+    navigationView.appendChild(headerBar);
+
+    const pagesContainer = document.createElement('div');
+    pagesContainer.classList.add('adw-navigation-view-pages-container');
+    navigationView.appendChild(pagesContainer);
+
+    const pageStack = []; // Stores { name: string, element: HTMLElement, header?: object }
+
+    function _updateHeaderBar() {
+        if (pageStack.length === 0) {
+            headerBar.updateTitleSubtitle(); // Clear title
+            headerBar.setStartWidgets([]);
+            headerBar.setEndWidgets([]);
+            return;
+        }
+
+        const currentPageData = pageStack[pageStack.length - 1];
+        const headerData = currentPageData.header || {};
+
+        headerBar.updateTitleSubtitle(headerData.title || currentPageData.name, headerData.subtitle);
+
+        const startWidgets = [];
+        if (pageStack.length > 1) { // Show back button if not the root page
+            const backButton = createAdwButton('', {
+                icon: '<svg viewBox="0 0 16 16" fill="currentColor" style="width:1em;height:1em;"><path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/></svg>', // Left arrow
+                flat: true,
+                onClick: () => navigationView.pop()
+            });
+            backButton.setAttribute('aria-label', 'Back');
+            startWidgets.push(backButton);
+        }
+        if (headerData.start && Array.isArray(headerData.start)) {
+            startWidgets.push(...headerData.start);
+        }
+        headerBar.setStartWidgets(startWidgets);
+
+        headerBar.setEndWidgets(headerData.end || []);
+    }
+
+    // Monkey-patch headerbar if it doesn't have these methods (from createAdwHeaderBar factory)
+    if(!headerBar.updateTitleSubtitle) {
+        headerBar.updateTitleSubtitle = (title, subtitle) => {
+            const titleEl = headerBar.querySelector('.adw-header-bar-title');
+            const subtitleEl = headerBar.querySelector('.adw-header-bar-subtitle');
+            if (titleEl) titleEl.textContent = title || '';
+            if (subtitleEl) {
+                subtitleEl.textContent = subtitle || '';
+                subtitleEl.style.display = subtitle ? '' : 'none';
+            } else if (subtitle && titleEl && titleEl.parentElement) {
+                const newSubtitleEl = document.createElement("h2");
+                newSubtitleEl.classList.add("adw-header-bar-subtitle");
+                newSubtitleEl.textContent = subtitle;
+                titleEl.parentElement.appendChild(newSubtitleEl); // Append to center box
+            }
+        };
+    }
+    if(!headerBar.setStartWidgets) {
+        headerBar.setStartWidgets = (widgets) => {
+            const startBox = headerBar.querySelector('.adw-header-bar-start');
+            if(startBox) {
+                startBox.innerHTML = ''; // Clear
+                widgets.forEach(w => startBox.appendChild(w));
+            }
+        };
+    }
+     if(!headerBar.setEndWidgets) {
+        headerBar.setEndWidgets = (widgets) => {
+            const endBox = headerBar.querySelector('.adw-header-bar-end');
+            if(endBox) {
+                endBox.innerHTML = ''; // Clear
+                widgets.forEach(w => endBox.appendChild(w));
             }
         };
     }
 
 
-    const row = Adw.createRow({
-        children: [titleLabel, passwordEntry, visibilityButton]
-    });
-    row.classList.add("adw-password-entry-row");
-    // Adjust AdwRow internal structure for better layout if needed
-    passwordEntry.style.flexGrow = "1";
-    titleLabel.style.flexShrink = "0";
-    visibilityButton.style.flexShrink = "0";
+    navigationView.push = (pageData) => {
+        if (!pageData || !pageData.name || !pageData.element) {
+            console.error("AdwNavigationView.push: Invalid pageData. Requires name and element.", pageData);
+            return;
+        }
 
-    return row;
+        if (pageStack.length > 0) {
+            const currentPage = pageStack[pageStack.length - 1];
+            currentPage.element.classList.remove('adw-navigation-page-active');
+            currentPage.element.classList.add('adw-navigation-page-exiting-left'); // Slide out left
+             // No timeout needed for display:none if using animations that hide it
+        }
+
+        pageData.element.classList.add('adw-navigation-page');
+        pageData.element.style.display = ''; // Make sure it's not display:none
+        pagesContainer.appendChild(pageData.element);
+
+        // Force reflow before adding animation class
+        void pageData.element.offsetWidth;
+        pageData.element.classList.add('adw-navigation-page-entering-right'); // Slide in from right
+        pageData.element.classList.add('adw-navigation-page-active');
+
+
+        pageStack.push(pageData);
+        _updateHeaderBar();
+
+        // Remove animation classes after transition (assuming 300ms)
+        setTimeout(() => {
+            if (pageStack.length > 1) {
+                 const prevPage = pageStack[pageStack.length - 2];
+                 if(prevPage) prevPage.element.classList.remove('adw-navigation-page-exiting-left');
+            }
+            pageData.element.classList.remove('adw-navigation-page-entering-right');
+        }, 300);
+
+        navigationView.dispatchEvent(new CustomEvent('pushed', {detail: {pageName: pageData.name}}));
+    };
+
+    navigationView.pop = () => {
+        if (pageStack.length <= 1) return;
+
+        const poppedPageData = pageStack.pop();
+        poppedPageData.element.classList.remove('adw-navigation-page-active');
+        poppedPageData.element.classList.add('adw-navigation-page-exiting-right'); // Slide out right
+
+        if (pageStack.length > 0) {
+            const newCurrentPageData = pageStack[pageStack.length - 1];
+            newCurrentPageData.element.style.display = ''; // Make sure it's visible
+            newCurrentPageData.element.classList.remove('adw-navigation-page-exiting-left'); // Remove if it was set
+            newCurrentPageData.element.classList.add('adw-navigation-page-entering-left'); // Slide in from left
+            newCurrentPageData.element.classList.add('adw-navigation-page-active');
+
+            setTimeout(() => {
+                poppedPageData.element.remove();
+                newCurrentPageData.element.classList.remove('adw-navigation-page-entering-left');
+            }, 300);
+        } else { // Should not happen if length <= 1 check is correct
+             setTimeout(() => { poppedPageData.element.remove(); }, 300);
+        }
+        _updateHeaderBar();
+
+        navigationView.dispatchEvent(new CustomEvent('popped', {detail: {pageName: poppedPageData.name}}));
+    };
+
+    navigationView.getVisiblePageName = () => {
+        return pageStack.length > 0 ? pageStack[pageStack.length - 1].name : null;
+    };
+
+    // Initialize with initial pages
+    (opts.initialPages || []).forEach((pageData, index) => {
+        pageData.element.classList.add('adw-navigation-page');
+        pagesContainer.appendChild(pageData.element);
+        pageStack.push(pageData);
+        if (index === 0) {
+            pageData.element.classList.add('adw-navigation-page-active');
+            pageData.element.style.display = '';
+        } else {
+            pageData.element.style.display = 'none';
+        }
+    });
+    if(pageStack.length > 0){
+        _updateHeaderBar();
+    }
+
+
+    return navigationView;
 }
+
+/**
+ * Creates an AdwBin container.
+ * A simple container that holds a single child.
+ * @param {object} [options={}] Configuration options.
+ * @param {HTMLElement} [options.child] The single child element.
+ * @returns {HTMLDivElement} The created bin element.
+ */
+function createAdwBin(options = {}) {
+    const opts = options || {};
+    const bin = document.createElement('div');
+    bin.classList.add('adw-bin');
+
+    if (opts.child instanceof Node) {
+        bin.appendChild(opts.child);
+    } else if (opts.child) {
+        console.warn("AdwBin: options.child was provided but is not a valid DOM Node. It will be ignored.");
+    }
+
+    // Alignment options would typically be handled by how the bin itself is placed
+    // within a parent flex or grid container, or by applying utility classes directly
+    // to the bin from outside. Implementing generic vertical/horizontal alignment
+    // that works in all contexts for the child *inside* the bin is complex.
+    // For now, AdwBin is just a simple single-child div.
+
+    return bin;
+}
+
+/**
+ * Creates an AdwWrapBox container.
+ * Arranges children in a line, wrapping to new lines as needed.
+ * @param {object} [options={}] Configuration options.
+ * @param {HTMLElement[]} [options.children=[]] Child elements.
+ * @param {"horizontal"|"vertical"} [options.orientation="horizontal"] Main layout direction.
+ * @param {string|number} [options.spacing] Gap between items (maps to 'gap'). E.g., '12px' or 12.
+ * @param {string|number} [options.lineSpacing] Gap between lines (maps to 'row-gap').
+ * @param {"start"|"center"|"end"|"stretch"} [options.align="start"] align-items (cross-axis alignment).
+ * @param {"start"|"center"|"end"|"between"|"around"|"evenly"} [options.justify="start"] justify-content (main-axis alignment within a line).
+ * @returns {HTMLDivElement} The created wrap box element.
+ */
+function createAdwWrapBox(options = {}) {
+    const opts = options || {};
+    const wrapBox = document.createElement('div');
+    wrapBox.classList.add('adw-wrap-box');
+
+    wrapBox.style.display = 'flex';
+    wrapBox.style.flexWrap = 'wrap';
+
+    if (opts.orientation === 'vertical') {
+        wrapBox.style.flexDirection = 'column';
+        // In vertical wrap, 'wrap' means items will form new columns.
+        // Height constraint on the wrapBox would be needed to see wrapping.
+    } else {
+        wrapBox.style.flexDirection = 'row'; // Default
+    }
+
+    let gapValue = "var(--spacing-m)"; // Default gap
+    if (typeof opts.spacing === 'number') {
+        gapValue = `${opts.spacing}px`;
+    } else if (typeof opts.spacing === 'string') {
+        gapValue = opts.spacing;
+    }
+
+    let rowGapValue = gapValue;
+    if (typeof opts.lineSpacing === 'number') {
+        rowGapValue = `${opts.lineSpacing}px`;
+    } else if (typeof opts.lineSpacing === 'string') {
+        rowGapValue = opts.lineSpacing;
+    }
+
+    // If lineSpacing is different from spacing, use row-gap and column-gap
+    if (rowGapValue !== gapValue) {
+        wrapBox.style.rowGap = rowGapValue;
+        wrapBox.style.columnGap = gapValue; // column-gap takes the main spacing value
+    } else {
+        wrapBox.style.gap = gapValue; // Uniform gap
+    }
+
+    const flexAlignMap = {
+        start: 'flex-start',
+        center: 'center',
+        end: 'flex-end',
+        stretch: 'stretch'
+    };
+    wrapBox.style.alignItems = flexAlignMap[opts.align] || flexAlignMap.start;
+
+    const flexJustifyMap = {
+        start: 'flex-start',
+        center: 'center',
+        end: 'flex-end',
+        between: 'space-between',
+        around: 'space-around',
+        evenly: 'space-evenly'
+    };
+    wrapBox.style.justifyContent = flexJustifyMap[opts.justify] || flexJustifyMap.start;
+
+    // align-content for wrapped lines (default is stretch)
+    // wrapBox.style.alignContent = flexAlignMap[opts.align] || flexAlignMap.start; // Can be different from align-items
+
+    (opts.children || []).forEach(child => {
+        if (child instanceof Node) {
+            wrapBox.appendChild(child);
+        }
+    });
+
+    return wrapBox;
+}
+
+/**
+ * Creates an AdwClamp container.
+ * Constrains its child's width to a maximum size and centers it.
+ * @param {object} [options={}] Configuration options.
+ * @param {HTMLElement} [options.child] The single child element.
+ * @param {string} [options.maximumSize="80ch"] The maximum width for the child.
+ * @param {boolean} [options.isScrollable=false] If true, allows content to scroll.
+ * @returns {HTMLDivElement} The created clamp element.
+ */
+function createAdwClamp(options = {}) {
+    const opts = options || {};
+    const clamp = document.createElement('div');
+    clamp.classList.add('adw-clamp');
+
+    // An inner wrapper to apply max-width and centering easily
+    const innerWrapper = document.createElement('div');
+    innerWrapper.classList.add('adw-clamp-child-wrapper');
+    innerWrapper.style.maxWidth = opts.maximumSize || '80ch'; // Default to a reasonable character measure
+
+    // Centering the innerWrapper within the clamp container
+    // This can be done if clamp itself is display:flex, justify-content:center
+    // or if innerWrapper has margin: auto and clamp is block
+    clamp.style.display = 'flex'; // Using flex on the clamp itself
+    clamp.style.justifyContent = 'center'; // Center the wrapper
+    // innerWrapper.style.marginLeft = 'auto'; // Alternative for block parent
+    // innerWrapper.style.marginRight = 'auto';
+
+
+    if (opts.child instanceof Node) {
+        innerWrapper.appendChild(opts.child);
+    } else if (opts.child) {
+        console.warn("AdwClamp: options.child was provided but is not a valid DOM Node.");
+    }
+    clamp.appendChild(innerWrapper);
+
+    if (opts.isScrollable) {
+        clamp.classList.add('scrollable');
+        // For scrollable clamp, the clamp itself (outer element) should handle scrolling
+        // if its content (the wrapper or child) overflows.
+        // The inner wrapper still dictates the max-width of the content flow.
+        clamp.style.overflowX = 'hidden'; // Typically clamp scrollable is for vertical scroll
+        clamp.style.overflowY = 'auto';
+        // The inner wrapper should not have overflow itself, it sets width.
+        // Ensure the clamp itself can have a defined height or stretches to fill.
+        innerWrapper.style.width = '100%'; // Allow wrapper to take full width of scroll area if needed
+    }
+
+    return clamp;
+}
+
+/**
+ * Creates an AdwBreakpointBin container.
+ * Shows one of its children based on width breakpoints.
+ * @param {object} [options={}] Configuration options.
+ * @param {Array<{name: string, element: HTMLElement, condition: string|number}>} options.children
+ *        Array of child objects. `condition` can be a media query like string (e.g., "min-width: 600px")
+ *        or a number (interpreted as min-width in pixels).
+ * @param {string} [options.defaultChildName] Name of the child to show if no conditions match. (Usually the smallest)
+ * @returns {HTMLDivElement & { updateVisibility: function(): void }} The created breakpoint bin element.
+ */
+function createAdwBreakpointBin(options = {}) {
+    const opts = options || {};
+    const breakpointBin = document.createElement('div');
+    breakpointBin.classList.add('adw-breakpoint-bin');
+    // BreakpointBin itself doesn't usually have visual styling, it's a controller.
+    // It needs to be in the DOM and have a width to be observed.
+
+    let sortedChildren = [];
+    if (Array.isArray(opts.children)) {
+        // Children should have {name, element, condition (number for min-width, or string for media query)}
+        // Sort by condition (ascending for min-width numbers)
+        sortedChildren = opts.children.map(c => {
+            let minWidth = 0;
+            if (typeof c.condition === 'number') {
+                minWidth = c.condition;
+            } else if (typeof c.condition === 'string') {
+                const match = c.condition.match(/min-width:\s*(\d+)(px)?/i);
+                if (match && match[1]) {
+                    minWidth = parseInt(match[1], 10);
+                } else {
+                    console.warn(`AdwBreakpointBin: Could not parse condition "${c.condition}" for child "${c.name}". Treating as 0.`);
+                }
+            }
+            return { ...c, _minWidth: minWidth };
+        }).sort((a, b) => a._minWidth - b._minWidth);
+    }
+
+    let defaultChild = null;
+    if(opts.defaultChildName){
+        defaultChild = sortedChildren.find(c => c.name === opts.defaultChildName)?.element;
+    }
+    if(!defaultChild && sortedChildren.length > 0) {
+        defaultChild = sortedChildren[0].element; // Fallback to the 'smallest' condition child
+    }
+
+    sortedChildren.forEach(childData => {
+        if (childData.element instanceof Node) {
+            childData.element.style.display = 'none'; // Initially hide all
+            breakpointBin.appendChild(childData.element);
+        }
+    });
+    if(defaultChild) defaultChild.style.display = '';
+
+
+    let currentVisibleChild = defaultChild;
+
+    breakpointBin.updateVisibility = () => {
+        const containerWidth = breakpointBin.offsetWidth;
+        let newVisibleChild = defaultChild;
+
+        // Iterate from largest condition to smallest
+        for (let i = sortedChildren.length - 1; i >= 0; i--) {
+            const childData = sortedChildren[i];
+            if (containerWidth >= childData._minWidth) {
+                newVisibleChild = childData.element;
+                break;
+            }
+        }
+
+        if (currentVisibleChild !== newVisibleChild) {
+            if (currentVisibleChild) currentVisibleChild.style.display = 'none';
+            if (newVisibleChild) newVisibleChild.style.display = '';
+            currentVisibleChild = newVisibleChild;
+            // Dispatch an event if needed:
+            // breakpointBin.dispatchEvent(new CustomEvent('child-changed', { detail: { visibleChildName: newVisibleChild?.dataset.name } }));
+        }
+    };
+
+    let resizeObserver = null;
+    if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(() => {
+            breakpointBin.updateVisibility();
+        });
+        // Start observing when the element is connected to the DOM
+        // This is typically handled by the web component's connectedCallback.
+        // For factory usage, the user would need to ensure it's in DOM then call observe.
+        // To make it more self-contained for factory:
+        // Check if in DOM, if so, observe. If not, use MutationObserver to wait.
+        // This adds complexity. Simpler: user calls an explicit 'observe' method.
+        // Or, we rely on a web component wrapper.
+        // For now, let's assume it will be observed by a web component or manually.
+    } else {
+        console.warn("AdwBreakpointBin: ResizeObserver not supported. Breakpoints will not update on resize.");
+        // Could fall back to window resize listener, but that's less accurate.
+    }
+
+    // Add a method to start observing, to be called by WC or user.
+    breakpointBin.startObserving = () => {
+        if (resizeObserver && !breakpointBin._isObserving) {
+            resizeObserver.observe(breakpointBin);
+            breakpointBin._isObserving = true;
+        }
+    };
+    breakpointBin.stopObserving = () => {
+         if (resizeObserver && breakpointBin._isObserving) {
+            resizeObserver.unobserve(breakpointBin);
+            breakpointBin._isObserving = false;
+        }
+    };
+
+    // Initial visibility update
+    // Needs to be deferred slightly if the element isn't in the DOM yet to get offsetWidth
+    // setTimeout(() => breakpointBin.updateVisibility(), 0);
+    // Better handled by connectedCallback in a Web Component.
+
+    return breakpointBin;
+}
+
+/**
+ * Creates an AdwToolbarView layout container.
+ * @param {object} [options={}] Configuration options.
+ * @param {HTMLElement} [options.content] The main content element.
+ * @param {HTMLElement} [options.topBar] Optional element for the top bar.
+ * @param {HTMLElement} [options.bottomBar] Optional element for the bottom bar.
+ * @param {boolean} [options.topBarRevealed=true] Initial visibility of the top bar.
+ * @param {boolean} [options.bottomBarRevealed=true] Initial visibility of the bottom bar.
+ * @returns {HTMLDivElement & { setTopBar: Function, setBottomBar: Function, showTopBar: Function, hideTopBar: Function, showBottomBar: Function, hideBottomBar: Function }}
+ *          The created toolbar view element with control methods.
+ */
+function createAdwToolbarView(options = {}) {
+    const opts = options || {};
+    const toolbarView = document.createElement('div');
+    toolbarView.classList.add('adw-toolbar-view');
+
+    const topBarSlot = document.createElement('div');
+    topBarSlot.classList.add('adw-toolbar-view-top-bar');
+    if (opts.topBar instanceof Node) {
+        topBarSlot.appendChild(opts.topBar);
+    }
+    topBarSlot.style.display = (opts.topBarRevealed !== false) ? '' : 'none';
+
+    const contentSlot = document.createElement('div');
+    contentSlot.classList.add('adw-toolbar-view-content');
+    if (opts.content instanceof Node) {
+        contentSlot.appendChild(opts.content);
+    }
+
+    const bottomBarSlot = document.createElement('div');
+    bottomBarSlot.classList.add('adw-toolbar-view-bottom-bar');
+    if (opts.bottomBar instanceof Node) {
+        bottomBarSlot.appendChild(opts.bottomBar);
+    }
+    bottomBarSlot.style.display = (opts.bottomBarRevealed !== false) ? '' : 'none';
+
+    toolbarView.appendChild(topBarSlot);
+    toolbarView.appendChild(contentSlot);
+    toolbarView.appendChild(bottomBarSlot);
+
+    toolbarView.setTopBar = (element) => {
+        topBarSlot.innerHTML = '';
+        if (element instanceof Node) topBarSlot.appendChild(element);
+        topBarSlot.style.display = (element && opts.topBarRevealed !== false) ? '' : 'none';
+    };
+    toolbarView.setBottomBar = (element) => {
+        bottomBarSlot.innerHTML = '';
+        if (element instanceof Node) bottomBarSlot.appendChild(element);
+        bottomBarSlot.style.display = (element && opts.bottomBarRevealed !== false) ? '' : 'none';
+    };
+    toolbarView.showTopBar = () => {
+        opts.topBarRevealed = true;
+        if (topBarSlot.firstChild) topBarSlot.style.display = '';
+    };
+    toolbarView.hideTopBar = () => {
+        opts.topBarRevealed = false;
+        topBarSlot.style.display = 'none';
+    };
+    toolbarView.showBottomBar = () => {
+        opts.bottomBarRevealed = true;
+        if (bottomBarSlot.firstChild) bottomBarSlot.style.display = '';
+    };
+    toolbarView.hideBottomBar = () => {
+        opts.bottomBarRevealed = false;
+        bottomBarSlot.style.display = 'none';
+    };
+
+    // Add accessors for revealed state if needed
+    Object.defineProperty(toolbarView, 'topBarRevealed', {
+        get: () => opts.topBarRevealed !== false && topBarSlot.style.display !== 'none',
+        set: (value) => value ? toolbarView.showTopBar() : toolbarView.hideTopBar()
+    });
+     Object.defineProperty(toolbarView, 'bottomBarRevealed', {
+        get: () => opts.bottomBarRevealed !== false && bottomBarSlot.style.display !== 'none',
+        set: (value) => value ? toolbarView.showBottomBar() : toolbarView.hideBottomBar()
+    });
+
+
+    return toolbarView;
+}
+
+// All other Adw.* factory functions follow...
+// ... (createAdwProgressBar, createAdwCheckbox, etc.) ...
 
 window.Adw = {
   createButton: createAdwButton,
@@ -1636,7 +2255,7 @@ window.Adw = {
   createBox: createAdwBox,
   createRow: createAdwRow,
   createToast: createAdwToast,
-  createAdwBanner: createAdwBanner,
+  createAdwBanner: createAdwBanner, // Note: createAdwBanner vs createBanner
   createDialog: createAdwDialog,
   createProgressBar: createAdwProgressBar,
   createCheckbox: createAdwCheckbox,
@@ -1648,7 +2267,7 @@ window.Adw = {
   DEFAULT_ACCENT_COLOR: DEFAULT_ACCENT_COLOR,
   createActionRow: createAdwActionRow,
   createEntryRow: createAdwEntryRow,
-  createAdwPasswordEntryRow: createAdwPasswordEntryRow, // Corrected assignment
+  createAdwPasswordEntryRow: createAdwPasswordEntryRow,
   createExpanderRow: createAdwExpanderRow,
   createComboRow: createAdwComboRow,
   createAvatar: createAdwAvatar,
@@ -1656,10 +2275,30 @@ window.Adw = {
   createFlap: createAdwFlap,
   createSpinner: createAdwSpinner,
   createStatusPage: createAdwStatusPage,
-  createSplitButton: createAdwSplitButton
+  createSplitButton: createAdwSplitButton,
+  createAlertDialog: createAdwAlertDialog,
+  createAboutDialog: createAdwAboutDialog,
+  createPreferencesDialog: createAdwPreferencesDialog,
+  createSpinButton: createAdwSpinButton,
+  createSpinRow: createAdwSpinRow,
+  createButtonRow: createAdwButtonRow,
+  createTabButton: createAdwTabButton,
+  createTabBar: createAdwTabBar,
+  createTabPage: createAdwTabPage,
+  createTabView: createAdwTabView,
+  createNavigationView: createAdwNavigationView,
+  createBottomSheet: createAdwBottomSheet,
+  createBin: createAdwBin,
+  createWrapBox: createAdwWrapBox,
+  createClamp: createAdwClamp,
+  createBreakpointBin: createAdwBreakpointBin,
+  createToolbarView: createAdwToolbarView
 };
 
 window.addEventListener("DOMContentLoaded", loadSavedTheme);
+
+// All Web Component class definitions follow...
+// ... (AdwButton, AdwBox, etc.) ...
 
 class AdwButton extends HTMLElement {
     static get observedAttributes() {
@@ -1734,13 +2373,11 @@ class AdwButton extends HTMLElement {
         this.shadowRoot.appendChild(buttonElement);
     }
 }
-// customElements.define('adw-button', AdwButton); // Moved to end
 
-class AdwButton extends HTMLElement { // This is a duplicate class definition from the previous incorrect merge
+class AdwBox extends HTMLElement {
     static get observedAttributes() {
-        return ['href', 'suggested', 'destructive', 'flat', 'disabled', 'active', 'circular', 'icon', 'appearance', 'type'];
+        return ['orientation', 'spacing', 'align', 'justify', 'fill-children'];
     }
-
     constructor() {
         super();
         this.attachShadow({ mode: 'open' });
@@ -1760,18 +2397,23 @@ class AdwButton extends HTMLElement { // This is a duplicate class definition fr
             this.shadowRoot.removeChild(this.shadowRoot.lastChild);
         }
         const options = {};
-        AdwBox.observedAttributes.forEach(attr => { // BUG: Should be AdwButton.observedAttributes
+        AdwBox.observedAttributes.forEach(attr => {
             if (this.hasAttribute(attr)) {
                 const value = this.getAttribute(attr);
-                options[attr.replace(/-([a-z])/g, g => g[1].toUpperCase())] = (attr === 'fill-children') ? (value !== null && value !== 'false') : value;
+                const camelCaseAttr = attr.replace(/-([a-z])/g, g => g[1].toUpperCase());
+                if (attr === 'fill-children') {
+                     options[camelCaseAttr] = value !== null && value !== 'false';
+                } else {
+                    options[camelCaseAttr] = value;
+                }
             }
         });
-        const boxElement = Adw.createBox(options); // BUG: Should be Adw.createButton
+        const boxElement = Adw.createBox(options);
         boxElement.appendChild(document.createElement('slot'));
-        this.shadowRoot.appendChild(boxElement); // BUG: Should be buttonElement
+        this.shadowRoot.appendChild(boxElement);
     }
 }
-// customElements.define('adw-box', AdwBox); // Moved to end
+
 
 class AdwEntry extends HTMLElement {
     static get observedAttributes() { return ['placeholder', 'value', 'disabled', 'name', 'required', 'type']; }
@@ -1817,7 +2459,6 @@ class AdwEntry extends HTMLElement {
         this.setAttribute('value', val);
     }
 }
-// customElements.define('adw-entry', AdwEntry); // Moved to end
 
 class AdwLabel extends HTMLElement {
     static get observedAttributes() { return ['for', 'title-level', 'body', 'caption', 'link', 'disabled']; }
@@ -1843,7 +2484,6 @@ class AdwLabel extends HTMLElement {
         this.shadowRoot.appendChild(labelElement);
     }
 }
-// customElements.define('adw-label', AdwLabel); // Moved to end
 
 class AdwEntryRow extends HTMLElement {
     static get observedAttributes() { return ['title', 'subtitle', 'required', 'name', 'value', 'placeholder', 'disabled']; }
@@ -1885,7 +2525,6 @@ class AdwEntryRow extends HTMLElement {
         this.setAttribute('value', val);
     }
 }
-// customElements.define('adw-entry-row', AdwEntryRow); // Moved to end
 
 class AdwPasswordEntryRow extends HTMLElement {
     static get observedAttributes() { return ['title', 'subtitle', 'required', 'name', 'value', 'placeholder', 'disabled']; }
@@ -1927,7 +2566,6 @@ class AdwPasswordEntryRow extends HTMLElement {
         this.setAttribute('value', val);
     }
 }
-// customElements.define('adw-password-entry-row', AdwPasswordEntryRow); // Moved to end
 
 class AdwActionRow extends HTMLElement {
     static get observedAttributes() { return ['title', 'subtitle', 'icon', 'show-chevron']; }
@@ -1957,7 +2595,6 @@ class AdwActionRow extends HTMLElement {
         this.shadowRoot.appendChild(actionRowElement);
     }
 }
-// customElements.define('adw-action-row', AdwActionRow); // Moved to end
 
 class AdwSwitch extends HTMLElement {
     static get observedAttributes() { return ['checked', 'disabled', 'label']; }
@@ -2000,7 +2637,6 @@ class AdwSwitch extends HTMLElement {
         if (isChecked) this.setAttribute('checked', ''); else this.removeAttribute('checked');
     }
 }
-// customElements.define('adw-switch', AdwSwitch); // Moved to end
 
 class AdwCheckbox extends HTMLElement {
     static get observedAttributes() { return ['checked', 'disabled', 'label', 'name']; }
@@ -2044,7 +2680,6 @@ class AdwCheckbox extends HTMLElement {
         if (isChecked) this.setAttribute('checked', ''); else this.removeAttribute('checked');
     }
 }
-// customElements.define('adw-checkbox', AdwCheckbox); // Moved to end
 
 class AdwRadioButton extends HTMLElement {
     static get observedAttributes() { return ['checked', 'disabled', 'label', 'name', 'value']; }
@@ -2090,7 +2725,6 @@ class AdwRadioButton extends HTMLElement {
         if (isChecked) this.setAttribute('checked', ''); else this.removeAttribute('checked');
     }
 }
-// customElements.define('adw-radio-button', AdwRadioButton); // Moved to end
 
 class AdwListBox extends HTMLElement {
     static get observedAttributes() { return ['flat', 'selectable']; }
@@ -2113,7 +2747,6 @@ class AdwListBox extends HTMLElement {
         this.shadowRoot.appendChild(listBoxElement);
     }
 }
-// customElements.define('adw-list-box', AdwListBox); // Moved to end
 
 class AdwRow extends HTMLElement {
     static get observedAttributes() { return ['activated', 'interactive']; }
@@ -2150,7 +2783,6 @@ class AdwRow extends HTMLElement {
         this.shadowRoot.appendChild(rowElement);
     }
 }
-// customElements.define('adw-row', AdwRow); // Moved to end
 
 class AdwWindowTitle extends HTMLElement {
     constructor() {
@@ -2167,7 +2799,6 @@ class AdwWindowTitle extends HTMLElement {
         h1.appendChild(document.createElement('slot')); this.shadowRoot.appendChild(h1);
     }
 }
-// customElements.define('adw-window-title', AdwWindowTitle); // Moved to end
 
 class AdwHeaderBar extends HTMLElement {
     constructor() {
@@ -2192,7 +2823,6 @@ class AdwHeaderBar extends HTMLElement {
         header.append(startBox, centerBox, endBox); this.shadowRoot.appendChild(header);
     }
 }
-// customElements.define('adw-header-bar', AdwHeaderBar); // Moved to end
 
 class AdwApplicationWindow extends HTMLElement {
     constructor() {
@@ -2212,7 +2842,6 @@ class AdwApplicationWindow extends HTMLElement {
         windowDiv.append(headerSlot, mainContent); this.shadowRoot.appendChild(windowDiv);
     }
 }
-// customElements.define('adw-application-window', AdwApplicationWindow); // Moved to end
 
 class AdwAvatar extends HTMLElement {
     static get observedAttributes() { return ['size', 'image-src', 'text', 'alt']; }
@@ -2235,7 +2864,6 @@ class AdwAvatar extends HTMLElement {
         this.shadowRoot.appendChild(Adw.createAvatar(options));
     }
 }
-// customElements.define('adw-avatar', AdwAvatar); // Moved to end
 
 class AdwFlap extends HTMLElement {
     static get observedAttributes() { return ['folded', 'flap-width', 'transition-speed']; }
@@ -2280,10 +2908,9 @@ class AdwFlap extends HTMLElement {
         if (state) this.setAttribute('folded', ''); else this.removeAttribute('folded');
     }
 }
-// customElements.define('adw-flap', AdwFlap); // Moved to end
 
 class AdwViewSwitcher extends HTMLElement {
-    static get observedAttributes() { return ['label', 'active-view']; }
+    static get observedAttributes() { return ['label', 'active-view', 'is-inline']; }
     constructor() {
         super();
         this.attachShadow({ mode: 'open' });
@@ -2316,8 +2943,10 @@ class AdwViewSwitcher extends HTMLElement {
         while (this.shadowRoot.lastChild && this.shadowRoot.lastChild !== this.shadowRoot.querySelector('link')) this.shadowRoot.removeChild(this.shadowRoot.lastChild);
         const views = this._parseViews();
         const options = {
-            views: views, label: this.getAttribute('label') || undefined,
+            views: views,
+            label: this.getAttribute('label') || undefined,
             activeViewName: this.getAttribute('active-view') || (views.length > 0 ? views[0].name : undefined),
+            isInline: this.hasAttribute('is-inline'),
             onViewChanged: (viewName, buttonId, panelId) => {
                 this.setAttribute('active-view', viewName);
                 this.dispatchEvent(new CustomEvent('view-changed', { detail: { viewName, buttonId, panelId }, bubbles: true, composed: true }));
@@ -2331,7 +2960,6 @@ class AdwViewSwitcher extends HTMLElement {
         else this.setAttribute('active-view', viewName);
     }
 }
-// customElements.define('adw-view-switcher', AdwViewSwitcher); // Moved to end
 
 class AdwProgressBar extends HTMLElement {
     static get observedAttributes() { return ['value', 'indeterminate', 'disabled']; }
@@ -2353,7 +2981,6 @@ class AdwProgressBar extends HTMLElement {
         this.shadowRoot.appendChild(Adw.createProgressBar(options));
     }
 }
-// customElements.define('adw-progress-bar', AdwProgressBar); // Moved to end
 
 class AdwSpinner extends HTMLElement {
     static get observedAttributes() { return ['size', 'active']; }
@@ -2389,7 +3016,6 @@ class AdwSpinner extends HTMLElement {
         }
     }
 }
-// customElements.define('adw-spinner', AdwSpinner); // Moved to end
 
 class AdwSplitButton extends HTMLElement {
     static get observedAttributes() { return ['action-text', 'action-href', 'suggested', 'disabled', 'dropdown-aria-label']; }
@@ -2417,7 +3043,6 @@ class AdwSplitButton extends HTMLElement {
         this.shadowRoot.appendChild(Adw.createSplitButton(options));
     }
 }
-// customElements.define('adw-split-button', AdwSplitButton); // Moved to end
 
 class AdwStatusPage extends HTMLElement {
     static get observedAttributes() { return ['title', 'description', 'icon']; }
@@ -2447,7 +3072,6 @@ class AdwStatusPage extends HTMLElement {
         this.shadowRoot.appendChild(Adw.createStatusPage(options));
     }
 }
-// customElements.define('adw-status-page', AdwStatusPage); // Moved to end
 
 class AdwExpanderRow extends HTMLElement {
     static get observedAttributes() { return ['title', 'subtitle', 'expanded']; }
@@ -2470,7 +3094,6 @@ class AdwExpanderRow extends HTMLElement {
         this.shadowRoot.appendChild(Adw.createExpanderRow(options));
     }
 }
-// customElements.define('adw-expander-row', AdwExpanderRow); // Moved to end
 
 class AdwDialog extends HTMLElement {
     static get observedAttributes() { return ['title', 'close-on-backdrop-click', 'open']; }
@@ -2522,7 +3145,6 @@ class AdwDialog extends HTMLElement {
         // onClose callback handles removing 'open' attribute.
     }
 }
-// customElements.define('adw-dialog', AdwDialog); // Moved to end
 
 class AdwBanner extends HTMLElement {
     static get observedAttributes() { return ['message', 'type', 'dismissible', 'show']; }
@@ -2559,7 +3181,6 @@ class AdwBanner extends HTMLElement {
         this._bannerInstance = null;
     }
 }
-// customElements.define('adw-banner', AdwBanner); // Moved to end
 
 class AdwToast extends HTMLElement {
     static get observedAttributes() { return ['message', 'type', 'timeout', 'show']; }
@@ -2594,7 +3215,1635 @@ class AdwToast extends HTMLElement {
         this._toastInstance = null; this.removeAttribute('show');
     }
 }
-// customElements.define('adw-toast', AdwToast); // Moved to end
+
+class AdwAlertDialog extends HTMLElement {
+    static get observedAttributes() { return ['heading', 'body', 'open', 'close-on-backdrop-click']; }
+
+    constructor() {
+        super();
+        // No shadow DOM for dialogs that are modal and globally positioned.
+        // The factory function handles DOM creation and appending to body.
+        this._alertDialogInstance = null;
+        this._choices = []; // For declarative choices via slotted buttons
+    }
+
+    connectedCallback() {
+        // Parse declarative choices first
+        this._parseChoices();
+        // Then render/build the dialog instance
+        this._render();
+        if (this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    disconnectedCallback() {
+        if (this._alertDialogInstance) {
+            this._alertDialogInstance.close(); // Ensure cleanup
+            // The dialog DOM is removed by its own close mechanism
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+
+        if (name === 'open') {
+            if (newValue !== null) this.open();
+            else this.close();
+        } else {
+            // Re-render if other attributes change, ensuring the dialog instance is updated
+            // This might involve closing and reopening if the dialog is already open,
+            // or simply updating the instance if it's not yet shown.
+            if (this._alertDialogInstance && this.hasAttribute('open')) {
+                // If open, and attributes change, it's complex to update live.
+                // Simplest is to close, re-render, then re-open.
+                this._alertDialogInstance.close();
+                this._render(); // Rebuilds with new attributes
+                this.open();
+            } else {
+                this._render(); // Rebuild if not open
+            }
+        }
+    }
+
+    _parseChoices() {
+        this._choices = [];
+        const choiceElements = this.querySelectorAll('button[slot="choice"]');
+        choiceElements.forEach(btn => {
+            this._choices.push({
+                label: btn.textContent.trim(),
+                value: btn.getAttribute('value') || btn.textContent.trim().toLowerCase(),
+                style: btn.dataset.style || 'default' // e.g., data-style="suggested"
+            });
+        });
+    }
+
+    _render() {
+        const bodyContent = this.querySelector('[slot="body-content"]');
+        const options = {
+            heading: this.getAttribute('heading') || undefined,
+            customContent: bodyContent ? bodyContent.cloneNode(true) : undefined,
+            choices: this._choices.length > 0 ? this._choices : undefined, // Use parsed choices if available
+            closeOnBackdropClick: this.hasAttribute('close-on-backdrop-click') ? (this.getAttribute('close-on-backdrop-click') !== 'false') : false, // Default false for alerts
+            onResponse: (value) => {
+                this.dispatchEvent(new CustomEvent('response', { detail: { value } }));
+                // The factory's button onClick already closes the dialog.
+                // We also need to ensure the 'open' attribute is removed.
+                if (this.hasAttribute('open')) {
+                    this.removeAttribute('open');
+                }
+            }
+        };
+
+        // If AdwAlertDialog's first arg is body string, get it from attribute or slotted text
+        let bodyStr = this.getAttribute('body');
+        if (!bodyContent && !bodyStr) {
+            // Fallback to text content if no body attribute and no specific slot
+            const nonChoiceSlots = Array.from(this.childNodes).filter(node => node.nodeType === Node.TEXT_NODE || (node.nodeType === Node.ELEMENT_NODE && !node.hasAttribute('slot'))).map(n => n.textContent.trim()).join(' ');
+            if(nonChoiceSlots.trim()) bodyStr = nonChoiceSlots.trim();
+        }
+
+
+        this._alertDialogInstance = Adw.createAlertDialog(bodyStr || '', options);
+
+        // If AdwDialog's onClose is used by the factory, ensure it syncs 'open' attr
+        const originalFactoryOnClose = options.onClose;
+        this._alertDialogInstance.dialog.addEventListener('close', () => { // Assuming createAdwDialog's onClose is wired
+             if (this.hasAttribute('open')) {
+                this.removeAttribute('open');
+            }
+            if(typeof originalFactoryOnClose === 'function') {
+                originalFactoryOnClose();
+            }
+             this.dispatchEvent(new CustomEvent('close')); // Dispatch standard close event
+        });
+    }
+
+    open() {
+        if (!this._alertDialogInstance) {
+            this._render(); // Ensure instance is created
+        }
+        this._alertDialogInstance.open();
+        if (!this.hasAttribute('open')) {
+            this.setAttribute('open', '');
+        }
+    }
+
+    close() {
+        if (this._alertDialogInstance) {
+            this._alertDialogInstance.close();
+        }
+        // The dialog's internal onClose or the onResponse callback should handle removing the 'open' attribute.
+    }
+}
+
+class AdwAboutDialog extends HTMLElement {
+    static get observedAttributes() {
+        return [
+            'app-name', 'app-icon', 'logo', 'version', 'copyright',
+            'developer-name', 'website', 'website-label', 'license-type',
+            'comments', 'open'
+            // More complex attributes like developers array, acknowledgements array
+            // are better handled via properties or slotted content.
+        ];
+    }
+
+    constructor() {
+        super();
+        this._aboutDialogInstance = null;
+        // For slotted content
+        this._slotObserver = new MutationObserver(() => this._reRenderIfOpen());
+    }
+
+    connectedCallback() {
+        this._slotObserver.observe(this, { childList: true, subtree: true, characterData: true });
+        this._render();
+        if (this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+        if (this._aboutDialogInstance) {
+            this._aboutDialogInstance.close();
+        }
+    }
+
+    _reRenderIfOpen() {
+        if (this.hasAttribute('open') && this._aboutDialogInstance) {
+            this._aboutDialogInstance.close();
+            this._render();
+            this.open();
+        } else {
+            // If not open, just mark for re-render on next open
+            this._render();
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+        if (name === 'open') {
+            if (newValue !== null) this.open();
+            else this.close();
+        } else {
+            this._reRenderIfOpen();
+        }
+    }
+
+    _gatherOptions() {
+        const options = {};
+        ['appName', 'appIcon', 'logo', 'version', 'copyright', 'developerName', 'website', 'websiteLabel', 'licenseType', 'comments']
+            .forEach(key => {
+                const attrName = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+                if (this.hasAttribute(attrName)) {
+                    options[key] = this.getAttribute(attrName);
+                }
+            });
+
+        // Helper to parse slotted lists
+        const getSlottedArray = (slotName) => {
+            const slot = this.querySelector(`[slot="${slotName}"]`);
+            if (slot) {
+                if (slot.tagName === 'UL' || slot.tagName === 'OL') {
+                    return Array.from(slot.children).map(li => li.textContent.trim());
+                } else { // Assume a div with paragraphs or comma separated text
+                    return slot.innerHTML.split(/<br\s*\/?>|\n|,/g).map(s => s.trim()).filter(Boolean);
+                }
+            }
+            return undefined;
+        };
+
+        // Helper for acknowledgements (more complex structure)
+        const getSlottedAcknowledgements = () => {
+            const slot = this.querySelector('[slot="acknowledgements"]');
+            if (slot) {
+                const acks = [];
+                // Example: <div title="Tooling">Lib Corp, Other Inc</div>
+                //          <p>Special thanks to...</p>
+                Array.from(slot.children).forEach(child => {
+                    if (child.hasAttribute('title') && child.textContent) {
+                        acks.push({title: child.getAttribute('title'), names: child.textContent.split(',').map(s=>s.trim()).filter(Boolean)});
+                    } else if (child.textContent) {
+                        acks.push(child.textContent.trim());
+                    }
+                });
+                if (acks.length > 0) return acks;
+            }
+            return undefined;
+        };
+
+
+        options.developers = getSlottedArray('developers');
+        options.designers = getSlottedArray('designers');
+        options.documenters = getSlottedArray('documenters');
+        options.artists = getSlottedArray('artists');
+        options.acknowledgements = getSlottedAcknowledgements();
+
+
+        const licenseTextSlot = this.querySelector('[slot="license-text"]');
+        if (licenseTextSlot) options.licenseText = licenseTextSlot.textContent.trim();
+
+        const appIconSlot = this.querySelector('[slot="app-icon"]');
+        if (appIconSlot && appIconSlot.firstElementChild && appIconSlot.firstElementChild.tagName === 'IMG') {
+            options.appIcon = appIconSlot.firstElementChild.src;
+        }
+        const logoSlot = this.querySelector('[slot="logo"]');
+        if (logoSlot && logoSlot.firstElementChild && logoSlot.firstElementChild.tagName === 'IMG') {
+            options.logo = logoSlot.firstElementChild.src;
+        }
+         const commentsSlot = this.querySelector('[slot="comments"]');
+        if (commentsSlot) options.comments = commentsSlot.textContent.trim();
+
+
+        // Allow main text content to be 'comments' if not explicitly slotted or attributed
+        if (!options.comments && !commentsSlot) {
+            const nonSlottedText = Array.from(this.childNodes)
+                .filter(node => node.nodeType === Node.TEXT_NODE && node.textContent.trim())
+                .map(node => node.textContent.trim())
+                .join('\n');
+            if (nonSlottedText) options.comments = nonSlottedText;
+        }
+
+
+        return options;
+    }
+
+    _render() {
+        const options = this._gatherOptions();
+        this._aboutDialogInstance = Adw.createAboutDialog(options);
+
+        // Sync close event with attribute
+         this._aboutDialogInstance.dialog.addEventListener('close', () => {
+             if (this.hasAttribute('open')) {
+                this.removeAttribute('open');
+            }
+            this.dispatchEvent(new CustomEvent('close'));
+        });
+    }
+
+    open() {
+        if (!this._aboutDialogInstance || this._slotObserver.takeRecords().length > 0) {
+            // If instance doesn't exist or if slots changed before open, re-render.
+             if (this._aboutDialogInstance) this._aboutDialogInstance.close(); // Close old one if exists
+            this._render();
+        }
+        this._aboutDialogInstance.open();
+        if (!this.hasAttribute('open')) {
+            this.setAttribute('open', '');
+        }
+    }
+
+    close() {
+        if (this._aboutDialogInstance) {
+            this._aboutDialogInstance.close();
+        }
+        // 'open' attribute is removed by the dialog's internal close handling via event listener
+    }
+}
+
+class AdwPreferencesDialog extends HTMLElement {
+    static get observedAttributes() { return ['title', 'open', 'initial-page-name']; }
+
+    constructor() {
+        super();
+        this._preferencesDialogInstance = null;
+        this._slotObserver = new MutationObserver(() => this._reRenderIfOpen());
+    }
+
+    connectedCallback() {
+        this._slotObserver.observe(this, { childList: true, subtree: false }); // Only direct children (pages)
+        this._render();
+        if (this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+        if (this._preferencesDialogInstance) {
+            this._preferencesDialogInstance.close();
+        }
+    }
+
+    _reRenderIfOpen() {
+        if (this.hasAttribute('open') && this._preferencesDialogInstance) {
+            this._preferencesDialogInstance.close();
+            this._render(); // Re-collect pages from slots
+            this.open();
+        } else {
+             // If not open, just mark for re-render on next open
+            this._render();
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+        if (name === 'open') {
+            if (newValue !== null) this.open();
+            else this.close();
+        } else {
+            this._reRenderIfOpen();
+        }
+    }
+
+    _gatherPages() {
+        const pages = [];
+        Array.from(this.children).forEach((child, index) => {
+            // Assuming children are adw-preferences-page or have a similar contract
+            if (child.matches('adw-preferences-page') || child.classList.contains('adw-preferences-page')) {
+                const pageName = child.getAttribute('name') || `page-${index}`;
+                const pageTitle = child.getAttribute('title') || child.dataset.pageTitle || `Page ${index + 1}`;
+                pages.push({
+                    name: pageName,
+                    title: pageTitle,
+                    pageElement: child.cloneNode(true) // Clone to pass to factory
+                });
+            }
+        });
+        return pages;
+    }
+
+    _render() {
+        const pages = this._gatherPages();
+        const options = {
+            title: this.getAttribute('title') || "Preferences",
+            pages: pages,
+            initialPageName: this.getAttribute('initial-page-name') || undefined,
+            onClose: () => {
+                // This is the factory's onClose, AdwDialog handles its own closing.
+                // We need to sync the 'open' attribute.
+                if (this.hasAttribute('open')) {
+                    this.removeAttribute('open');
+                }
+                this.dispatchEvent(new CustomEvent('close'));
+            }
+        };
+        this._preferencesDialogInstance = Adw.createPreferencesDialog(options);
+
+        // The factory's onClose is passed to AdwDialog, which should handle it.
+        // If not, we might need to listen on the dialog instance itself.
+        // For instance, if AdwDialog emits a 'close' event on its dialog element:
+        // this._preferencesDialogInstance.dialog.addEventListener('close', () => { ... });
+    }
+
+    open() {
+        if (!this._preferencesDialogInstance || this._slotObserver.takeRecords().length > 0) {
+            if(this._preferencesDialogInstance) this._preferencesDialogInstance.close();
+            this._render();
+        }
+        this._preferencesDialogInstance.open();
+        if (!this.hasAttribute('open')) {
+            this.setAttribute('open', '');
+        }
+    }
+
+    close() {
+        if (this._preferencesDialogInstance) {
+            this._preferencesDialogInstance.close();
+        }
+        // 'open' attribute should be removed by the onClose logic during _render
+    }
+}
+
+class AdwSpinButton extends HTMLElement {
+    static get observedAttributes() { return ['value', 'min', 'max', 'step', 'disabled']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css'; // Adjust path as needed
+        this.shadowRoot.appendChild(styleLink);
+        this._spinButtonElement = null;
+    }
+
+    connectedCallback() {
+        this._render();
+        // Forward events if necessary, or handle value property
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._render(); // Re-render on attribute change
+        }
+    }
+
+    _render() {
+        // Clear previous content except style
+        while (this.shadowRoot.lastChild && this.shadowRoot.lastChild !== this.shadowRoot.querySelector('link')) {
+            this.shadowRoot.removeChild(this.shadowRoot.lastChild);
+        }
+
+        const options = {};
+        ['value', 'min', 'max', 'step'].forEach(attr => {
+            if (this.hasAttribute(attr)) options[attr] = parseFloat(this.getAttribute(attr));
+        });
+        if (this.hasAttribute('disabled')) options.disabled = this.getAttribute('disabled') !== 'false';
+
+        options.onValueChanged = (newValue) => {
+            // Update attribute if property is changed by the underlying component
+            if (this.getAttribute('value') !== String(newValue)) {
+                 this.setAttribute('value', newValue);
+            }
+            this.dispatchEvent(new CustomEvent('value-changed', { detail: { value: newValue } }));
+        };
+
+        this._spinButtonElement = Adw.createSpinButton(options);
+        this.shadowRoot.appendChild(this._spinButtonElement);
+    }
+
+    get value() {
+        return this.hasAttribute('value') ? parseFloat(this.getAttribute('value')) : (this._spinButtonElement ? parseFloat(this._spinButtonElement.querySelector('.adw-spin-button-entry').value) : 0);
+    }
+
+    set value(val) {
+        const numVal = parseFloat(val);
+        this.setAttribute('value', numVal);
+        // this._render(); // Could re-render, or try to update existing element if more performant
+        if(this._spinButtonElement) {
+            const entry = this._spinButtonElement.querySelector('.adw-spin-button-entry');
+            if(entry) entry.value = numVal;
+            // Need to also update button states if Adw.createSpinButton's internal logic doesn't handle it from outside
+        }
+    }
+
+    get disabled() { return this.hasAttribute('disabled'); }
+    set disabled(val) {
+        if (val) this.setAttribute('disabled', '');
+        else this.removeAttribute('disabled');
+    }
+}
+
+class AdwSpinRow extends HTMLElement {
+    static get observedAttributes() {
+        return ['title', 'subtitle', 'value', 'min', 'max', 'step', 'disabled'];
+    }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+        this.shadowRoot.appendChild(styleLink);
+        this._spinRowElement = null;
+    }
+
+    connectedCallback() {
+        this._render();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._render();
+        }
+    }
+
+    _render() {
+        while (this.shadowRoot.lastChild && this.shadowRoot.lastChild !== this.shadowRoot.querySelector('link')) {
+            this.shadowRoot.removeChild(this.shadowRoot.lastChild);
+        }
+
+        const spinButtonOptions = {};
+        ['value', 'min', 'max', 'step'].forEach(attr => {
+            if (this.hasAttribute(attr)) spinButtonOptions[attr] = parseFloat(this.getAttribute(attr));
+        });
+         if (this.hasAttribute('disabled')) spinButtonOptions.disabled = this.getAttribute('disabled') !== 'false';
+
+
+        const options = {
+            title: this.getAttribute('title') || '',
+            subtitle: this.getAttribute('subtitle') || undefined,
+            spinButtonOptions: spinButtonOptions,
+            onValueChanged: (newValue) => {
+                // Update attribute if property is changed by the underlying component
+                if (this.getAttribute('value') !== String(newValue)) {
+                    this.setAttribute('value', newValue);
+                }
+                this.dispatchEvent(new CustomEvent('value-changed', { detail: { value: newValue } }));
+            }
+        };
+
+        this._spinRowElement = Adw.createSpinRow(options);
+        this.shadowRoot.appendChild(this._spinRowElement);
+    }
+
+    // Value and disabled getters/setters could be added if direct property access is needed
+    // For now, attributes drive the component.
+    get value() {
+        return this.hasAttribute('value') ? parseFloat(this.getAttribute('value')) : 0;
+    }
+    set value(val) {
+        this.setAttribute('value', parseFloat(val));
+    }
+    get disabled() { return this.hasAttribute('disabled'); }
+    set disabled(val) {
+        if (val) this.setAttribute('disabled', '');
+        else this.removeAttribute('disabled');
+    }
+}
+
+class AdwButtonRow extends HTMLElement {
+    static get observedAttributes() { return ['centered']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+        this.shadowRoot.appendChild(styleLink);
+        this._buttonRowElement = null;
+        this._slotObserver = new MutationObserver(() => this._render());
+    }
+
+    connectedCallback() {
+        this._slotObserver.observe(this, { childList: true, subtree: true }); // Observe children for adw-button etc.
+        this._render();
+    }
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._render();
+        }
+    }
+
+    _render() {
+        while (this.shadowRoot.lastChild && this.shadowRoot.lastChild !== this.shadowRoot.querySelector('link')) {
+            this.shadowRoot.removeChild(this.shadowRoot.lastChild);
+        }
+
+        // Collect actual button elements from the slot
+        const slottedButtons = Array.from(this.querySelectorAll('adw-button, button'));
+        const buttonElements = slottedButtons.map(btn => btn.cloneNode(true));
+
+
+        const options = {
+            buttons: buttonElements, // Pass cloned elements to factory
+            centered: this.hasAttribute('centered')
+        };
+
+        this._buttonRowElement = Adw.createButtonRow(options);
+
+        // Instead of passing cloned buttons, the factory could accept a slot, or we directly put a slot here.
+        // For simplicity with current factory, it takes elements.
+        // If factory was modified to accept slot name, that would be cleaner for WC.
+        // Alternative: AdwButtonRow's shadow DOM directly contains the .adw-button-row-container and a <slot>.
+        // Let's try that for better WC practice.
+
+        const rowDiv = document.createElement('div');
+        rowDiv.classList.add('adw-row', 'adw-button-row');
+        if(options.centered) rowDiv.classList.add('centered');
+
+        const containerDiv = document.createElement('div');
+        containerDiv.classList.add('adw-button-row-container');
+        if(options.centered) containerDiv.style.justifyContent = 'center';
+        else containerDiv.style.justifyContent = 'flex-end';
+
+        const slot = document.createElement('slot');
+        containerDiv.appendChild(slot);
+        rowDiv.appendChild(containerDiv);
+
+        this.shadowRoot.appendChild(rowDiv);
+        this._buttonRowElement = rowDiv; // Reference to the main row div in shadow DOM
+    }
+}
+
+class AdwTabButton extends HTMLElement {
+    static get observedAttributes() { return ['label', 'page-name', 'active', 'closable', 'icon']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+        this.shadowRoot.appendChild(styleLink);
+        this._tabButtonElement = null;
+    }
+
+    connectedCallback() {
+        this._render();
+        // Event listeners for select/close are on the _tabButtonElement itself,
+        // they will dispatch events on this custom element.
+        if (this._tabButtonElement) {
+            this._tabButtonElement.addEventListener('click', (e) => {
+                 // Don't dispatch 'select' if the click was on the close button part
+                if (e.target.closest && e.target.closest('.adw-tab-button-close')) {
+                    return;
+                }
+                this.dispatchEvent(new CustomEvent('select', { detail: { pageName: this.pageName }}));
+            });
+            const closeBtn = this._tabButtonElement.querySelector('.adw-tab-button-close');
+            if (closeBtn) {
+                closeBtn.addEventListener('click', (e) => {
+                    e.stopPropagation(); // Already done in factory, but good practice
+                    this.dispatchEvent(new CustomEvent('close', { detail: { pageName: this.pageName }}));
+                });
+            }
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._render();
+        }
+    }
+
+    _render() {
+        while (this.shadowRoot.lastChild && this.shadowRoot.lastChild !== this.shadowRoot.querySelector('link')) {
+            this.shadowRoot.removeChild(this.shadowRoot.lastChild);
+        }
+        const iconSlot = this.querySelector('[slot="icon"]');
+
+        const options = {
+            label: this.getAttribute('label') || this.textContent.trim() || 'Tab',
+            pageName: this.pageName, // Use getter
+            isActive: this.active,   // Use getter
+            isClosable: this.closable, // Use getter
+            iconHTML: this.hasAttribute('icon') ? this.getAttribute('icon') : (iconSlot ? iconSlot.innerHTML : undefined),
+            // onSelect and onClose are handled by events dispatched from the custom element
+        };
+
+        if (!options.pageName) {
+            console.warn("adw-tab-button requires a 'page-name' attribute.");
+            return;
+        }
+
+        this._tabButtonElement = Adw.createTabButton(options);
+        this.shadowRoot.appendChild(this._tabButtonElement);
+    }
+
+    get pageName() { return this.getAttribute('page-name'); }
+    set pageName(value) { this.setAttribute('page-name', value); }
+
+    get active() { return this.hasAttribute('active'); }
+    set active(value) {
+        if (value) this.setAttribute('active', '');
+        else this.removeAttribute('active');
+    }
+
+    get closable() { return !this.hasAttribute('closable') || this.getAttribute('closable') !== 'false'; }
+    set closable(value) {
+        if (value) this.removeAttribute('closable'); // Default is closable, so remove attr if true
+        else this.setAttribute('closable', 'false');
+    }
+}
+
+class AdwTabBar extends HTMLElement {
+    static get observedAttributes() { return ['active-tab-name', 'show-new-tab-button']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+        this.shadowRoot.appendChild(styleLink);
+        this._tabBarElement = null; // This will be the element from the factory
+        this._slotObserver = new MutationObserver(() => this._rebuildTabsFromSlotted());
+    }
+
+    connectedCallback() {
+        this._render(); // Initial render with factory
+        // Observe direct children for adw-tab-button additions/removals
+        this._slotObserver.observe(this, { childList: true });
+        this._rebuildTabsFromSlotted(); // Populate from initial slotted content
+
+        // Listen to custom events from slotted adw-tab-buttons (if they bubble)
+        // Or, more reliably, the factory-created buttons inside shadow DOM will have their own listeners.
+        // The factory's onTabSelect/onTabClose will then dispatch events from this AdwTabBar.
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+
+        if (name === 'active-tab-name' && this._tabBarElement) {
+            this._tabBarElement.setActiveTab(newValue);
+             // Ensure slotted children also reflect this
+            Array.from(this.children).forEach(child => {
+                if (child.matches('adw-tab-button')) {
+                    child.active = child.getAttribute('page-name') === newValue;
+                }
+            });
+        } else if (name === 'show-new-tab-button') {
+             this._render();
+             this._rebuildTabsFromSlotted();
+        }
+    }
+
+    _rebuildTabsFromSlotted() {
+        if (!this._tabBarElement) {
+            // console.warn("AdwTabBar: _tabBarElement not ready for _rebuildTabsFromSlotted");
+            return;
+        }
+
+        // Clear existing tabs managed by factory from the shadow DOM tabButtonContainer
+        const tabButtonContainer = this._tabBarElement.querySelector('.adw-tab-bar-button-container');
+        if(tabButtonContainer) {
+            while(tabButtonContainer.firstChild) {
+                tabButtonContainer.removeChild(tabButtonContainer.firstChild);
+            }
+        }
+
+
+        const tabsData = Array.from(this.children)
+            .filter(child => child.matches('adw-tab-button'))
+            .map(tb => ({
+                label: tb.getAttribute('label') || tb.textContent.trim(),
+                iconHTML: tb.hasAttribute('icon') ? tb.getAttribute('icon') : (tb.querySelector('[slot="icon"]') ? tb.querySelector('[slot="icon"]').innerHTML : undefined),
+                pageName: tb.getAttribute('page-name'),
+                isClosable: !tb.hasAttribute('closable') || tb.getAttribute('closable') !== 'false',
+            }));
+
+        tabsData.forEach(td => {
+            if(td.pageName) {
+                 // The factory's addTab method handles isActive internally based on currentActiveTabName
+                this._tabBarElement.addTab(td, td.pageName === this.getAttribute('active-tab-name'));
+            }
+        });
+
+        const activeName = this.getAttribute('active-tab-name');
+        if (activeName) {
+            this._tabBarElement.setActiveTab(activeName);
+        } else if (tabsData.length > 0 && tabsData[0].pageName) {
+            this._tabBarElement.setActiveTab(tabsData[0].pageName);
+            // Do NOT setAttribute('active-tab-name') here, to avoid loops & let factory handle initial state.
+        }
+    }
+
+    _render() {
+        while (this.shadowRoot.lastChild && this.shadowRoot.lastChild !== this.shadowRoot.querySelector('link')) {
+            this.shadowRoot.removeChild(this.shadowRoot.lastChild);
+        }
+
+        const options = {
+            activeTabName: this.getAttribute('active-tab-name') || undefined,
+            showNewTabButton: this.hasAttribute('show-new-tab-button'),
+            onTabSelect: (pageName) => {
+                if (this.getAttribute('active-tab-name') !== pageName) {
+                    this.setAttribute('active-tab-name', pageName); // This will trigger attributeChangedCallback
+                }
+                this.dispatchEvent(new CustomEvent('tab-select', { detail: { pageName }, bubbles: true, composed: true }));
+            },
+            onTabClose: (pageName) => {
+                this.dispatchEvent(new CustomEvent('tab-close', { detail: { pageName }, bubbles: true, composed: true }));
+                // Parent (adw-tab-view) should handle removing the corresponding adw-tab-button from light DOM
+            },
+            onNewTabRequested: () => {
+                this.dispatchEvent(new CustomEvent('new-tab-requested', { bubbles: true, composed: true }));
+            }
+        };
+
+        this._tabBarElement = Adw.createTabBar(options);
+        this.shadowRoot.appendChild(this._tabBarElement);
+    }
+
+    // Public methods for programmatic control
+    addSlottedTab(tabButtonElement) {
+        if (tabButtonElement && tabButtonElement.matches('adw-tab-button')) {
+            this.appendChild(tabButtonElement); // This will trigger slotObserver and _rebuildTabsFromSlotted
+        } else {
+            console.error("AdwTabBar.addSlottedTab: Argument must be an adw-tab-button element.");
+        }
+    }
+
+    removeSlottedTab(pageName) {
+        const slottedTab = this.querySelector(`adw-tab-button[page-name="${pageName}"]`);
+        if (slottedTab) {
+            slottedTab.remove(); // This will trigger slotObserver and _rebuildTabsFromSlotted
+        }
+    }
+
+    setActiveTab(pageName) { // Programmatic way to set active tab
+        this.setAttribute('active-tab-name', pageName);
+    }
+}
+
+class AdwTabPage extends HTMLElement { // Basic component for discoverability and styling
+    static get observedAttributes() { return ['page-name', 'label']; } // label for tab if not on button
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+
+        const slot = document.createElement('slot');
+        this._wrapper = document.createElement('div');
+        this._wrapper.classList.add('adw-tab-page');
+        this._wrapper.setAttribute('role', 'tabpanel');
+        this._wrapper.appendChild(slot);
+        this.shadowRoot.append(styleLink, this._wrapper);
+    }
+    connectedCallback(){
+        if(!this.hasAttribute('page-name')) {
+            // Try to generate one if possible, or warn
+            const generatedName = `page-${[...this.parentElement.children].indexOf(this)}`;
+            this.setAttribute('page-name', generatedName);
+            console.warn(`adw-tab-page missing 'page-name', assigned '${generatedName}'. Explicit names recommended.`);
+        }
+        // aria-labelledby will be set by AdwTabView
+    }
+}
+
+class AdwTabView extends HTMLElement {
+    static get observedAttributes() { return ['active-page-name', 'show-new-tab-button']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+        this.shadowRoot.appendChild(styleLink);
+
+        this._tabViewFactoryInstance = null;
+        this._pagesSlot = document.createElement('slot');
+        // Naming the slot allows specific assignment if needed, though default slot works too.
+        this._pagesSlot.name = "page-content-slot";
+        this._slotObserver = new MutationObserver(() => this._rebuildFactoryPages());
+    }
+
+    connectedCallback() {
+        this._renderFactoryInstance(); // Create the internal Adw.createTabView structure
+        this.shadowRoot.appendChild(this._pagesSlot); // Add slot to shadow DOM
+        this._slotObserver.observe(this, { childList: true, attributes: true, subtree: false }); // Observe direct children: adw-tab-page elements
+        this._rebuildFactoryPages(); // Initial population from slotted children
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue || !this._tabViewFactoryInstance) return;
+
+        if (name === 'active-page-name') {
+            this._tabViewFactoryInstance.setActivePage(newValue);
+            this._updateSlottedPageDisplay(newValue);
+        } else if (name === 'show-new-tab-button') {
+            // This option affects the factory's construction, so re-render factory
+            this._renderFactoryInstance();
+            this._rebuildFactoryPages(); // Re-populate tabs in the new factory instance
+        }
+    }
+
+    _updateSlottedPageDisplay(activePageName) {
+        const slottedElements = this._pagesSlot.assignedNodes({ flatten: true });
+        slottedElements.forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE && (node.matches('adw-tab-page') || node.dataset.adwTabPage)) {
+                 const isPageActive = node.getAttribute('page-name') === activePageName;
+                 node.style.display = isPageActive ? '' : 'none';
+                 if(isPageActive) node.setAttribute('active',''); else node.removeAttribute('active');
+            }
+        });
+    }
+
+    _rebuildFactoryPages() {
+        if (!this._tabViewFactoryInstance) this._renderFactoryInstance();
+
+        const slottedElements = this._pagesSlot.assignedNodes({ flatten: true });
+        const pagesDataForFactory = [];
+
+        slottedElements.forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE && (node.matches('adw-tab-page') || node.dataset.adwTabPage)) {
+                // Ensure page-name, create if missing (though AdwTabPage now tries to self-assign)
+                let pageName = node.getAttribute('page-name');
+                if (!pageName) {
+                    pageName = adwGenerateId('dyn-page');
+                    node.setAttribute('page-name', pageName);
+                }
+                // The content for the factory is the node itself (or a clone if factory modifies it)
+                // The factory's createAdwTabPage will wrap this content.
+                // For the Adw.createTabView factory, it expects content to be passed to its internal createAdwTabPage.
+                // So we pass the node itself. The factory's AdwTabPage will handle it.
+                pagesDataForFactory.push({
+                    name: pageName,
+                    title: node.getAttribute('label') || pageName,
+                    content: node, // Pass the live slotted element
+                    isClosable: !node.hasAttribute('non-closable')
+                });
+            }
+        });
+
+        // Clear old pages from factory (assuming a method or re-creation)
+        // For now, let's assume Adw.createTabView can be called again to replace.
+        // This means the old factory instance and its event listeners need cleanup.
+        // A more robust factory would have clearPages() and addPage() methods.
+
+        // Simplified: Re-render factory with new page data.
+        // This is not ideal as it rebuilds the tab bar too.
+        // A better Adw.createTabView would have methods to update pages dynamically.
+        // Given current factory structure, this is the most straightforward.
+        this._renderFactoryInstance(pagesDataForFactory, this.getAttribute('active-page-name'));
+    }
+
+    _renderFactoryInstance(pagesData = [], activePageNameOverride = null) {
+        if (this._tabViewFactoryInstance && this._tabViewFactoryInstance.parentElement) {
+            this._tabViewFactoryInstance.remove(); // Clean up old factory instance from shadow DOM
+        }
+
+        const effectiveActivePageName = activePageNameOverride || this.getAttribute('active-page-name');
+
+        const options = {
+            pages: pagesData, // Factory will create its own tab buttons and page wrappers from this
+            activePageName: effectiveActivePageName || undefined,
+            showNewTabButton: this.hasAttribute('show-new-tab-button'),
+            onNewTabRequested: () => {
+                this.dispatchEvent(new CustomEvent('new-tab-requested', {bubbles: true, composed: true}));
+            },
+            onPageChanged: (pageName) => {
+                if(this.getAttribute('active-page-name') !== pageName) {
+                    this.setAttribute('active-page-name', pageName); // Triggers attributeChangedCallback
+                } else {
+                    // If already correct, ensure display is synced (e.g. on initial load)
+                     this._updateSlottedPageDisplay(pageName);
+                }
+                this.dispatchEvent(new CustomEvent('page-changed', {detail: {pageName}, bubbles:true, composed: true}));
+            },
+            onBeforePageClose: (pageName) => {
+                const event = new CustomEvent('before-page-close', {detail: {pageName}, cancelable: true, bubbles:true, composed: true});
+                this.dispatchEvent(event);
+                return !event.defaultPrevented;
+            },
+            onPageClosed: (pageName) => {
+                // Factory handles removing its internal page and tab button.
+                // We need to remove the corresponding slotted adw-tab-page from light DOM.
+                const pageElement = this.querySelector(`adw-tab-page[page-name="${pageName}"], [data-adw-tab-page][page-name="${pageName}"]`);
+                if (pageElement) pageElement.remove(); // This triggers slotchange, causing a rebuild.
+                this.dispatchEvent(new CustomEvent('page-closed', {detail: {pageName}, bubbles:true, composed: true}));
+            }
+        };
+        this._tabViewFactoryInstance = Adw.createTabView(options);
+        // Prepend factory output so slot comes after, for correct display order if pages are complex
+        this.shadowRoot.insertBefore(this._tabViewFactoryInstance, this._pagesSlot);
+
+        // Initial display sync for slotted pages based on factory's decision
+        if (this._tabViewFactoryInstance.getActivePageName()) {
+            this._updateSlottedPageDisplay(this._tabViewFactoryInstance.getActivePageName());
+        } else if (pagesData.length > 0) {
+             this._updateSlottedPageDisplay(pagesData[0].name); // Default to first if factory doesn't pick one
+        }
+    }
+
+    // Public API
+    addPage(pageElement, makeActive = false) {
+        if (pageElement && (pageElement.matches('adw-tab-page') || pageElement.dataset.adwTabPage)) {
+            let pageName = pageElement.getAttribute('page-name');
+            if(!pageName){
+                pageName = adwGenerateId('dyn-page-added');
+                pageElement.setAttribute('page-name', pageName);
+            }
+            this.appendChild(pageElement); // Triggers slotchange -> _rebuildFactoryPages
+            if (makeActive) {
+                this.setActivePage(pageName);
+            }
+        } else {
+            console.error("AdwTabView.addPage: argument must be an adw-tab-page or [data-adw-tab-page] element.");
+        }
+    }
+    removePage(pageName) {
+        // This will call factory's removePage -> onPageClosed -> which removes from lightDOM.
+        if (this._tabViewFactoryInstance) this._tabViewFactoryInstance.removePage(pageName);
+    }
+    setActivePage(pageName) {
+        this.setAttribute('active-page-name', pageName);
+    }
+    getActivePageName() {
+        return this.getAttribute('active-page-name');
+    }
+}
+
+class AdwNavigationView extends HTMLElement {
+    static get observedAttributes() { return []; } // Initially no attributes, relies on slotted content and methods
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+        this.shadowRoot.appendChild(styleLink);
+
+        this._navigationViewFactoryInstance = null;
+        this._pagesSlot = document.createElement('slot');
+        this._slotObserver = new MutationObserver(() => this._rebuildFactoryPagesFromSlotted());
+    }
+
+    connectedCallback() {
+        this._renderFactoryInstance(); // Create the basic structure (HeaderBar, pages container)
+        this.shadowRoot.appendChild(this._pagesSlot);
+        this._slotObserver.observe(this, { childList: true, attributes: true, subtree: true }); // Observe for page changes
+        this._rebuildFactoryPagesFromSlotted();
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+    }
+
+    _getPageDataFromElement(element) {
+        if (!element || !element.matches || (!element.matches('adw-navigation-page, [data-page-name]') && !element.dataset.adwNavigationPage )) {
+            return null;
+        }
+        const pageName = element.getAttribute('data-page-name') || element.getAttribute('page-name') || adwGenerateId('nav-page');
+        if (!element.hasAttribute('data-page-name') && !element.hasAttribute('page-name')) {
+            element.setAttribute('data-page-name', pageName); // Ensure it has a name
+        }
+
+        const header = {};
+        const titleEl = element.querySelector('[slot="header-title"]');
+        if (titleEl) header.title = titleEl.textContent;
+
+        const subtitleEl = element.querySelector('[slot="header-subtitle"]');
+        if (subtitleEl) header.subtitle = subtitleEl.textContent;
+
+        const startElements = element.querySelectorAll('[slot="header-start"] > *');
+        if (startElements.length > 0) header.start = Array.from(startElements).map(el => el.cloneNode(true));
+
+        const endElements = element.querySelectorAll('[slot="header-end"] > *');
+        if (endElements.length > 0) header.end = Array.from(endElements).map(el => el.cloneNode(true));
+
+        return {
+            name: pageName,
+            element: element, // Pass the live element to the factory for management
+            header: Object.keys(header).length > 0 ? header : undefined
+        };
+    }
+
+    _rebuildFactoryPagesFromSlotted() {
+        if (!this._navigationViewFactoryInstance) this._renderFactoryInstance();
+
+        const initialPagesData = [];
+        const slottedElements = this._pagesSlot.assignedNodes({ flatten: true });
+
+        slottedElements.forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                 const pageData = this._getPageDataFromElement(node);
+                 if(pageData) initialPagesData.push(pageData);
+            }
+        });
+        this._renderFactoryInstance(initialPagesData);
+    }
+
+
+    _renderFactoryInstance(initialPagesData = []) {
+         if (this._navigationViewFactoryInstance && this._navigationViewFactoryInstance.parentElement) {
+            this._navigationViewFactoryInstance.remove();
+        }
+
+        const options = {
+            initialPages: initialPagesData,
+        };
+
+        this._navigationViewFactoryInstance = Adw.createAdwNavigationView(options);
+        this.shadowRoot.insertBefore(this._navigationViewFactoryInstance, this._pagesSlot);
+
+        this._navigationViewFactoryInstance.addEventListener('pushed', (e) => {
+            this.dispatchEvent(new CustomEvent('pushed', { detail: e.detail }));
+            this._updateSlottedPageDisplay();
+        });
+        this._navigationViewFactoryInstance.addEventListener('popped', (e) => {
+            this.dispatchEvent(new CustomEvent('popped', { detail: e.detail }));
+            this._updateSlottedPageDisplay();
+        });
+
+        this._updateSlottedPageDisplay();
+    }
+
+    _updateSlottedPageDisplay() {
+        if(!this._navigationViewFactoryInstance) return;
+        const visiblePageName = this._navigationViewFactoryInstance.getVisiblePageName();
+        const slottedElements = this._pagesSlot.assignedNodes({ flatten: true });
+        slottedElements.forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE && (node.matches('adw-navigation-page, [data-page-name]') || node.dataset.adwNavigationPage)) {
+                // The factory itself now handles display:none on the actual page elements
+                // So we just need to ensure the correct one is active if we add that class for CSS.
+                if (node.getAttribute('data-page-name') === visiblePageName || node.getAttribute('page-name') === visiblePageName) {
+                    // node.classList.add('adw-navigation-page-active'); // Factory handles this
+                } else {
+                    // node.classList.remove('adw-navigation-page-active');
+                }
+            }
+        });
+    }
+
+
+    // Public API
+    push(pageElementOrName) {
+        if (typeof pageElementOrName === 'string') {
+            const pageName = pageElementOrName;
+            const element = this.querySelector(`[data-page-name="${pageName}"], [page-name="${pageName}"]`);
+            if (element && this._navigationViewFactoryInstance) {
+                 const pageData = this._getPageDataFromElement(element);
+                 if(pageData) this._navigationViewFactoryInstance.push(pageData);
+            } else {
+                console.error(`AdwNavigationView: Page with name "${pageName}" not found in slotted content.`);
+            }
+        } else if (pageElementOrName instanceof HTMLElement) {
+            const pageData = this._getPageDataFromElement(pageElementOrName);
+            if (pageData && this._navigationViewFactoryInstance) {
+                if (!pageElementOrName.parentElement) {
+                    this.appendChild(pageElementOrName);
+                }
+                // The factory's push method will take the element from pageData and manage it.
+                this._navigationViewFactoryInstance.push(pageData);
+            } else if(!pageData) {
+                 console.error("AdwNavigationView.push: Invalid page element provided.", pageElementOrName);
+            }
+        } else {
+            console.error("AdwNavigationView.push: Argument must be a page name (string) or an HTMLElement.");
+        }
+    }
+
+    pop() {
+        if (this._navigationViewFactoryInstance) {
+            this._navigationViewFactoryInstance.pop();
+        }
+    }
+
+    getVisiblePageName(){
+        if(this._navigationViewFactoryInstance) {
+            return this._navigationViewFactoryInstance.getVisiblePageName();
+        }
+        return null;
+    }
+}
+
+class AdwBottomSheet extends HTMLElement {
+    static get observedAttributes() { return ['open', 'close-on-backdrop-click']; }
+
+    constructor() {
+        super();
+        // No shadow DOM for modal / overlay components that need to be top-level
+        this._bottomSheetInstance = null;
+        this._contentElement = null; // To store the slotted content
+    }
+
+    connectedCallback() {
+        // Grab content from light DOM
+        this._contentElement = document.createElement('div');
+        while(this.firstChild){
+            this._contentElement.appendChild(this.firstChild); // Move children to internal div
+        }
+        this._render();
+        if (this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    disconnectedCallback() {
+        if (this._bottomSheetInstance && this._bottomSheetInstance.isOpen) {
+            this._bottomSheetInstance.close();
+        }
+         // Restore content to light DOM if needed, or ensure it's cleaned up
+        if(this._contentElement){
+            while(this._contentElement.firstChild){
+                this.appendChild(this._contentElement.firstChild);
+            }
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+
+        if (name === 'open') {
+            if (newValue !== null) this.open();
+            else this.close();
+        } else {
+            // Re-render if other attributes change
+            this._render();
+            if (this.hasAttribute('open')) this.open(); // Re-open if it was open
+        }
+    }
+
+    _render() {
+        // If an instance exists and is open, close it before re-rendering
+        if (this._bottomSheetInstance && this._bottomSheetInstance.isOpen) {
+            this._bottomSheetInstance.close(); // This is async due to animations
+        }
+
+        if(!this._contentElement || !this._contentElement.hasChildNodes()){
+            // Create a placeholder if no content, or wait for content.
+            // For now, let's assume content will be there or added.
+            // console.warn("AdwBottomSheet: No content provided.");
+        }
+
+        const options = {
+            content: this._contentElement.cloneNode(true), // Pass a clone of the content
+            closeOnBackdropClick: !this.hasAttribute('close-on-backdrop-click') || this.getAttribute('close-on-backdrop-click') !== 'false',
+            onOpen: () => {
+                if (!this.hasAttribute('open')) this.setAttribute('open', '');
+                this.dispatchEvent(new CustomEvent('open', {bubbles: true, composed: true}));
+            },
+            onClose: () => {
+                if (this.hasAttribute('open')) this.removeAttribute('open');
+                this.dispatchEvent(new CustomEvent('close', {bubbles: true, composed: true}));
+            }
+        };
+        this._bottomSheetInstance = Adw.createBottomSheet(options);
+    }
+
+    open() {
+        if (!this._bottomSheetInstance) this._render(); // Ensure instance exists
+        // If content was dynamically added after initial render, re-render before opening.
+        if (this._contentElement.childNodes.length === 0 && this.childNodes.length > 0) {
+             while(this.firstChild){ this._contentElement.appendChild(this.firstChild); }
+             this._render();
+        }
+
+        this._bottomSheetInstance.open();
+        // setAttribute('open') is handled by onOpen callback
+    }
+
+    close() {
+        if (this._bottomSheetInstance) {
+            this._bottomSheetInstance.close();
+        }
+        // removeAttribute('open') is handled by onClose callback
+    }
+}
+
+class AdwBin extends HTMLElement {
+    // No observedAttributes needed if it's just a simple container.
+    // Alignment would be controlled by parent or utility classes applied to the <adw-bin> itself.
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css'; // Adjust path as needed
+
+        const binDiv = document.createElement('div');
+        binDiv.classList.add('adw-bin');
+
+        const slot = document.createElement('slot');
+        binDiv.appendChild(slot);
+
+        this.shadowRoot.append(styleLink, binDiv);
+    }
+
+    connectedCallback() {
+        // Ensure only one direct element child if strictly enforcing Bin behavior
+        // This is a bit tricky with slots and text nodes.
+        // For now, we'll rely on user providing a single element.
+        // A MutationObserver could be used to warn or adjust if multiple elements are slotted.
+    }
+}
+
+class AdwWrapBox extends HTMLElement {
+    static get observedAttributes() {
+        return ['orientation', 'spacing', 'line-spacing', 'align', 'justify'];
+    }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css'; // Adjust path as needed
+
+        this._wrapBoxElement = document.createElement('div');
+        this._wrapBoxElement.classList.add('adw-wrap-box');
+
+        const slot = document.createElement('slot');
+        this._wrapBoxElement.appendChild(slot);
+
+        this.shadowRoot.append(styleLink, this._wrapBoxElement);
+    }
+
+    connectedCallback() {
+        this._updateStyles();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._updateStyles();
+        }
+    }
+
+    _updateStyles() {
+        const opts = {};
+        if (this.hasAttribute('orientation')) opts.orientation = this.getAttribute('orientation');
+        if (this.hasAttribute('spacing')) opts.spacing = this.getAttribute('spacing');
+        if (this.hasAttribute('line-spacing')) opts.lineSpacing = this.getAttribute('line-spacing');
+        if (this.hasAttribute('align')) opts.align = this.getAttribute('align');
+        if (this.hasAttribute('justify')) opts.justify = this.getAttribute('justify');
+
+        // Apply styles directly based on attributes, similar to how factory does
+        this._wrapBoxElement.style.display = 'flex';
+        this._wrapBoxElement.style.flexWrap = 'wrap';
+
+        if (opts.orientation === 'vertical') {
+            this._wrapBoxElement.style.flexDirection = 'column';
+        } else {
+            this._wrapBoxElement.style.flexDirection = 'row';
+        }
+
+        let gapValue = "var(--spacing-m)";
+        if (opts.spacing) {
+            gapValue = isNaN(parseFloat(opts.spacing)) ? opts.spacing : `${opts.spacing}px`;
+        }
+
+        let rowGapValue = gapValue;
+        if (opts.lineSpacing) {
+            rowGapValue = isNaN(parseFloat(opts.lineSpacing)) ? opts.lineSpacing : `${opts.lineSpacing}px`;
+        }
+
+        if (rowGapValue !== gapValue) {
+            this._wrapBoxElement.style.rowGap = rowGapValue;
+            this._wrapBoxElement.style.columnGap = gapValue;
+        } else {
+            this._wrapBoxElement.style.gap = gapValue;
+        }
+
+        const flexAlignMap = { start: 'flex-start', center: 'center', end: 'flex-end', stretch: 'stretch' };
+        this._wrapBoxElement.style.alignItems = flexAlignMap[opts.align] || flexAlignMap.start;
+
+        const flexJustifyMap = { start: 'flex-start', center: 'center', end: 'flex-end', between: 'space-between', around: 'space-around', evenly: 'space-evenly' };
+        this._wrapBoxElement.style.justifyContent = flexJustifyMap[opts.justify] || flexJustifyMap.start;
+    }
+}
+
+class AdwClamp extends HTMLElement {
+    static get observedAttributes() { return ['maximum-size', 'scrollable']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+
+        this._clampElement = document.createElement('div');
+        this._clampElement.classList.add('adw-clamp');
+
+        this._childWrapper = document.createElement('div');
+        this._childWrapper.classList.add('adw-clamp-child-wrapper');
+
+        const slot = document.createElement('slot');
+        this._childWrapper.appendChild(slot);
+        this._clampElement.appendChild(this._childWrapper);
+
+        this.shadowRoot.append(styleLink, this._clampElement);
+    }
+
+    connectedCallback() {
+        this._updateStyles();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._updateStyles();
+        }
+    }
+
+    _updateStyles() {
+        this._childWrapper.style.maxWidth = this.getAttribute('maximum-size') || '80ch';
+
+        this._clampElement.style.display = 'flex';
+        this._clampElement.style.justifyContent = 'center';
+
+        if (this.hasAttribute('scrollable')) {
+            this._clampElement.classList.add('scrollable');
+            this._clampElement.style.overflowX = 'hidden';
+            this._clampElement.style.overflowY = 'auto';
+            this._childWrapper.style.width = '100%';
+        } else {
+            this._clampElement.classList.remove('scrollable');
+            this._clampElement.style.overflowX = '';
+            this._clampElement.style.overflowY = '';
+            // this._childWrapper.style.width = ''; // Let it be intrinsic or set by max-width
+        }
+    }
+}
+
+class AdwBreakpointBin extends HTMLElement {
+    static get observedAttributes() { return ['default-child-name']; }
+
+    constructor() {
+        super();
+        // BreakpointBin is a controller, so no Shadow DOM for its own visual style.
+        // It directly manipulates its light DOM children's display.
+        this._breakpointBinInstance = null;
+        this._slotObserver = new MutationObserver(() => this._rebuildChildren());
+    }
+
+    connectedCallback() {
+        this._rebuildChildren(); // Initial setup based on children
+        if(this._breakpointBinInstance) this._breakpointBinInstance.startObserving();
+    }
+
+    disconnectedCallback() {
+        if (this._breakpointBinInstance) this._breakpointBinInstance.stopObserving();
+        this._slotObserver.disconnect();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+        if (name === 'default-child-name' && this._breakpointBinInstance) {
+            // Re-initialize or update default child logic in factory if possible
+            // For now, simplest is to re-render the factory logic
+            this._rebuildChildren();
+        }
+    }
+
+    _rebuildChildren() {
+        const childrenData = [];
+        // Detach observer while manipulating children to avoid loops
+        this._slotObserver.disconnect();
+
+        Array.from(this.children).forEach(child => {
+            if (child.nodeType === Node.ELEMENT_NODE) {
+                const condition = child.dataset.condition || child.getAttribute('condition'); // Allow data- or plain attr
+                const name = child.dataset.name || child.getAttribute('name') || adwGenerateId('bp-child');
+                if(!child.dataset.name && !child.getAttribute('name')) child.setAttribute('data-name', name);
+
+                if (condition) {
+                    childrenData.push({
+                        name: name,
+                        element: child, // Pass live element
+                        condition: isNaN(parseFloat(condition)) ? condition : parseFloat(condition)
+                    });
+                } else {
+                    console.warn("AdwBreakpointBin: Child element is missing a 'data-condition' or 'condition' attribute.", child);
+                }
+            }
+        });
+
+        // Clear previous factory instance if exists (especially its DOM manipulations)
+        if (this._breakpointBinInstance) {
+            // The factory appends children to itself. If we re-create it,
+            // we must ensure light DOM children are correctly re-associated or cloned.
+            // The current factory takes children and appends them.
+            // For WC, it's better if the factory operates on children already in its container.
+            // This might require a change in factory or a different approach here.
+            // For now, let's assume the factory is re-created and light DOM children are re-slotted/re-managed.
+            // This implies the factory should not remove children from their original parent if they are slotted.
+            // The factory currently appends children passed to it. This means it needs clones.
+            // However, for a WC, we want to operate on the light DOM children.
+            // This needs a slight rethink of how factory and WC interact for children.
+
+            // Let's adjust the factory to take the container (this WC itself) and find its children.
+            // OR, the WC passes child *data* and the factory creates/manages internal copies.
+            // The current factory takes element references and appends them.
+            // For the WC, we will pass clones to the factory. The WC will manage display of its own light DOM.
+        }
+
+
+        const factoryOptions = {
+            children: childrenData.map(cd => ({...cd, element: cd.element.cloneNode(true)})), // Factory gets clones
+            defaultChildName: this.getAttribute('default-child-name') || undefined
+        };
+
+        // The factory instance is now just for logic, not DOM manipulation directly in light DOM.
+        // The WC itself will manage display of its slotted children.
+        // So, we don't append factory output to shadow DOM.
+
+        // If factory was used to manage its own DOM:
+        // if (this._breakpointBinInstance && this._breakpointBinInstance.parentElement) {
+        //    this._breakpointBinInstance.remove();
+        // }
+        // this._breakpointBinInstance = Adw.createAdwBreakpointBin(factoryOptions);
+        // this.shadowRoot.appendChild(this._breakpointBinInstance); // If it had its own shadow structure
+        // this._breakpointBinInstance.startObserving();
+
+        // Simpler: WC does the work, using factory logic if needed, but directly on light DOM.
+        this._initializeBreakpointLogic(childrenData);
+
+
+        this._slotObserver.observe(this, { childList: true, attributes: true, subtree: false });
+    }
+
+    _initializeBreakpointLogic(childrenData) {
+        // Sort children by their minWidth condition
+        this._sortedChildrenConfig = childrenData.map(c => {
+            let minWidth = 0;
+            if (typeof c.condition === 'number') minWidth = c.condition;
+            else if (typeof c.condition === 'string') {
+                const match = c.condition.match(/min-width:\s*(\d+)(px)?/i);
+                if (match && match[1]) minWidth = parseInt(match[1], 10);
+            }
+            return { ...c, _minWidth: minWidth };
+        }).sort((a, b) => a._minWidth - b._minWidth);
+
+        let defaultChildName = this.getAttribute('default-child-name');
+        this._defaultChildElement = null;
+
+        if (defaultChildName) {
+            const found = this._sortedChildrenConfig.find(c => c.name === defaultChildName);
+            if (found) this._defaultChildElement = found.element;
+        }
+        if (!this._defaultChildElement && this._sortedChildrenConfig.length > 0) {
+            this._defaultChildElement = this._sortedChildrenConfig[0].element; // Smallest one
+        }
+
+        this._currentVisibleElement = null;
+
+        if (typeof ResizeObserver !== 'undefined') {
+            if (this._resizeObserver) this._resizeObserver.disconnect();
+            this._resizeObserver = new ResizeObserver(() => this.updateVisibility());
+            this._resizeObserver.observe(this);
+        } else {
+            console.warn("AdwBreakpointBin WC: ResizeObserver not supported.");
+            // Fallback to window resize (less accurate)
+            // window.addEventListener('resize', () => this.updateVisibility());
+        }
+        this.updateVisibility(); // Initial check
+    }
+
+    updateVisibility() {
+        const containerWidth = this.offsetWidth;
+        let newVisibleElement = this._defaultChildElement;
+
+        for (let i = this._sortedChildrenConfig.length - 1; i >= 0; i--) {
+            const childConfig = this._sortedChildrenConfig[i];
+            if (containerWidth >= childConfig._minWidth) {
+                newVisibleElement = childConfig.element;
+                break;
+            }
+        }
+
+        if (this._currentVisibleElement !== newVisibleElement) {
+            // Hide all slotted children first
+            Array.from(this.children).forEach(child => {
+                if(child.style) child.style.display = 'none';
+            });
+
+            if (newVisibleElement && newVisibleElement.style) {
+                 newVisibleElement.style.display = '';
+            }
+            this._currentVisibleElement = newVisibleElement;
+            this.dispatchEvent(new CustomEvent('child-changed', {
+                detail: { visibleChildName: newVisibleElement ? (newVisibleElement.dataset.name || newVisibleElement.getAttribute('name')) : null }
+            }));
+        }
+    }
+}
+
+class AdwToolbarView extends HTMLElement {
+    static get observedAttributes() { return ['top-bar-revealed', 'bottom-bar-revealed']; }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const styleLink = document.createElement('link');
+        styleLink.rel = 'stylesheet'; styleLink.href = '/static/css/adwaita-web.css';
+
+        this._toolbarViewElement = document.createElement('div');
+        this._toolbarViewElement.classList.add('adw-toolbar-view');
+
+        this._topBarSlotContainer = document.createElement('div');
+        this._topBarSlotContainer.classList.add('adw-toolbar-view-top-bar');
+        this._topBarSlot = document.createElement('slot');
+        this._topBarSlot.name = 'top-bar';
+        this._topBarSlotContainer.appendChild(this._topBarSlot);
+
+        this._contentSlotContainer = document.createElement('div');
+        this._contentSlotContainer.classList.add('adw-toolbar-view-content');
+        this._contentSlot = document.createElement('slot'); // Default slot for main content
+        this._contentSlotContainer.appendChild(this._contentSlot);
+
+        this._bottomBarSlotContainer = document.createElement('div');
+        this._bottomBarSlotContainer.classList.add('adw-toolbar-view-bottom-bar');
+        this._bottomBarSlot = document.createElement('slot');
+        this._bottomBarSlot.name = 'bottom-bar';
+        this._bottomBarSlotContainer.appendChild(this._bottomBarSlot);
+
+        this._toolbarViewElement.append(this._topBarSlotContainer, this._contentSlotContainer, this._bottomBarSlotContainer);
+        this.shadowRoot.append(styleLink, this._toolbarViewElement);
+    }
+
+    connectedCallback() {
+        this._updateBarVisibility();
+        // No factory instance needed if we manage display via CSS/attributes directly.
+        // This WC will be more about structure and CSS.
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue !== newValue) {
+            this._updateBarVisibility();
+        }
+    }
+
+    _updateBarVisibility() {
+        const topBarRevealed = !this.hasAttribute('top-bar-revealed') || this.getAttribute('top-bar-revealed') !== 'false';
+        const bottomBarRevealed = !this.hasAttribute('bottom-bar-revealed') || this.getAttribute('bottom-bar-revealed') !== 'false';
+
+        this._topBarSlotContainer.style.display = topBarRevealed ? '' : 'none';
+        this._bottomBarSlotContainer.style.display = bottomBarRevealed ? '' : 'none';
+
+        // Add classes for CSS transitions/animations if desired
+        this._topBarSlotContainer.classList.toggle('revealed', topBarRevealed);
+        this._bottomBarSlotContainer.classList.toggle('revealed', bottomBarRevealed);
+
+    }
+
+    // Public methods (optional, could rely on attributes)
+    showTopBar() { this.setAttribute('top-bar-revealed', ''); }
+    hideTopBar() { this.removeAttribute('top-bar-revealed'); } // Or set to "false"
+    showBottomBar() { this.setAttribute('bottom-bar-revealed', ''); }
+    hideBottomBar() { this.removeAttribute('bottom-bar-revealed'); }
+}
+
 
 class AdwPreferencesView extends HTMLElement {
     constructor() {
@@ -2608,7 +4857,6 @@ class AdwPreferencesView extends HTMLElement {
         this.shadowRoot.append(styleLink, wrapper);
     }
 }
-// customElements.define('adw-preferences-view', AdwPreferencesView); // Moved to end
 
 class AdwPreferencesPage extends HTMLElement {
     static get observedAttributes() { return ['title']; }
@@ -2626,7 +4874,6 @@ class AdwPreferencesPage extends HTMLElement {
     attributeChangedCallback(name, oldValue, newValue) { if (name === 'title' && oldValue !== newValue) this._renderTitle(); }
     _renderTitle() { this._titleElement.textContent = this.getAttribute('title') || 'Page'; }
 }
-// customElements.define('adw-preferences-page', AdwPreferencesPage); // Moved to end
 
 class AdwPreferencesGroup extends HTMLElement {
     static get observedAttributes() { return ['title']; }
@@ -2648,7 +4895,6 @@ class AdwPreferencesGroup extends HTMLElement {
         this._titleElement.style.display = title ? '' : 'none';
     }
 }
-// customElements.define('adw-preferences-group', AdwPreferencesGroup); // Moved to end
 
 class AdwSwitchRow extends HTMLElement {
     static get observedAttributes() { return ['title', 'subtitle', 'active', 'disabled']; }
@@ -2698,7 +4944,6 @@ class AdwSwitchRow extends HTMLElement {
         this._wrapper.classList.toggle('disabled', isDisabled);
     }
 }
-// customElements.define('adw-switch-row', AdwSwitchRow); // Moved to end
 
 class AdwComboRow extends HTMLElement {
     static get observedAttributes() { return ['title', 'subtitle', 'value', 'disabled']; }
@@ -2766,7 +5011,6 @@ class AdwComboRow extends HTMLElement {
         if (isDisabled) this.setAttribute('disabled', ''); else this.removeAttribute('disabled');
     }
 }
-// customElements.define('adw-combo-row', AdwComboRow); // Moved to end
 
 // console.log('[Debug] components.js execution ended'); // Will be replaced
 
@@ -2803,5 +5047,24 @@ customElements.define('adw-preferences-page', AdwPreferencesPage);
 customElements.define('adw-preferences-group', AdwPreferencesGroup);
 customElements.define('adw-switch-row', AdwSwitchRow);
 customElements.define('adw-combo-row', AdwComboRow);
+customElements.define('adw-alert-dialog', AdwAlertDialog);
+customElements.define('adw-about-dialog', AdwAboutDialog);
+customElements.define('adw-preferences-dialog', AdwPreferencesDialog);
+customElements.define('adw-spin-button', AdwSpinButton);
+customElements.define('adw-spin-row', AdwSpinRow);
+customElements.define('adw-button-row', AdwButtonRow);
+customElements.define('adw-tab-button', AdwTabButton);
+customElements.define('adw-tab-bar', AdwTabBar);
+customElements.define('adw-tab-page', AdwTabPage);
+customElements.define('adw-tab-view', AdwTabView);
+customElements.define('adw-navigation-view', AdwNavigationView);
+customElements.define('adw-bottom-sheet', AdwBottomSheet);
+customElements.define('adw-bin', AdwBin);
+customElements.define('adw-wrap-box', AdwWrapBox);
+customElements.define('adw-clamp', AdwClamp);
+customElements.define('adw-breakpoint-bin', AdwBreakpointBin);
+customElements.define('adw-toolbar-view', AdwToolbarView);
 
 console.log('[Debug] components.js all custom elements defined and execution ended.');
+
+[end of js/components.js]

--- a/scss/_about_dialog.scss
+++ b/scss/_about_dialog.scss
@@ -1,0 +1,157 @@
+// scss/_about_dialog.scss
+@use 'variables';
+
+.adw-about-dialog {
+  // Inherits .adw-dialog styles for the main dialog frame, backdrop, etc.
+
+  .adw-about-dialog-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
+  }
+
+  .adw-about-dialog-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-l);
+    padding-bottom: var(--spacing-l);
+    border-bottom: 1px solid var(--border-color-light); /* Use theme-aware border */
+  }
+
+  .dark-theme .adw-about-dialog-header,
+  body.dark-theme .adw-about-dialog-header {
+    border-bottom-color: var(--border-color-dark);
+  }
+
+
+  .adw-about-dialog-logo {
+    width: 96px; // Standard size for a larger logo in about dialog
+    height: 96px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
+  .adw-about-dialog-app-icon-img {
+    width: 64px;
+    height: 64px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
+   .adw-about-dialog-app-icon { // For icon font/SVG class
+    font-size: 64px; // Adjust as needed
+    width: 64px;
+    height: 64px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+
+  .adw-about-dialog-app-info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xxs);
+  }
+
+  .adw-about-dialog-app-name {
+    font-size: var(--font-size-h1);
+    font-weight: bold;
+    margin: 0;
+    color: var(--headerbar-fg-color); // Match headerbar text color for title
+  }
+
+  .adw-about-dialog-version {
+    font-size: var(--font-size-base);
+    opacity: 0.8;
+    margin: 0;
+  }
+
+  .adw-about-dialog-main-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+
+    p {
+      margin: 0;
+      line-height: 1.6;
+    }
+  }
+
+  .adw-about-dialog-developer,
+  .adw-about-dialog-copyright,
+  .adw-about-dialog-website {
+    font-size: var(--font-size-small);
+    opacity: 0.9;
+  }
+  .adw-about-dialog-website a {
+    color: var(--link-color);
+    text-decoration: none;
+    &:hover {
+        text-decoration: underline;
+    }
+  }
+
+
+  .adw-about-dialog-details-content {
+    // This is the content of the expander row
+    padding-top: var(--spacing-m); // Add some space if expander content has its own padding too
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+  }
+
+  .adw-about-dialog-credits-section,
+  .adw-about-dialog-license-section {
+    h3 {
+      font-size: var(--font-size-large);
+      font-weight: bold;
+      margin-bottom: var(--spacing-xs);
+      color: var(--headerbar-fg-color); // Consistent heading color
+    }
+    ul {
+      list-style: none;
+      padding-left: 0;
+      margin: 0;
+      li {
+        font-size: var(--font-size-small);
+        margin-bottom: var(--spacing-xxs);
+      }
+    }
+    p {
+        font-size: var(--font-size-small);
+        margin-bottom: var(--spacing-xxs);
+    }
+  }
+
+  .adw-about-dialog-license-text {
+    font-family: var(--monospace-font-family);
+    font-size: var(--font-size-small);
+    white-space: pre-wrap;
+    background-color: var(--shade-color); // Subtle background for preformatted text
+    padding: var(--spacing-s);
+    border-radius: var(--border-radius-small);
+    max-height: 200px; // Prevent extremely long licenses from dominating
+    overflow-y: auto;
+    border: 1px solid var(--border-color-light);
+  }
+
+  .dark-theme .adw-about-dialog-license-text,
+  body.dark-theme .adw-about-dialog-license-text {
+    border-color: var(--border-color-dark);
+  }
+
+  // Ensure the expander row itself looks good within the dialog
+  .adw-expander-row-wrapper {
+    // The wrapper might have a border-bottom if not last child.
+    // Inside a dialog, we might not want these default listbox-like borders.
+    border-bottom: none;
+
+    .adw-expander-row { // The clickable part
+        padding: var(--spacing-s) 0; // Less padding if inside dialog
+    }
+    .adw-expander-row-content { // The collapsible part
+        padding-left: var(--spacing-m);
+        padding-right: var(--spacing-m);
+    }
+  }
+}

--- a/scss/_alert_dialog.scss
+++ b/scss/_alert_dialog.scss
@@ -1,0 +1,24 @@
+// scss/_alert_dialog.scss
+@use 'variables';
+
+.adw-alert-dialog {
+  // Inherits most styles from .adw-dialog
+
+  // Specific styling for the body text within an alert dialog
+  .adw-alert-dialog-body {
+    font-size: var(--font-size-base); // Ensure consistent font size
+    line-height: 1.6; // Slightly more line height for readability of alert messages
+    // No specific color needed if it inherits from .adw-dialog-content's color
+  }
+
+  // If the heading (title) of an alert dialog needs specific styling
+  // distinct from a generic dialog title.
+  // .adw-dialog-title (when part of .adw-alert-dialog) {
+  //   // Example: Maybe alert dialog titles are less prominent
+  //   // font-size: var(--font-size-large);
+  // }
+}
+
+// Dark theme adjustments are typically handled by the base .adw-dialog styles
+// and the variables they use. If .adw-alert-dialog had unique background/foreground
+// that differed from .adw-dialog, dark theme overrides would go here.

--- a/scss/_bin.scss
+++ b/scss/_bin.scss
@@ -1,0 +1,22 @@
+// scss/_bin.scss
+@use 'variables';
+
+.adw-bin {
+  display: block; // Or inline-block, depending on desired default flow
+  // No specific padding or border by default, it's a minimal container.
+  // Its child will dictate its size, or the bin itself can be sized by parent/CSS.
+
+  // If alignment properties were added to the factory/WC for the child:
+  // &.align-child-start { align-items: flex-start; } // If display:flex on .adw-bin
+  // &.justify-child-center { justify-content: center; } // If display:flex on .adw-bin
+
+  // Generally, AdwBin itself is simple. The child it contains, or the context
+  // the AdwBin is placed in, will determine more complex layout.
+}
+
+// No dark theme specific styles usually needed for a simple bin,
+// unless it had its own background or border that needed to adapt.
+// .dark-theme .adw-bin,
+// body.dark-theme .adw-bin {
+//   // ...
+// }

--- a/scss/_bottom_sheet.scss
+++ b/scss/_bottom_sheet.scss
@@ -1,0 +1,78 @@
+// scss/_bottom_sheet.scss
+@use 'variables';
+
+.adw-bottom-sheet-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.25); // Similar to dialog backdrop
+  z-index: var(--z-index-modal-backdrop, 400);
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  visibility: hidden;
+
+  &.visible {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.adw-bottom-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: var(--popover-bg-color); // Popover bg is often good for transient surfaces
+  color: var(--popover-fg-color);
+  border-top-left-radius: var(--border-radius-large);
+  border-top-right-radius: var(--border-radius-large);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.15);
+  z-index: var(--z-index-modal, 401); // Above backdrop
+  transform: translateY(100%);
+  transition: transform 0.3s ease-in-out;
+  visibility: hidden;
+  max-height: 80vh; // Prevent full screen takeover on large content
+  display: flex;
+  flex-direction: column;
+
+  // Optional: Handle for dragging/swiping (visual cue)
+  // &::before {
+  //   content: "";
+  //   display: block;
+  //   width: 40px;
+  //   height: 4px;
+  //   background-color: var(--border-color-light); // Or a specific handle color
+  //   border-radius: 2px;
+  //   margin: var(--spacing-s) auto;
+  //   opacity: 0.5;
+  // }
+
+  &.visible {
+    transform: translateY(0);
+    visibility: visible;
+  }
+
+  // The content passed to the factory is directly appended.
+  // If that content needs scrolling, it should handle it internally or have a wrapper.
+  // For example, if the factory wraps opts.content in a div:
+  // > div { // Assuming the factory wraps content in a direct child div
+  //   overflow-y: auto;
+  //   padding: var(--spacing-l); // Padding for the content area
+  // }
+  // If opts.content itself is expected to be the scrollable area:
+  > *:first-child { // Assuming the passed content is the first child
+    overflow-y: auto;
+    padding: var(--spacing-l); // Common padding
+    // Potentially add padding-bottom to account for device navigation bars if needed (hard to do universally)
+  }
+}
+
+.dark-theme .adw-bottom-sheet,
+body.dark-theme .adw-bottom-sheet {
+  // box-shadow: 0 -2px 10px rgba(0,0,0, 0.3); // Darker shadow for dark theme
+  // &::before {
+  //   background-color: var(--border-color-dark);
+  // }
+}

--- a/scss/_breakpoint_bin.scss
+++ b/scss/_breakpoint_bin.scss
@@ -1,0 +1,27 @@
+// scss/_breakpoint_bin.scss
+@use 'variables';
+
+.adw-breakpoint-bin {
+  display: block; // Or 'grid' or 'flex' if it needs to manage layout beyond showing/hiding.
+                  // For now, JS handles display of children.
+  position: relative; // If children were to be absolutely positioned within it.
+  width: 100%; // Usually takes up available width.
+  // height: 100%; // Or available height.
+
+  // Direct children (the pages/views to be swapped)
+  // The JS will set display: none or display: '' on these.
+  // No general styling needed for children from the bin's perspective usually,
+  // as they are arbitrary content.
+  // > ::slotted(*) {
+  //   display: none; // Initially hide all slotted children if WC manages display
+  // }
+  // > ::slotted(*.visible-breakpoint-child) {
+  //   display: block; // Or whatever their natural display type is
+  // }
+}
+
+// No dark theme specific styles usually needed for AdwBreakpointBin itself.
+// .dark-theme .adw-breakpoint-bin,
+// body.dark-theme .adw-breakpoint-bin {
+//   // ...
+// }

--- a/scss/_button_row.scss
+++ b/scss/_button_row.scss
@@ -1,0 +1,34 @@
+// scss/_button_row.scss
+@use 'variables';
+
+.adw-button-row {
+  // Inherits .adw-row styles by default.
+  // AdwRow provides display:flex, align-items:center.
+  // We might want to adjust padding for button rows if they are purely for actions.
+  padding-top: var(--spacing-s);
+  padding-bottom: var(--spacing-s);
+
+  .adw-button-row-container {
+    display: flex;
+    flex-wrap: wrap; // Allow buttons to wrap on smaller screens
+    gap: var(--spacing-s); // Spacing between buttons
+    width: 100%; // Take full width to allow justification within the row
+  }
+
+  // The factory function sets justify-content on the container directly.
+  // If using the web component with slotted content, these utility classes on the host
+  // could be an alternative way to control alignment if the ::slotted selector is problematic
+  // for direct flex styling of the slot itself.
+
+  // &.centered .adw-button-row-container {
+  //   justify-content: center;
+  // }
+  // &:not(.centered) .adw-button-row-container {
+  //    justify-content: flex-end; // Default to end-aligned buttons
+  // }
+}
+
+// No specific dark theme needed if variables are correctly set up for buttons and row background.
+// .dark-theme .adw-button-row {
+//   // ...
+// }

--- a/scss/_clamp.scss
+++ b/scss/_clamp.scss
@@ -1,0 +1,31 @@
+// scss/_clamp.scss
+@use 'variables';
+
+.adw-clamp {
+  // display: flex; // Set by JS factory/WC
+  // justify-content: center; // Set by JS factory/WC
+  width: 100%; // Clamp itself should take available width to center its child.
+
+  .adw-clamp-child-wrapper {
+    width: 100%; // Takes full width up to its own max-width.
+                 // If clamp is scrollable, this ensures it uses the scrollable area.
+    // max-width is set by JS.
+    // margin-left: auto; // Set by JS if using margin auto centering
+    // margin-right: auto; // Set by JS if using margin auto centering
+  }
+
+  // &.scrollable { // Class added by JS
+  //   overflow-x: hidden; // Set by JS
+  //   overflow-y: auto;   // Set by JS
+  //   // Ensure it has a height to make scrolling meaningful, e.g.,
+  //   // height: 100%;
+  //   // or parent needs to constrain its height.
+  // }
+}
+
+// No specific dark theme styles usually needed for AdwClamp itself,
+// as it's a transparent container. Child content handles its own theme.
+// .dark-theme .adw-clamp,
+// body.dark-theme .adw-clamp {
+//   // ...
+// }

--- a/scss/_navigation_view.scss
+++ b/scss/_navigation_view.scss
@@ -1,0 +1,89 @@
+// scss/_navigation_view.scss
+@use 'variables';
+
+.adw-navigation-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%; // Assume it fills its container
+  overflow: hidden; // Important for transitions
+  position: relative; // For positioning pages
+
+  > .adw-header-bar {
+    // Standard header bar styling applies
+    flex-shrink: 0; // Header bar should not shrink
+  }
+
+  .adw-navigation-view-pages-container {
+    flex-grow: 1;
+    position: relative; // Child pages will be absolute/relative to this
+    overflow: hidden; // Clip page transitions
+    background-color: var(--window-bg-color); // Default background
+  }
+
+  .adw-navigation-page {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    // background-color: var(--window-bg-color); // Pages have their own bg or inherit
+    overflow-y: auto; // Allow individual pages to scroll
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    // visibility: hidden; // Controlled by display initially
+
+    // &.adw-navigation-page-active {
+    //   visibility: visible;
+    //   z-index: 1;
+    // }
+  }
+
+  // Slide from right for push
+  .adw-navigation-page-entering-right {
+    transform: translateX(100%);
+    opacity: 0.8;
+    z-index: 2; // Ensure entering page is on top
+  }
+  .adw-navigation-page-active.adw-navigation-page-entering-right { // Target active page during its enter phase
+     transform: translateX(0);
+     opacity: 1;
+  }
+
+
+  // Slide out to left for push
+  .adw-navigation-page-exiting-left {
+    transform: translateX(-30%); // Libadwaita uses a smaller slide out for previous page
+    opacity: 0.5;
+    z-index: 0;
+  }
+
+  // Slide in from left for pop
+  .adw-navigation-page-entering-left {
+      transform: translateX(-30%);
+      opacity: 0.5;
+      z-index: 2;
+  }
+   .adw-navigation-page-active.adw-navigation-page-entering-left {
+     transform: translateX(0);
+     opacity: 1;
+  }
+
+  // Slide out to right for pop
+  .adw-navigation-page-exiting-right {
+    transform: translateX(100%);
+    opacity: 0.8;
+    z-index: 0;
+  }
+
+}
+
+// Dark theme adjustments (mostly handled by variables, but if specific overrides needed)
+// .dark-theme .adw-navigation-view,
+// body.dark-theme .adw-navigation-view {
+//   .adw-navigation-view-pages-container {
+//     background-color: var(--window-bg-color);
+//   }
+//   .adw-navigation-page {
+//     // background-color: var(--window-bg-color);
+//   }
+// }

--- a/scss/_preferences_dialog.scss
+++ b/scss/_preferences_dialog.scss
@@ -1,0 +1,85 @@
+// scss/_preferences_dialog.scss
+@use 'variables';
+
+.adw-preferences-dialog {
+  // Inherits .adw-dialog styles for the main dialog frame.
+
+  // The direct content wrapper of the dialog (created by AdwDialog factory)
+  // might need specific padding if the preferences content is edge-to-edge.
+  > .adw-dialog-content {
+    padding: 0; // Remove default dialog content padding
+                 // if the view switcher or pages handle their own.
+    display: flex; // Allow content to fill height
+    flex-direction: column;
+  }
+
+  .adw-preferences-dialog-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1; // Ensure it tries to fill the dialog height
+    overflow: hidden; // Contained scrolling within view switcher content
+  }
+
+  .adw-preferences-dialog-view-switcher {
+    flex-grow: 1; // Allow the view switcher to take up space
+    display: flex;
+    flex-direction: column; // Stack bar and content vertically
+
+    // Styling for the ViewSwitcherBar within a PreferencesDialog
+    .adw-view-switcher-bar {
+      background-color: var(--headerbar-bg-color); // Or a slightly different shade
+      padding: var(--spacing-xs) var(--spacing-m);
+      // Potentially remove bottom border if it's inside the dialog frame
+      border-bottom: 1px solid var(--headerbar-border-color);
+
+      .adw-button {
+        // Preferences tabs are often less prominent than main view switcher tabs
+        padding: var(--spacing-xs) var(--spacing-s);
+        font-size: var(--font-size-small);
+        color: var(--secondary-text-color);
+
+        &.active {
+          color: var(--accent-color);
+          font-weight: bold; // Keep bold for active
+          background-color: transparent; // Active tab bg usually transparent on headerbar-like bg
+          border-bottom-color: var(--accent-color); // Use accent for underline
+          margin-bottom: -1px; // Overlap border if using underline style
+        }
+         &:hover:not(.active) {
+            background-color: var(--button-flat-hover-bg-color);
+            color: var(--headerbar-fg-color);
+        }
+      }
+    }
+
+    // Styling for the ViewSwitcherContent within a PreferencesDialog
+    .adw-view-switcher-content {
+      flex-grow: 1; // Allow content to fill remaining space
+      // The AdwPreferencesPage itself should handle its internal padding & scrolling
+      padding: 0; // Remove default viewswitcher content padding
+      border: none; // Remove default border, dialog frame provides it
+      background-color: var(--window-bg-color); // Match window bg
+      overflow-y: auto; // Allow individual pages to scroll if they become too long
+    }
+  }
+
+  // Ensure AdwPreferencesPage and its children look correct
+  adw-preferences-page, .adw-preferences-page {
+    // background-color: var(--window-bg-color); // Already on view-switcher-content
+    // padding: var(--spacing-l); // AdwPreferencesPage component should handle its own padding
+  }
+}
+
+// Dark theme adjustments for specific parts if not covered by variables
+.dark-theme .adw-preferences-dialog,
+body.dark-theme .adw-preferences-dialog {
+  .adw-preferences-dialog-view-switcher {
+    .adw-view-switcher-bar {
+      // background-color: var(--headerbar-bg-color);
+      // border-bottom-color: var(--headerbar-border-color);
+    }
+    .adw-view-switcher-content {
+      // background-color: var(--window-bg-color);
+    }
+  }
+}

--- a/scss/_spin_button.scss
+++ b/scss/_spin_button.scss
@@ -1,0 +1,101 @@
+// scss/_spin_button.scss
+@use 'variables';
+
+.adw-spin-button {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--button-border-color); // Use button border for consistency
+  border-radius: var(--border-radius-default);
+  background-color: var(--view-bg-color); // Entry part background
+  overflow: hidden; // Keep buttons contained
+
+  &.disabled {
+    opacity: var(--opacity-disabled, 0.5);
+    pointer-events: none;
+    .adw-spin-button-entry {
+      background-color: var(--shade-color); // Disabled entry background
+    }
+  }
+
+  .adw-spin-button-entry {
+    // AdwEntry styles are applied by the factory, but we might override some specifics
+    border: none; // Remove individual entry border, wrapper has it
+    border-radius: 0; // No radius inside the wrapper
+    // padding-right: var(--spacing-xxs); // Slightly less padding if buttons are close
+    box-shadow: none; // No inner shadow
+    min-height: calc(var(--button-size-base) - 2px); // Match button height, minus border
+    height: calc(var(--button-size-base) - 2px);
+
+    &:focus, &:focus-within {
+      box-shadow: none; // No focus shadow on entry if wrapper handles focus
+    }
+  }
+
+  .adw-spin-button-buttons {
+    display: flex;
+    flex-direction: column;
+    height: 100%; // Match entry height
+
+    .adw-button { // Up and Down buttons
+      background-color: var(--button-bg-color);
+      border: none;
+      border-radius: 0;
+      padding: 0 var(--spacing-xs); // Minimal padding for small buttons
+      min-height: 0; // Allow them to be very short
+      height: 50%; // Each button takes half the height
+      line-height: 0; // Try to center icon if it's line-height sensitive
+      box-shadow: none;
+
+
+      &:hover {
+        background-color: var(--button-hover-bg-color);
+      }
+      &:active {
+        background-color: var(--button-active-bg-color);
+      }
+      &:disabled {
+        background-color: var(--button-bg-color); // Keep bg, opacity handles disable
+        opacity: 0.3; // More opacity for disabled internal buttons
+      }
+
+      .icon svg {
+        width: 12px; // Smaller icons for spin buttons
+        height: 12px;
+      }
+    }
+    .adw-spin-button-up {
+        border-bottom: 1px solid var(--button-border-color);
+    }
+  }
+
+  &:focus-within { // Focus indication on the wrapper
+    outline: 2px solid var(--accent-bg-color);
+    outline-offset: 1px;
+    border-color: var(--accent-bg-color);
+  }
+}
+
+.dark-theme .adw-spin-button,
+body.dark-theme .adw-spin-button {
+  border-color: var(--button-border-color);
+  background-color: var(--view-bg-color);
+
+   &.disabled .adw-spin-button-entry {
+      background-color: var(--shade-color);
+    }
+
+  .adw-spin-button-buttons {
+    .adw-button {
+      background-color: var(--button-bg-color);
+      &:disabled {
+         background-color: var(--button-bg-color);
+      }
+    }
+     .adw-spin-button-up {
+        border-bottom-color: var(--button-border-color);
+    }
+  }
+   &:focus-within {
+    border-color: var(--accent-bg-color);
+  }
+}

--- a/scss/_spin_row.scss
+++ b/scss/_spin_row.scss
@@ -1,0 +1,45 @@
+// scss/_spin_row.scss
+@use 'variables';
+@use 'row_types'; // For common row text content styling if applicable
+
+.adw-spin-row {
+  // Inherits .adw-row styles by default if created using Adw.createRow
+  // display: flex; (from .adw-row)
+  // align-items: center; (from .adw-row)
+  gap: var(--spacing-m); // Standard gap for row items
+
+  .adw-spin-row-text-content {
+    flex-grow: 1; // Allow text content to take available space
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden; // For text ellipsis
+  }
+
+  .adw-spin-row-title {
+    // Uses AdwLabel, so inherits its styles.
+    // Specific overrides if needed:
+    // font-weight: normal;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .adw-spin-row-subtitle {
+    // Uses AdwLabel, so inherits its styles (font-size-small, opacity).
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .adw-spin-row-spin-button {
+    // This class is on the adw-spin-button component itself (the wrapper div)
+    flex-shrink: 0; // Don't allow the spin button to shrink
+  }
+}
+
+// No specific dark theme overrides needed here if child components and variables handle it.
+// .dark-theme .adw-spin-row,
+// body.dark-theme .adw-spin-row {
+//   // ...
+// }

--- a/scss/_tabs.scss
+++ b/scss/_tabs.scss
@@ -1,0 +1,189 @@
+// scss/_tabs.scss
+@use 'variables';
+
+// --- AdwTabButton ---
+.adw-tab-button {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-s) var(--spacing-m);
+  border: 1px solid transparent; // Usually border comes from TabBar or active state
+  border-radius: var(--border-radius-default) var(--border-radius-default) 0 0; // Rounded top corners
+  cursor: pointer;
+  user-select: none;
+  background-color: var(--button-flat-bg-color); // Start flat
+  color: var(--secondary-text-color);
+  margin-right: var(--spacing-xxs); // Small gap between tabs
+  margin-bottom: -1px; // Overlap TabBar's bottom border
+  position: relative;
+  max-width: 200px; // Prevent tabs from getting too wide
+
+  &:hover {
+    background-color: var(--button-flat-hover-bg-color);
+    color: var(--window-fg-color);
+  }
+
+  &.active {
+    background-color: var(--window-bg-color); // Active tab matches content area bg
+    color: var(--accent-color); // Active tab text is accented
+    font-weight: bold;
+    border-color: var(--headerbar-border-color); // Use a defined border color
+    border-bottom-color: var(--window-bg-color); // "Merge" with content area
+    z-index: 1; // Ensure active tab border overlaps inactive ones
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-bg-color);
+    outline-offset: -2px; // Outline inside
+    z-index: 2; // Ensure focus outline is visible
+  }
+
+  .adw-tab-button-content-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    overflow: hidden; // For label ellipsis
+  }
+
+  .adw-tab-button-icon {
+    flex-shrink: 0;
+    // SVG/font icon styling here if needed
+    svg { width: 1em; height: 1em; }
+  }
+
+  .adw-tab-button-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .adw-tab-button-close {
+    // AdwButton styling will apply. Specific tweaks:
+    padding: var(--spacing-xxs) !important; // Make close button smaller
+    margin-left: var(--spacing-xs);
+    opacity: 0.7;
+    &:hover { opacity: 1; }
+    .icon svg {
+        width: 0.7em; // Smaller 'x' icon
+        height: 0.7em;
+    }
+  }
+}
+
+// --- AdwTabBar ---
+.adw-tab-bar {
+  display: flex;
+  align-items: flex-end; // Align buttons to the bottom border
+  background-color: var(--headerbar-bg-color); // Or a specific tab bar background
+  padding: 0 var(--spacing-xs); // Padding for the bar itself
+  border-bottom: 1px solid var(--headerbar-border-color); // Main line under the tabs
+  overflow-x: auto; // Allow horizontal scrolling if many tabs
+  scrollbar-width: thin;
+
+  .adw-tab-bar-button-container {
+    display: flex;
+    align-items: flex-end;
+  }
+
+  .adw-tab-bar-new-tab-button {
+    // AdwButton styling will apply.
+    margin-left: var(--spacing-s);
+    margin-bottom: var(--spacing-xs); // Align with tab buttons before their bottom border
+    align-self: center; // Center it vertically if other tabs make bar taller
+  }
+}
+
+// --- AdwTabPage ---
+// This is the web component's wrapper for slotted content
+adw-tab-page {
+    display: block; // Default, can be changed by AdwTabView
+    & > .adw-tab-page { // The inner div created by AdwTabPage WC
+        padding: var(--spacing-l); // Standard content padding
+        background-color: var(--window-bg-color);
+        height: 100%; // Try to fill parent if sized
+        box-sizing: border-box;
+    }
+}
+
+
+// --- AdwTabView ---
+.adw-tab-view {
+  display: flex;
+  flex-direction: column;
+  // height: 100%; // If it should fill its parent
+  background-color: var(--window-bg-color);
+  border: 1px solid var(--headerbar-border-color); // Outer border for the whole view
+  border-radius: var(--border-radius-default); // Overall rounding
+  overflow: hidden; // Clip content to rounded corners
+
+  // The AdwTabBar is the first child from the factory
+  > .adw-tab-bar {
+    border-top-left-radius: var(--border-radius-default);
+    border-top-right-radius: var(--border-radius-default);
+    border-bottom-width: 0; // TabView provides the lower border usually
+    // If tab bar is inside the tab view's border, remove its own:
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    padding-left: var(--spacing-s); // Match typical headerbar padding
+    padding-right: var(--spacing-s);
+  }
+
+  // The pages container from the factory
+  > .adw-tab-view-pages-container {
+    flex-grow: 1;
+    position: relative; // For absolute positioning of pages if needed, or just overflow
+    overflow: auto; // If pages themselves don't scroll
+    // The AdwTabPage elements are direct children here from the factory
+    > .adw-tab-page {
+        // These are the pages created by createAdwTabPage factory
+        // They will have their own padding.
+        background-color: var(--window-bg-color);
+        // Ensure they fill the container when active
+        &[style*="display: block"], &:not([style*="display: none"]) { // Crude check for active
+             width: 100%;
+             height: 100%;
+        }
+    }
+  }
+
+  // The slot for web component usage
+  ::slotted(adw-tab-page) {
+    // These are the light DOM elements passed to adw-tab-view WC
+    // Their display is controlled by the AdwTabView JS.
+    // They should also take up full space when active.
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+  }
+}
+
+
+// Dark Theme Adjustments
+.dark-theme, body.dark-theme {
+  .adw-tab-button {
+    &.active {
+      background-color: var(--window-bg-color);
+      border-color: var(--headerbar-border-color);
+      border-bottom-color: var(--window-bg-color);
+      color: var(--accent-color);
+    }
+     &:hover:not(.active) {
+        background-color: var(--button-flat-hover-bg-color);
+        color: var(--window-fg-color);
+    }
+  }
+  .adw-tab-bar {
+    background-color: var(--headerbar-bg-color);
+    border-bottom-color: var(--headerbar-border-color);
+  }
+  .adw-tab-view {
+     background-color: var(--window-bg-color);
+     border-color: var(--headerbar-border-color);
+     > .adw-tab-view-pages-container > .adw-tab-page {
+        background-color: var(--window-bg-color);
+     }
+  }
+  adw-tab-page > .adw-tab-page { // Inner div of WC
+    background-color: var(--window-bg-color);
+  }
+}

--- a/scss/_toolbar_view.scss
+++ b/scss/_toolbar_view.scss
@@ -1,0 +1,66 @@
+// scss/_toolbar_view.scss
+@use 'variables';
+
+.adw-toolbar-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%; // Typically, a toolbar view would fill its parent.
+  background-color: var(--window-bg-color); // Or view-bg-color depending on context
+
+  .adw-toolbar-view-top-bar,
+  .adw-toolbar-view-bottom-bar {
+    flex-shrink: 0; // Prevent bars from shrinking
+    // background-color: var(--headerbar-bg-color); // Default bar background
+    // color: var(--headerbar-fg-color);
+    // border-bottom: 1px solid var(--headerbar-border-color); // For top bar
+    // border-top: 1px solid var(--headerbar-border-color); // For bottom bar
+    // padding: var(--spacing-xs) var(--spacing-m); // Default padding for bars
+    // transition for reveal/hide if using max-height or transform
+    // transition: max-height 0.2s ease-out, opacity 0.2s ease-out, visibility 0.2s;
+    // overflow: hidden; // Important for max-height transitions
+
+    // &.revealed { // If using class-based transitions
+    //   max-height: 200px; // Example max height
+    //   opacity: 1;
+    //   visibility: visible;
+    // }
+    // &:not(.revealed) {
+    //    max-height: 0;
+    //    opacity: 0;
+    //    visibility: hidden;
+    //    padding-top: 0;
+    //    padding-bottom: 0;
+    //    border-width: 0;
+    // }
+  }
+
+  // Assuming direct children of slot are the actual headerbar/actionbar components
+  .adw-toolbar-view-top-bar ::slotted(adw-header-bar),
+  .adw-toolbar-view-top-bar ::slotted(header) { // For native header
+    border-bottom: 1px solid var(--headerbar-border-color);
+  }
+
+  .adw-toolbar-view-bottom-bar ::slotted(adw-header-bar), // Though less common for bottom
+  .adw-toolbar-view-bottom-bar ::slotted(footer), // For native footer or action bar
+  .adw-toolbar-view-bottom-bar ::slotted(.adw-action-bar) { // If an action-bar class is used
+     border-top: 1px solid var(--headerbar-border-color);
+  }
+
+
+  .adw-toolbar-view-content {
+    flex-grow: 1;
+    overflow-y: auto; // Main content is usually scrollable
+    // padding: var(--spacing-l); // Content padding, if not handled by the slotted content itself
+  }
+}
+
+// Dark theme adjustments if needed, though variables should cover most.
+// .dark-theme .adw-toolbar-view,
+// body.dark-theme .adw-toolbar-view {
+//   .adw-toolbar-view-top-bar,
+//   .adw-toolbar-view-bottom-bar {
+//     background-color: var(--headerbar-bg-color);
+//     color: var(--headerbar-fg-color);
+//     border-color: var(--headerbar-border-color);
+//   }
+// }

--- a/scss/_viewswitcher.scss
+++ b/scss/_viewswitcher.scss
@@ -10,6 +10,47 @@
   justify-content: flex-start;
   background-color: transparent;
   border-bottom: var(--border-width, 1px) solid var(--border-color, var(--headerbar-border-color));
+  // Default gap for non-inline buttons in the bar
+  gap: var(--spacing-xs);
+
+
+  // Inline variant styling
+  &.inline-switcher {
+    border: 1px solid var(--button-border-color); // Group border
+    border-radius: var(--border-radius-default);
+    padding: var(--spacing-xxs); // Small internal padding for the bar
+    width: max-content; // Shrink to content
+    gap: 0; // No gap between inline buttons
+    background-color: var(--button-bg-color); // Bar itself gets a background
+
+    .adw-button {
+      border: none !important; // Override individual button borders
+      border-radius: var(--border-radius-small) !important; // Slightly less rounding for inner segments
+      padding: var(--spacing-xs) var(--spacing-s); // Adjust padding for inline
+      margin-bottom: 0; // No negative margin needed
+      background-color: transparent; // Default transparent background for buttons
+      color: var(--button-fg-color); // Standard button text color
+      opacity: 1;
+      box-shadow: none !important; // No individual shadows
+
+      &:not(:last-child) {
+        // Could add a very subtle separator if desired:
+        // border-right: 1px solid var(--button-border-color) !important;
+      }
+
+      &:hover {
+        background-color: var(--button-flat-hover-bg-color) !important; // Subtle hover
+        color: var(--button-fg-color) !important;
+      }
+
+      &.active {
+        background-color: var(--accent-bg-color) !important; // Active button gets accent
+        color: var(--accent-fg-color) !important;
+        font-weight: 500; // Slightly bolder active tab
+        // No special border needed for active if bg is distinct
+      }
+    }
+  }
 
   .adw-button {
     background-color: transparent;

--- a/scss/_wrap_box.scss
+++ b/scss/_wrap_box.scss
@@ -1,0 +1,39 @@
+// scss/_wrap_box.scss
+@use 'variables';
+
+.adw-wrap-box {
+  // display: flex; // Set by JS factory/WC directly for now
+  // flex-wrap: wrap; // Set by JS factory/WC directly
+
+  // Default spacing if not overridden by JS (though JS sets gap directly)
+  // gap: var(--spacing-m);
+
+  // If specific utility classes were to be used instead of direct style manipulation by JS:
+  // &.horizontal { flex-direction: row; }
+  // &.vertical { flex-direction: column; }
+
+  // &.spacing-xs { gap: var(--spacing-xs); }
+  // &.spacing-s { gap: var(--spacing-s); }
+  // &.spacing-m { gap: var(--spacing-m); }
+  // &.spacing-l { gap: var(--spacing-l); }
+  // &.spacing-xl { gap: var(--spacing-xl); }
+
+  // &.align-start { align-items: flex-start; }
+  // &.align-center { align-items: center; }
+  // &.align-end { align-items: flex-end; }
+  // &.align-stretch { align-items: stretch; }
+
+  // &.justify-start { justify-content: flex-start; }
+  // &.justify-center { justify-content: center; }
+  // &.justify-end { justify-content: flex-end; }
+  // &.justify-between { justify-content: space-between; }
+  // &.justify-around { justify-content: space-around; }
+  // &.justify-evenly { justify-content: space-evenly; }
+}
+
+// No dark theme specific styles usually needed if it's a simple wrapper
+// and children handle their own theming.
+// .dark-theme .adw-wrap-box,
+// body.dark-theme .adw-wrap-box {
+//   // ...
+// }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -26,3 +26,17 @@
 @use "password_entry_row";
 @use "window";
 @use "toast";
+@use "alert_dialog";
+@use "about_dialog";
+@use "preferences_dialog";
+@use "spin_button";
+@use "spin_row";
+@use "button_row";
+@use "tabs";
+@use "navigation_view";
+@use "bottom_sheet";
+@use "bin";
+@use "wrap_box";
+@use "clamp";
+@use "breakpoint_bin";
+@use "toolbar_view";


### PR DESCRIPTION
Implemented the following widgets with their JS factories, web components, and basic SCSS:
- AdwAlertDialog
- AdwAboutDialog
- AdwPreferencesDialog
- AdwSpinButton (helper)
- AdwSpinRow
- AdwButtonRow
- AdwViewSwitcher (enhanced for inline style)
- AdwTabs (TabButton, TabBar, TabPage, TabView)
- AdwNavigationView
- AdwBottomSheet
- AdwBin
- AdwWrapBox
- AdwClamp
- AdwBreakpointBin

These widgets expand the library's capabilities, providing more UI building blocks aligned with Libadwaita.