### PR TITLE
Fix: Second attempt to correct syntax errors

### DIFF
--- a/js/components.js
+++ b/js/components.js
@@ -2977,7 +2977,7 @@ window.Adw = {
   createAdwToggleButton: createAdwToggleButton,
   createAdwToggleGroup: createAdwToggleGroup,
   createAdwNavigationSplitView: createAdwNavigationSplitView,
-  createAdwOverlaySplitView: createAdwOverlaySplitView
+  createAdwOverlaySplitView: createAdwOverlaySplitView,
 };
 
 window.addEventListener("DOMContentLoaded", loadSavedTheme);


### PR DESCRIPTION
- Verified that the unterminated template literal in index.html was previously fixed.
- Reverted a change in `js/components.js` by restoring a trailing comma in the `window.Adw` object definition, as a trial to fix a persistent "missing ]" parsing error.

This addresses ongoing JavaScript parsing issues preventing component loading.