### PR TITLE
Fix: Correct syntax errors in index.html and components.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,7 +667,6 @@ const spinnerLarge = Adw.createSpinner({ size: 'large' });
         // --- Status Pages ---
         const statusPagesTitle = Adw.createLabel("Status Pages", { title: 1 });
         // Re-use an existing SVG icon string from components.js for demo purposes if available, or define a simple one.
-        // const ADW_ICON_INFO_EXAMPLE = \`<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"/></svg>\`;
         const statusPageIconSVG = ADW_ICON_VISIBILITY_SHOW; // Using a globally available one for simplicity
 
         const statusPageDemo1 = Adw.createStatusPage({


### PR DESCRIPTION
- Removed an unterminated template literal comment in index.html.
- Corrected a trailing comma in the window.Adw object definition in components.js.

These fixes resolve JavaScript parsing errors that prevented the Adwaita-Web components from loading and widgets from functioning on the demo page.