### PR TITLE
Refactor to prioritize web components and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,356 +67,308 @@ Vanilla JavaScript UI framework that mimics the look and feel of GNOME's GTK4 an
 
    This will automatically recompile `style.css` whenever you make changes to any of the SCSS files.
 
-4. **Include in your HTML:** Include the compiled `style.css` and the `components.js` file in your HTML:
+4. **Include in your HTML:** Include the compiled `style.css` and the `components.js` file in your HTML. `components.js` should be loaded as a module if you are using ES6 imports within your own scripts, or ensure it's loaded before scripts that use `Adw`. For web components to be defined, it must be included.
 
    ```html
    <head>
      <link rel="stylesheet" href="style.css" />
+     <!-- Ensure components.js is loaded, ideally as a module or before your app script -->
+     <script src="js/components.js" defer></script>
    </head>
    <body>
-     <div id="app"></div>
-     <script src="js/components.js"></script>
+     <div id="app">
+       <!-- You can now use Adwaita Web Components directly -->
+       <adw-button id="my-declarative-button" suggested>Click Me Declaratively!</adw-button>
+     </div>
      <script>
-       // Your application code using the Adw components goes here
+       // Example of interacting with the declarative button
+       document.getElementById('my-declarative-button').addEventListener('click', () => {
+         Adw.createToast("Declarative button clicked!");
+       });
      </script>
    </body>
    ```
 
 ## Usage
 
-The framework provides a global `Adw` object containing functions for creating each UI component. Each function takes an `options` object to customize the appearance and behavior of the component.
+Adwaita Web components can be used in two main ways:
 
-**Example:**
+1.  **Declaratively in HTML:** Most components are provided as [Custom Elements (Web Components)](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) that you can use directly in your HTML markup. This is the recommended approach for structuring your UI.
+    Example:
+    ```html
+    <adw-button suggested>Save</adw-button>
+    <adw-entry placeholder="Enter your name..."></adw-entry>
+    ```
 
-```javascript
-const myButton = Adw.createButton("Click Me", {
-  onClick: () => {
-    Adw.createToast("Button clicked!");
-  },
-  suggested: true,
-});
-
-document.getElementById("app").appendChild(myButton);
-```
+2.  **Imperatively via JavaScript:** The framework also provides a global `Adw` object containing factory functions (e.g., `Adw.createButton(...)`) for creating UI components from JavaScript. This is useful for dynamic content generation, one-off elements like toasts and dialogs, or if you prefer a JavaScript-driven approach.
+    Example:
+    ```javascript
+    const myButton = Adw.createButton("Click Me Imperatively", {
+      onClick: () => {
+        Adw.createToast("Imperative button clicked!");
+      },
+      suggested: true,
+    });
+    document.getElementById("app").appendChild(myButton);
+    ```
 
 ## Component Documentation
 
-All components are created using functions available under the global `Adw` object (e.g., `Adw.createButton(...)`).
-Detailed API information, including all options for each component, can be found in the JSDoc comments within `js/components.js`.
+Components can be used as HTML custom elements (e.g., `<adw-button>`) or created imperatively using JavaScript functions from the global `Adw` object (e.g., `Adw.createButton(...)`). Attributes in HTML map to options in the JavaScript factory functions.
 
-Here's an overview of common components and their basic usage:
+Detailed API information for JavaScript factories, including all options for each component, can be found in the JSDoc comments within the respective `js/components/*.js` files. For web components, attributes often mirror these options.
 
-### `Adw.createButton(text, options = {})`
+Here's an overview of common components:
+
+### Buttons (`<adw-button>` / `Adw.createButton()`)
 
 Creates a button.
 
-- **`text`**: `string` - Text displayed on the button.
-- **`options`**: `object`
-  - `onClick`: `function` - Callback for click events.
-  - `suggested`: `boolean` - Styles as a suggested action (e.g., primary button). Uses the current accent color.
-  - `destructive`: `boolean` - Styles as a destructive action (e.g., for delete).
-  - `flat`: `boolean` - Styles as a flat button (no border/background).
-  - `disabled`: `boolean` - Disables the button.
-  - `icon`: `string` - SVG string or icon font class for an icon. Icon is prepended.
-  - `isCircular`: `boolean` - For icon-only circular buttons.
-  - `href`: `string` - If provided, creates an `<a>` tag styled as a button.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-button id="save-btn" suggested>Save</adw-button>
+    <adw-button id="icon-btn" icon="<svg><!-- icon --></svg>" circular></adw-button>
+    <adw-button flat>Flat</adw-button>
+    ```
+    Common attributes: `suggested`, `destructive`, `flat`, `disabled`, `icon`, `circular`. Text content goes inside the tags.
+-   **JS Factory:** `Adw.createButton(text, options = {})`
+    - `text`: `string` - Text displayed on the button.
+    - `options`: `object` (corresponds to HTML attributes)
+        - `onClick`: `function` - Callback for click events.
+        - `suggested`, `destructive`, `flat`, `disabled`, `icon`, `isCircular` (maps to `circular`), `href`.
 
-  ```javascript
-  const saveButton = Adw.createButton("Save", { suggested: true });
-  const iconButton = Adw.createButton("", {
-    icon: "<svg><!-- dummy svg --></svg>",
-    isCircular: true,
-  });
-  ```
-
-### `Adw.createEntry(options = {})`
+### Entries (`<adw-entry>` / `Adw.createEntry()`)
 
 Creates a text input field.
 
-- **`options`**: `object`
-  - `placeholder`: `string` - Placeholder text.
-  - `value`: `string` - Initial value.
-  - `onInput`: `function` - Callback for input events.
-  - `disabled`: `boolean` - Disables the entry.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-entry placeholder="Enter your name..." value="Initial Text"></adw-entry>
+    <adw-entry disabled value="Cannot edit"></adw-entry>
+    ```
+    Common attributes: `placeholder`, `value`, `disabled`.
+-   **JS Factory:** `Adw.createEntry(options = {})`
+    - `options`: `placeholder`, `value`, `onInput`, `disabled`.
 
-  ```javascript
-  const nameEntry = Adw.createEntry({ placeholder: "Enter your name" });
-  ```
-
-### `Adw.createSwitch(options = {})`
+### Switches (`<adw-switch>` / `Adw.createSwitch()`)
 
 Creates a toggle switch.
 
-- **`options`**: `object`
-  - `checked`: `boolean` - Initial state.
-  - `onChanged`: `function` - Callback when state changes.
-  - `disabled`: `boolean` - Disables the switch.
-  - `label`: `string` - Optional label text next to the switch.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-switch label="Enable Notifications" checked></adw-switch>
+    <adw-switch label="Disabled Switch" disabled></adw-switch>
+    ```
+    Common attributes: `label`, `checked`, `disabled`.
+-   **JS Factory:** `Adw.createSwitch(options = {})`
+    - `options`: `label`, `checked`, `onChanged`, `disabled`.
 
-  ```javascript
-  const notificationsSwitch = Adw.createSwitch({
-    label: "Enable Notifications",
-    checked: true,
-  });
-  ```
-
-### `Adw.createLabel(text, options = {})`
+### Labels (`<adw-label>` / `Adw.createLabel()`)
 
 Creates a text label. Can also be used for headings and other text elements.
 
-- **`text`**: `string` - The text content.
-- **`options`**: `object`
-  - `htmlTag`: `string` - HTML tag to use (default: "label"). E.g., "p", "h1", "span".
-  - `title`: `number` (1-4) - Applies heading style class `title-N`.
-  - `isCaption`: `boolean` - Applies caption style.
-  - `isLink`: `boolean` - Styles as a link. Provide `onClick` for action.
-  - `isDisabled`: `boolean` - Applies disabled style.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-label title-level="1">Main Application Title</adw-label>
+    <adw-label is-caption>A small note or caption.</adw-label>
+    <adw-label is-body>Standard body text.</adw-label>
+    ```
+    Common attributes: `title-level` (1-4), `is-caption`, `is-body`, `is-link`, `disabled`. Text content goes inside.
+-   **JS Factory:** `Adw.createLabel(text, options = {})`
+    - `options`: `htmlTag`, `title` (maps to `title-level`), `isCaption`, `isLink`, `isDisabled`.
 
-  ```javascript
-  const mainTitle = Adw.createLabel("My Application", {
-    htmlTag: "h1",
-    title: 1,
-  });
-  const smallNote = Adw.createLabel("This is important.", { isCaption: true });
-  ```
+### Header Bars (`<adw-header-bar>` / `Adw.createHeaderBar()`)
 
-### `Adw.createHeaderBar(options = {})`
+Creates a header bar, typically used at the top of a window or view. Uses slots for content.
 
-Creates a header bar, typically used at the top of a window or view.
+-   **HTML Example:**
+    ```html
+    <adw-header-bar>
+      <adw-button slot="start" icon="<svg><!-- menu --></svg>" circular></adw-button>
+      <adw-window-title slot="title" title="My App" subtitle="Version 1.0"></adw-window-title>
+      <adw-button slot="end">Action</adw-button>
+    </adw-header-bar>
+    ```
+    Use `<adw-window-title slot="title">` for the title area.
+-   **JS Factory:** `Adw.createHeaderBar(options = {})`
+    - `options`: `title`, `subtitle` (for simple text titles), `start` (HTMLElement[]), `end` (HTMLElement[]).
 
-- **`options`**: `object`
-  - `title`: `string` - Main title.
-  - `subtitle`: `string` - Subtitle (optional).
-  - `start`: `HTMLElement[]` - Elements for the left side.
-  - `end`: `HTMLElement[]` - Elements for the right side.
-- **Example:**
+### Application Windows (`<adw-application-window>` / `Adw.createWindow()`)
 
-  ```javascript
-  const header = Adw.createHeaderBar({
-    title: "My App",
-    start: [
-      Adw.createButton("", { icon: "menu-icon-class", isCircular: true }),
-    ],
-  });
-  ```
+A top-level container, often holding a header bar and main content area.
 
-### `Adw.createWindow(options = {})`
+-   **HTML Example:**
+    ```html
+    <adw-application-window>
+      <adw-header-bar slot="header">
+        <!-- ... header content ... -->
+      </adw-header-bar>
+      <div class="main-content">
+        <p>Window content goes here.</p>
+      </div>
+    </adw-application-window>
+    ```
+-   **JS Factory:** `Adw.createWindow(options = {})` (Primarily for simpler, non-slotted content)
+    - `options`: `header` (HTMLElement), `content` (HTMLElement).
 
-Creates a window-like container.
+### Boxes (`<adw-box>` / `Adw.createBox()`)
 
-- **`options`**: `object`
-  - `header`: `HTMLElement` - An `Adw.createHeaderBar()` element (optional).
-  - `content`: `HTMLElement` - Main content for the window.
-- **Example:**
+A flexbox container.
 
-  ```javascript
-  const myContent = document.createElement("p");
-  myContent.textContent = "Window content goes here.";
-  const appWindow = Adw.createWindow({ content: myContent });
-  ```
+-   **HTML Example:**
+    ```html
+    <adw-box orientation="horizontal" spacing="s" align="center">
+      <adw-button>OK</adw-button>
+      <adw-button>Cancel</adw-button>
+    </adw-box>
+    ```
+    Attributes: `orientation` ('vertical'/'horizontal'), `spacing`, `align`, `justify`, `fill-children`.
+-   **JS Factory:** `Adw.createBox(options = {})`
+    - `options`: `orientation`, `align`, `justify`, `spacing`, `fillChildren`, `children`.
 
-### `Adw.createBox(options = {})`
+### List Boxes (`<adw-list-box>` / `Adw.createListBox()`) & Rows
 
-Creates a flexbox container.
+Creates a list box container. Rows are typically children.
 
-- **`options`**: `object`
-  - `orientation`: `"vertical"` or `"horizontal"` (default).
-  - `align`: `"start"`, `"center"`, `"end"`, `"stretch"`.
-  - `justify`: `"start"`, `"center"`, `"end"`, `"between"`, etc.
-  - `spacing`: `"xs"`, `"s"`, `"m"`, `"l"`, `"xl"` - applies gap.
-  - `fillChildren`: `boolean` - If true, children flex-grow.
-  - `children`: `HTMLElement[]` - Child elements.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-list-box selectable>
+      <adw-row interactive>
+        <adw-label>Setting 1</adw-label>
+      </adw-row>
+      <adw-action-row title="Open Settings" subtitle="Configure preferences"></adw-action-row>
+    </adw-list-box>
+    ```
+    Attributes for `<adw-list-box>`: `flat` (removes outer border), `selectable`.
+    See specialized row components below.
+-   **JS Factory:** `Adw.createListBox(options = {})`
+    - `options`: `children` (HTMLElement[], typically created rows), `isFlat`, `selectable`.
+    **JS Factory for basic `<adw-row>`:** `Adw.createRow(options = {})`
+    - `options`: `children`, `activated`, `interactive`, `onClick`.
 
-  ```javascript
-  const buttonBox = Adw.createBox({
-    spacing: "s",
-    children: [Adw.createButton("OK"), Adw.createButton("Cancel")],
-  });
-  ```
-
-### `Adw.createRow(options = {})`
-
-Creates a row element, often used within `AdwListBox` or vertical `AdwBox`.
-
-- **`options`**: `object`
-  - `children`: `HTMLElement[]` - Child elements.
-  - `activated`: `boolean` - If true, applies 'activated' style.
-  - `interactive`: `boolean` - If true, applies hover styles and makes row focusable if `onClick` is present.
-  - `onClick`: `function` - Click handler.
-- **Example:** See `AdwListBox`.
-
-### `Adw.createListBox(options = {})`
-
-Creates a list box container.
-
-- **`options`**: `object`
-  - `children`: `HTMLElement[]` - Child elements, typically `Adw.createRow()`.
-  - `isFlat`: `boolean` - If true, removes outer border.
-  - `selectable`: `boolean` - Adds ARIA role="listbox".
-- **Example:**
-
-  ```javascript
-  const row1 = Adw.createRow({
-    interactive: true,
-    children: [Adw.createLabel("Setting 1")],
-  });
-  const listBox = Adw.createListBox({ children: [row1], selectable: true });
-  ```
-
-### `Adw.createProgressBar(options = {})`
+### Progress Bars (`<adw-progress-bar>` / `Adw.createProgressBar()`)
 
 Creates a progress bar.
 
-- **`options`**: `object`
-  - `value`: `number` (0-100) - Current progress.
-  - `isIndeterminate`: `boolean` - If true, shows an animated indeterminate state.
-  - `disabled`: `boolean` - Applies disabled style.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-progress-bar value="50"></adw-progress-bar>
+    <adw-progress-bar indeterminate></adw-progress-bar>
+    ```
+    Attributes: `value` (0-100), `indeterminate`, `disabled`.
+-   **JS Factory:** `Adw.createProgressBar(options = {})`
+    - `options`: `value`, `isIndeterminate`, `disabled`.
 
+### Checkboxes & Radio Buttons (`<adw-checkbox>`, `<adw-radio-button>` / `Adw.createCheckbox()`, `Adw.createRadioButton()`)
+
+-   **HTML Example:**
+    ```html
+    <adw-checkbox label="I agree" checked></adw-checkbox>
+    <adw-radio-button label="Option 1" name="group1" checked></adw-radio-button>
+    <adw-radio-button label="Option 2" name="group1"></adw-radio-button>
+    ```
+    Attributes: `label`, `checked`, `disabled`, `name` (required for radio).
+-   **JS Factory:** `Adw.createCheckbox(options = {})`, `Adw.createRadioButton(options = {})`
+    - `options`: `label`, `checked`, `onChanged`, `disabled`, `name`.
+
+### Dialogs (`<adw-dialog>` / `Adw.createDialog()`)
+
+Creates a modal dialog. Declarative dialogs are defined in HTML and opened/closed via JavaScript.
+
+-   **HTML Example (Declarative Dialog):**
+    ```html
+    <adw-button id="open-my-dialog">Open Dialog</adw-button>
+
+    <adw-dialog id="my-sample-dialog" title="Confirm Action">
+      <div slot="content">Are you sure you want to proceed?</div>
+      <adw-button slot="buttons" data-action="confirm" suggested>Confirm</adw-button>
+      <adw-button slot="buttons" data-action="cancel">Cancel</adw-button>
+    </adw-dialog>
+
+    <script>
+      const dialog = document.getElementById('my-sample-dialog');
+      document.getElementById('open-my-dialog').addEventListener('click', () => dialog.open());
+      dialog.addEventListener('click', (event) => { // Example: handle button clicks
+        const action = event.target.closest('[data-action]')?.dataset.action;
+        if (action === 'confirm' || action === 'cancel') dialog.close();
+      });
+    </script>
+    ```
+    Attributes for `<adw-dialog>`: `title`, `open`, `close-on-backdrop-click`. Content and buttons are slotted.
+-   **JS Factory (Imperative Dialog):** `Adw.createDialog(options = {})`
+    - `options`: `title`, `content` (HTMLElement/string), `buttons` (HTMLElement[]), `onClose`, `closeOnBackdropClick`.
+    - Returns: `{ dialog, open, close }`. Useful for quick, dynamic dialogs.
+    - **Specialized Dialog Factories:** `Adw.createAlertDialog()`, `Adw.createAboutDialog()`, `Adw.createPreferencesDialog()` are also available for common dialog patterns.
+
+### Toasts (`Adw.createToast()`)
+
+Shows a temporary toast notification. This is an imperative-only component.
+
+- **`Adw.createToast(text, options = {})`**
+  - `text`: `string` - Message to display.
+  - `options`: `object`
+    - `button`: `HTMLElement` - Optional button in the toast.
+    - `timeout`: `number` (ms) - Duration. 0 for persistent (default: 4000ms).
+    - `type`: `string` ('info', 'success', 'warning', 'error') - Styles the toast.
+- **Example:**
   ```javascript
-  const progress = Adw.createProgressBar({ value: 50 });
-  const loadingBar = Adw.createProgressBar({ isIndeterminate: true });
+  Adw.createToast("File saved successfully.", { type: 'success' });
   ```
 
-### `Adw.createCheckbox(options = {})` / `Adw.createRadioButton(options = {})`
+### ViewSwitchers (`<adw-view-switcher>` / `Adw.createViewSwitcher()`)
 
-Creates a checkbox or radio button.
+Creates a view switcher with a button bar to toggle between different content views.
 
-- **`options`**: `object`
-  - `label`: `string` - Text label.
-  - `checked`: `boolean` - Initial state.
-  - `onChanged`: `function` - Callback for state changes.
-  - `disabled`: `boolean` - Disables the control.
-  - `name`: `string` - **Required for RadioButton** to group them.
-- **Example:**
+-   **HTML Example:**
+    ```html
+    <adw-view-switcher active-view-name="view1">
+      <adw-view name="view1" title="View One">
+        <p>Content for View One</p>
+      </adw-view>
+      <adw-view name="view2" title="View Two">
+        <p>Content for View Two</p>
+      </adw-view>
+    </adw-view-switcher>
+    ```
+    `<adw-view>` children define the views. Attributes for `<adw-view-switcher>`: `active-view-name`, `label`, `is-inline`. Attributes for `<adw-view>`: `name`, `title`.
+-   **JS Factory:** `Adw.createViewSwitcher(options = {})`
+    - `options`: `views` (Array of `{name, title, content}`), `activeViewName`, `onViewChanged`, `label`, `isInline`.
 
-  ```javascript
-  const termsCheck = Adw.createCheckbox({
-    label: "I agree",
-    onChanged: (e) => console.log(e.target.checked),
-  });
-  const option1 = Adw.createRadioButton({ label: "Option 1", name: "group1" });
-  ```
+### Avatars (`<adw-avatar>` / `Adw.createAvatar()`)
 
-### `Adw.createDialog(options = {})`
+Displays an image, text initials, or custom content as an avatar.
 
-Creates a modal dialog.
+-   **HTML Example:**
+    ```html
+    <adw-avatar text="Jules Verne" size="64"></adw-avatar>
+    <adw-avatar image="path/to/image.png" size="48"></adw-avatar>
+    <adw-avatar icon="<svg>...</svg>" shape="rounded"></adw-avatar>
+    ```
+    Attributes: `text`, `image`, `icon`, `size`, `shape` ('circular'/'rounded').
+-   **JS Factory:** `Adw.createAvatar(options = {})`
+    - `options`: `text`, `imageSrc` (maps to `image`), `iconHTML` (maps to `icon`), `size`, `shape`.
 
-- **`options`**: `object`
-  - `title`: `string` - Dialog title.
-  - `content`: `HTMLElement` or `string` - Main content.
-  - `buttons`: `HTMLElement[]` - Array of buttons for the dialog footer.
-  - `onClose`: `function` - Callback when dialog is closed.
-  - `closeOnBackdropClick`: `boolean` (default: `true`).
-- **Returns**: `object` `{ dialog, open, close }`
-- **Example:**
+### Flaps (`<adw-flap>` / `Adw.createFlap()`)
 
-  ```javascript
-  const myDialog = Adw.createDialog({
-    title: "Confirm Action",
-    content: Adw.createLabel("Are you sure you want to proceed?"),
-    buttons: [
-      Adw.createButton("Confirm", {
-        suggested: true,
-        onClick: () => myDialog.close(),
-      }),
-      Adw.createButton("Cancel", { onClick: () => myDialog.close() }),
-    ],
-  });
-  // myDialog.open();
-  ```
+Creates a two-pane layout with a collapsible "flap" panel.
 
-### `Adw.createToast(text, options = {})`
-
-Shows a temporary toast notification.
-
-- **`text`**: `string` - Message to display.
-- **`options`**: `object`
-  - `button`: `HTMLElement` - Optional button in the toast.
-  - `timeout`: `number` (ms) - Duration. 0 for persistent (default: 4000ms).
-- **Example:**
-
-  ```javascript
-  // Adw.createToast("File saved successfully.", {
-  //   button: Adw.createButton("Undo", { flat: true })
-  // });
-  ```
-
-### `Adw.createViewSwitcher(options = {})`
-
-Creates a view switcher with a button bar and content area.
-
-- **`options`**: `object`
-  - `views`: `Array<{name: string, content: HTMLElement|string}>` - Array of view objects.
-    - `name`: Text for the button.
-    - `content`: DOM element or HTML string for the view.
-  - `activeViewName`: `string` - Name of the initially active view.
-  - `onViewChanged`: `function(viewName)` - Callback when view changes.
-- **Returns**: `HTMLElement` with a `setActiveView(viewName)` method. Active button uses accent color.
-- **Example:**
-
-  ```javascript
-  const viewSwitcher = Adw.createViewSwitcher({
-    views: [
-      { name: "Home", content: Adw.createLabel("Welcome Home!") },
-      {
-        name: "Settings",
-        content: Adw.createLabel("Configure your settings."),
-      },
-    ],
-    activeViewName: "Home",
-  });
-  // viewSwitcher.setActiveView("Settings");
-  ```
-
-### `Adw.createAvatar(options = {})`
-
-Displays an image, text initials, or custom content as a circular avatar.
-
-- **`options`**: `object`
-  - `size` (number, default: 48): Diameter of the avatar in pixels.
-  - `imageSrc` (string): URL for the avatar image.
-  - `text` (string): Fallback text used to generate initials if no image or if image fails to load. Also used for default alt text.
-  - `customFallback` (HTMLElement): A custom DOM element to display as fallback.
-  - `alt` (string): Alt text for the image.
-- **Example:**
-
-  ```javascript
-  const avatar1 = Adw.createAvatar({ text: "Jules Verne", size: 64 });
-  const avatar2 = Adw.createAvatar({
-    imageSrc: "path/to/image.png",
-    text: "User Name",
-    size: 48,
-  });
-  ```
-
-### `Adw.createFlap(options = {})`
-
-Creates a two-pane layout with a collapsible "flap".
-
-- **`options`**: `object`
-  - `flapContent`: `HTMLElement` - Content for the collapsible flap panel.
-  - `mainContent`: `HTMLElement` - Content for the main panel.
-  - `isFolded`: `boolean` - Initial folded state (default: `false`).
-  - `flapWidth`: `string` - Custom CSS width for the flap (e.g., "300px").
-  - `transitionSpeed`: `string` - Custom CSS transition speed (e.g., "0.3s").
-- **Returns**: `object` `{ element, toggleFlap, isFolded, setFolded }`
-- **Example:**
-
-  ```javascript
-  const flap = Adw.createFlap({
-    flapContent: Adw.createLabel("This is the flap!"),
-    mainContent: Adw.createLabel("This is the main content area."),
-    isFolded: true,
-  });
-  // const toggleFlapButton = Adw.createButton("Toggle Flap", { onClick: () => flap.toggleFlap() });
-  // document.body.appendChild(toggleFlapButton);
-  // document.body.appendChild(flap.element);
+-   **HTML Example:**
+    ```html
+    <adw-button id="toggle-my-flap">Toggle Flap</adw-button>
+    <adw-flap id="my-flap">
+      <div slot="flap-content">Flap Panel Content</div>
+      <div slot="main-content">Main Area Content</div>
+    </adw-flap>
+    <script>
+      document.getElementById('toggle-my-flap').addEventListener('click', () => {
+        document.getElementById('my-flap').toggle();
+      });
+    </script>
+    ```
+    Attributes: `folded`, `reveal-duration`, `sidebar-position` ('start'/'end'), `swipe-to-open`, `swipe-to-close`. Content is slotted.
+-   **JS Factory:** `Adw.createFlap(options = {})`
+    - `options`: `flapContent`, `mainContent`, `isFolded` (maps to `folded`), etc.
+    - Returns `{ element, toggleFlap, isFolded, setFolded }`.
   ```
 
 ### Specialized ListBox Rows

--- a/index.html
+++ b/index.html
@@ -55,8 +55,294 @@
             <!-- Other widget sections will be converted progressively -->
             <!-- For now, the rest of the script that generates UI via JS factories will be kept, -->
             <!-- but it will append to this .main-content-area instead of a dynamically created window. -->
+
+            <!-- Declarative Labels -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Typography (Declarative)</adw-label>
+                <adw-row>
+                    <adw-label title-level="1">Title 1</adw-label>
+                    <adw-label is-body>This is a standard body text label.</adw-label>
+                </adw-row>
+                 <adw-row>
+                    <adw-label title-level="2">Title 2</adw-label>
+                    <adw-label title-level="3">Title 3</adw-label>
+                </adw-row>
+                <adw-row>
+                    <adw-label title-level="4">Title 4</adw-label>
+                    <adw-label is-caption>This is a caption label.</adw-label>
+                </adw-row>
+                <details>
+                    <summary>Show Label Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-label title-level="1"&gt;Title 1&lt;/adw-label&gt;
+&lt;adw-label is-body&gt;This is a standard body text label.&lt;/adw-label&gt;
+&lt;adw-label is-caption&gt;This is a caption label.&lt;/adw-label&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Progress Bar -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Progress Bars (Declarative)</adw-label>
+                <adw-box orientation="vertical" spacing="s">
+                    <adw-row>
+                        <adw-label>Progress (50%):</adw-label>
+                        <adw-progress-bar value="50"></adw-progress-bar>
+                    </adw-row>
+                    <adw-row>
+                        <adw-label>Indeterminate:</adw-label>
+                        <adw-progress-bar indeterminate></adw-progress-bar>
+                    </adw-row>
+                </adw-box>
+                <details>
+                    <summary>Show Progress Bar Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-progress-bar value="50"&gt;&lt;/adw-progress-bar&gt;
+&lt;adw-progress-bar indeterminate&gt;&lt;/adw-progress-bar&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Checkbox and Radio Buttons -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Controls (Declarative)</adw-label>
+                <adw-box orientation="vertical" spacing="m">
+                    <adw-row>
+                        <adw-checkbox label="Enable Feature (Declarative)" id="declarative-checkbox-event" checked></adw-checkbox>
+                        <adw-checkbox label="Disabled Checkbox" disabled></adw-checkbox>
+                    </adw-row>
+                    <adw-row>
+                        <adw-label>Radio Group:</adw-label>
+                        <adw-radio-button label="Option Alpha" name="declarative-radio-group" checked></adw-radio-button>
+                        <adw-radio-button label="Option Beta" name="declarative-radio-group"></adw-radio-button>
+                        <adw-radio-button label="Option Gamma (Disabled)" name="declarative-radio-group" disabled></adw-radio-button>
+                    </adw-row>
+                </adw-box>
+                <details>
+                    <summary>Show Checkbox/Radio Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-checkbox label="Enable Feature" checked&gt;&lt;/adw-checkbox&gt;
+&lt;adw-radio-button label="Option Alpha" name="radio-group" checked&gt;&lt;/adw-radio-button&gt;
+&lt;adw-radio-button label="Option Beta" name="radio-group"&gt;&lt;/adw-radio-button&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative ListBox -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">List Boxes (Declarative)</adw-label>
+                <adw-list-box selectable>
+                    <adw-row interactive id="declarative-listbox-interactive-row">
+                        <adw-label>List Item 1 (Interactive Declarative)</adw-label>
+                    </adw-row>
+                    <adw-row>
+                        <adw-label>List Item 2 (Not Interactive)</adw-label>
+                        <adw-switch slot="suffix"></adw-switch>
+                    </adw-row>
+                    <adw-action-row title="Declarative Action Row in List" subtitle="From ListBox section" icon="&lt;svg width='16' height='16' viewBox='0 0 16 16'&gt;&lt;path fill='currentColor' d='M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16ZM6.5 4.5a.5.5 0 0 1 1 0V7h2.5a.5.5 0 0 1 0 1H7.5v2.5a.5.5 0 0 1-1 0V8H4a.5.5 0 0 1 0-1h2.5V4.5Z'/&gt;&lt;/svg&gt;"></adw-action-row>
+                </adw-list-box>
+                <details>
+                    <summary>Show ListBox Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-list-box selectable&gt;
+    &lt;adw-row interactive&gt;
+        &lt;adw-label&gt;List Item 1&lt;/adw-label&gt;
+    &lt;/adw-row&gt;
+    &lt;adw-action-row title="Action Row" subtitle="Subtitle"&gt;&lt;/adw-action-row&gt;
+&lt;/adw-list-box&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Banners (Declarative Trigger and Container) -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Banners (Declarative Trigger)</adw-label>
+                <adw-box orientation="vertical" spacing="s" id="declarative-banner-container" style="padding: var(--spacing-s); border: 1px dashed var(--border-color); min-height: 50px;">
+                    <!-- Banners will appear here -->
+                </adw-box>
+                <adw-box orientation="horizontal" spacing="s" style="margin-top: var(--spacing-s);">
+                    <adw-button id="trigger-info-banner-declarative">Show Info Banner</adw-button>
+                    <adw-button id="trigger-error-banner-declarative" destructive>Show Error Banner</adw-button>
+                </adw-box>
+                 <details>
+                    <summary>Show Banner Trigger Code Examples (JS for imperative banner creation)</summary>
+                    <pre><code>
+// HTML for container and trigger button:
+// &lt;adw-box id="my-banner-container" style="min-height: 50px;"&gt;&lt;/adw-box&gt;
+// &lt;adw-button id="show-banner-btn"&gt;Show Banner&lt;/adw-button&gt;
+
+// JavaScript:
+const bannerContainer = document.getElementById('my-banner-container');
+document.getElementById('show-banner-btn').addEventListener('click', () => {
+    Adw.createAdwBanner("This is an informational message.", {
+        type: 'info', // 'info', 'warning', 'error'
+        dismissible: true,
+        container: bannerContainer // Specify the container here
+    });
+});
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Spinners -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Spinners (Declarative)</adw-label>
+                <adw-box orientation="horizontal" spacing="m" style="align-items: center;">
+                    <adw-label>Default Spinner:</adw-label>
+                    <adw-spinner></adw-spinner>
+                    <adw-label>Small Spinner:</adw-label>
+                    <adw-spinner small></adw-spinner>
+                    <adw-label>Large Spinner:</adw-label>
+                    <adw-spinner large></adw-spinner>
+                </adw-box>
+                <details>
+                    <summary>Show Spinner Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-spinner&gt;&lt;/adw-spinner&gt;
+&lt;adw-spinner small&gt;&lt;/adw-spinner&gt;
+&lt;adw-spinner large&gt;&lt;/adw-spinner&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Status Pages -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Status Pages (Declarative)</adw-label>
+                <adw-status-page title="No Items Found" icon="<svg width='48' height='48' viewBox='0 0 24 24'><path fill='currentColor' d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z'/></svg>">
+                    <adw-label slot="description">There are currently no items to display in this section.</adw-label>
+                    <adw-button slot="action" suggested>Add New Item</adw-button>
+                </adw-status-page>
+                <details>
+                    <summary>Show Status Page Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-status-page title="No Items Found" icon="&lt;svg&gt;...&lt;/svg&gt;"&gt;
+    &lt;adw-label slot="description"&gt;There are currently no items to display.&lt;/adw-label&gt;
+    &lt;adw-button slot="action" suggested&gt;Add New Item&lt;/adw-button&gt;
+&lt;/adw-status-page&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Split Buttons -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Split Buttons (Declarative)</adw-label>
+                <adw-box orientation="horizontal" spacing="m" style="align-items: center;">
+                    <adw-split-button action-text="Save" id="declarative-split-btn">
+                        <adw-menu slot="menu">
+                            <adw-menu-item label="Save As..." data-action="save-as"></adw-menu-item>
+                            <adw-menu-item label="Export..." data-action="export"></adw-menu-item>
+                        </adw-menu>
+                    </adw-split-button>
+                    <adw-split-button action-text="Open" icon="<svg width='16' height='16'><path d='M2 3h12v2H2z'/></svg>" id="declarative-split-btn-icon" suggested>
+                         <adw-menu slot="menu">
+                            <adw-menu-item label="Open Recent" data-action="open-recent"></adw-menu-item>
+                        </adw-menu>
+                    </adw-split-button>
+                </adw-box>
+                <details>
+                    <summary>Show Split Button Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-split-button action-text="Save"&gt;
+    &lt;adw-menu slot="menu"&gt;
+        &lt;adw-menu-item label="Save As..."&gt;&lt;/adw-menu-item&gt;
+    &lt;/adw-menu&gt;
+&lt;/adw-split-button&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Avatars -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Avatars (Declarative)</adw-label>
+                <adw-box orientation="horizontal" spacing="m" style="align-items: center;">
+                    <adw-avatar text="Jules Verne" size="32"></adw-avatar>
+                    <adw-avatar image="app-demo/static/img/default_avatar.png" size="48"></adw-avatar>
+                    <adw-avatar text="Ada Lovelace" size="64" shape="rounded"></adw-avatar>
+                     <adw-avatar icon="<svg width='24' height='24' viewBox='0 0 24 24'><path fill='currentColor' d='M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z'/></svg>" size="40"></adw-avatar>
+                </adw-box>
+                <details>
+                    <summary>Show Avatar Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-avatar text="Jules Verne" size="32"&gt;&lt;/adw-avatar&gt;
+&lt;adw-avatar image="path/to/image.png" size="48"&gt;&lt;/adw-avatar&gt;
+&lt;adw-avatar text="Ada L" size="64" shape="rounded"&gt;&lt;/adw-avatar&gt;
+&lt;adw-avatar icon="&lt;svg&gt;...&lt;/svg&gt;" size="40"&gt;&lt;/adw-avatar&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative ViewSwitcher -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">ViewSwitcher (Declarative)</adw-label>
+                <adw-view-switcher id="declarative-view-switcher">
+                    <adw-view name="Page 1" title="Page One">
+                        <adw-box style="padding: var(--spacing-l);">
+                            <adw-label title-level="2">Content for Page One (Declarative)</adw-label>
+                            <adw-button>A button on page 1</adw-button>
+                        </adw-box>
+                    </adw-view>
+                    <adw-view name="Page 2" title="Page Two (Active)" active>
+                         <adw-box style="padding: var(--spacing-l);">
+                            <adw-label title-level="2">Content for Page Two (Declarative)</adw-label>
+                            <adw-entry placeholder="Type something on page 2"></adw-entry>
+                        </adw-box>
+                    </adw-view>
+                    <adw-view name="Page 3" title="Page Three">
+                         <adw-box style="padding: var(--spacing-l);">
+                            <adw-label title-level="2">Content for Page Three (Declarative)</adw-label>
+                        </adw-box>
+                    </adw-view>
+                </adw-view-switcher>
+                <details>
+                    <summary>Show ViewSwitcher Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-view-switcher&gt;
+    &lt;adw-view name="Page1" title="Page One"&gt;
+        &lt;!-- Content for page 1 --&gt;
+    &lt;/adw-view&gt;
+    &lt;adw-view name="Page2" title="Page Two" active&gt;
+        &lt;!-- Content for page 2 --&gt;
+    &lt;/adw-view&gt;
+&lt;/adw-view-switcher&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+            <!-- Declarative Flap -->
+            <section class="widget-showcase">
+                <adw-label title-level="1">Flap (Declarative)</adw-label>
+                <adw-button id="toggle-declarative-flap">Toggle Flap</adw-button>
+                <adw-flap id="declarative-flap-instance" style="border: 1px solid var(--border-color); margin-top: var(--spacing-s);">
+                    <adw-box slot="flap-content" style="padding: var(--spacing-m); background: var(--secondary-bg-color);" min-width="200px">
+                        <adw-label title-level="3">Flap Content</adw-label>
+                        <adw-button>Button in Flap</adw-button>
+                    </adw-box>
+                    <adw-box slot="main-content" style="padding: var(--spacing-m); min-height: 150px;">
+                        <adw-label title-level="3">Main Content Area</adw-label>
+                        <adw-entry placeholder="Entry in main content"></adw-entry>
+                    </adw-box>
+                </adw-flap>
+                 <details>
+                    <summary>Show Flap Code Examples (Declarative)</summary>
+                    <pre><code>
+&lt;adw-button id="toggle-flap-btn"&gt;Toggle Flap&lt;/adw-button&gt;
+&lt;adw-flap id="my-flap"&gt;
+    &lt;div slot="flap-content"&gt;Flap's content here.&lt;/div&gt;
+    &lt;div slot="main-content"&gt;Main content here.&lt;/div&gt;
+&lt;/adw-flap&gt;
+&lt;script&gt;
+    document.getElementById('toggle-flap-btn').addEventListener('click', () => {
+        document.getElementById('my-flap').toggle();
+    });
+&lt;/script&gt;
+                    </code></pre>
+                </details>
+            </section>
+
+
             <div id="legacy-js-factories-content">
-                <!-- JS factories will append their output here -->
+                 <adw-label title-level="1" id="legacy-js-section-title" style="display:none; margin-top: var(--spacing-xl);">Legacy JS Factory Examples</adw-label>
+                <!-- JS factories will append their output here for components NOT YET converted to declarative in this file -->
             </div>
         </div>
     </adw-application-window>
@@ -249,6 +535,50 @@
         // --- Event Listeners for NEW Declarative Sections ---
         document.getElementById('declarative-entry')?.addEventListener('input', (e) => Adw.createToast(`Declarative Entry Input: ${e.target.value}`, {timeout:1000}));
         document.getElementById('declarative-switch-1')?.addEventListener('change', (e) => Adw.createToast(`Declarative Switch 1: ${e.target.checked ? 'ON' : 'OFF'}`));
+        document.getElementById('declarative-checkbox-event')?.addEventListener('change', (e) => Adw.createToast(`Declarative Checkbox: ${e.target.checked ? 'Checked' : 'Unchecked'}`));
+        document.querySelectorAll('adw-radio-button[name="declarative-radio-group"]').forEach(radio => {
+            radio.addEventListener('change', (e) => {
+                if (e.target.checked) {
+                    Adw.createToast(`Declarative Radio selected: ${e.target.label}`);
+                }
+            });
+        });
+        document.getElementById('declarative-listbox-interactive-row')?.addEventListener('click', () => Adw.createToast("Declarative Interactive Row clicked!"));
+
+        // Declarative Banner Triggers
+        const declBannerContainer = document.getElementById('declarative-banner-container');
+        if (declBannerContainer) {
+            document.getElementById('trigger-info-banner-declarative')?.addEventListener('click', () => {
+                Adw.createAdwBanner("This is an informational message (declarative trigger).", { type: 'info', dismissible: true, container: declBannerContainer });
+            });
+            document.getElementById('trigger-error-banner-declarative')?.addEventListener('click', () => {
+                Adw.createAdwBanner("This is an error message (declarative trigger).", { type: 'error', dismissible: true, container: declBannerContainer });
+            });
+        }
+
+        // Declarative Split Button Listeners
+        const declSplitBtn = document.getElementById('declarative-split-btn');
+        declSplitBtn?.addEventListener('action', () => Adw.createToast("Split Button: Save Action clicked!"));
+        declSplitBtn?.addEventListener('menu-action', (e) => Adw.createToast(`Split Button Menu: ${e.detail.label} (${e.detail.action}) clicked!`));
+
+        const declSplitBtnIcon = document.getElementById('declarative-split-btn-icon');
+        declSplitBtnIcon?.addEventListener('action', () => Adw.createToast("Split Button (Icon): Open Action clicked!"));
+        declSplitBtnIcon?.addEventListener('menu-action', (e) => Adw.createToast(`Split Button (Icon) Menu: ${e.detail.label} (${e.detail.action}) clicked!`));
+
+        // Declarative ViewSwitcher Listener
+        document.getElementById('declarative-view-switcher')?.addEventListener('view-changed', (e) => {
+            Adw.createToast(`ViewSwitcher changed to: ${e.detail.title}`);
+        });
+
+        // Declarative Flap Listener
+        const declFlap = document.getElementById('declarative-flap-instance');
+        document.getElementById('toggle-declarative-flap')?.addEventListener('click', () => {
+            if(declFlap) declFlap.toggle();
+        });
+        declFlap?.addEventListener('flap-toggled', (e) => {
+            Adw.createToast(`Flap is now ${e.detail.isOpen ? 'open' : 'closed'}`);
+        });
+
 
         const declDialogInstance = document.getElementById('declarative-dialog-instance');
         document.getElementById('open-declarative-dialog')?.addEventListener('click', () => {
@@ -300,48 +630,16 @@
         }
 
         // --- Components to keep generating via JS factories for now (if not yet converted above) ---
-        // Labels (demonstrative)
-        const label = Adw.createLabel("This is a label (JS Factory)", {isBody: true});
-        const labelTitle1 = Adw.createLabel("Title 1 (JS Factory)", {title: 1});
-        const labelsBox = Adw.createRow({ children: [labelTitle1, label] });
-        const labelCodeSample = `
-// Body Text Label
-const bodyLabel = Adw.createLabel("This is a standard body text label.", {isBody: true});
-// Title Label
-const titleLabel = Adw.createLabel("Title 1", {title: 1});`;
-        const labelCodeDetails = createCodeSampleDetails('Show Label Code Examples (JS Factory)', labelCodeSample);
-
-        // Progress Bar (demonstrative)
-        const progressBar = Adw.createProgressBar({value: 50});
-        const progressBarBox = Adw.createBox({ orientation: 'vertical', spacing: "s", children: [ Adw.createRow({ children: [Adw.createLabel("Progress (50%): "), progressBar]})]});
-        const progressBarCodeSample = `const progressBar = Adw.createProgressBar({ value: 50 });`;
-        const progressBarCodeDetails = createCodeSampleDetails('Show Progress Bar Code Examples (JS Factory)', progressBarCodeSample);
-
-        // Checkbox (demonstrative)
-        const checkbox = Adw.createCheckbox({ label: "Enable Feature (JS)", onChanged: (e) => console.log("Checkbox:", e.target.checked) });
-        const checkBox = Adw.createBox({ orientation: 'horizontal', children: [ Adw.createRow({ children: [checkbox]})]});
-        const checkboxCodeSample = `const checkbox = Adw.createCheckbox({ label: "Enable Feature", onChanged: (e) => console.log("Checkbox state:", e.target.checked) });`;
-        const checkboxCodeDetails = createCodeSampleDetails('Show Checkbox Code Examples (JS Factory)', checkboxCodeSample);
-
-        // Radio Button (demonstrative)
-        const radio1 = Adw.createRadioButton({ label: "Option 1 (JS)", name: "radioGroupJS", checked: true });
-        const radioBox = Adw.createBox({ orientation: 'horizontal', children: [ Adw.createRow({ children: [radio1] })]});
-        const radioButtonCodeSample = `const radio1 = Adw.createRadioButton({ label: "Option A", name: "myRadioGroup", checked: true });`;
-        const radioButtonCodeDetails = createCodeSampleDetails('Show Radio Button Code Examples (JS Factory)', radioButtonCodeSample);
-
-        // ListBox (basic demonstrative)
-        const listBox = Adw.createListBox({ children: [ Adw.createRow({ interactive: true, onClick: () => Adw.createToast("Row 1 Clicked"), children: [Adw.createLabel("List Item 1 (Interactive JS)")] })]});
-        const listBoxContainer = Adw.createBox({ orientation: 'horizontal', spacing: 'm', children: [ Adw.createBox({orientation: 'vertical', spacing: 's', children: [Adw.createLabel("Default ListBox (JS)", {title:4}), listBox]})]});
-        const listBoxCodeSample = `const listBox = Adw.createListBox({ children: [ Adw.createRow({ interactive: true, children: [Adw.createLabel("List Item")] }) ] });`;
-        const listBoxCodeDetails = createCodeSampleDetails('Show ListBox Code Examples (JS Factory)', listBoxCodeSample);
-
         // Banners (imperative, so JS factory is fine)
         const bannersTitle = Adw.createLabel("Banners (JS Factory Triggered)", { title: 1 });
-        const bannerContainer = Adw.createBox({ orientation: 'vertical', spacing: 's', _meta_id: "banner-container-box" });
-        const showInfoBannerButton = Adw.createButton("Show Info Banner (JS)", { onClick: () => { Adw.createAdwBanner("This is an informational message.", { type: 'info', dismissible: true, container: bannerContainer }); }});
-        const bannerButtonsBox = Adw.createBox({ orientation: 'horizontal', spacing: 's', children: [showInfoBannerButton]});
-        const bannerCodeSample = `Adw.createAdwBanner("Message", { type: 'info', container: myContainer });`;
-        const bannerCodeDetails = createCodeSampleDetails('Show Banner Code Examples (JS Factory)', bannerCodeSample);
+        const bannerContainer = Adw.createBox({ orientation: 'vertical', spacing: 's', _meta_id: "banner-container-box" }); // This box itself will be created declaratively now.
+        const showInfoBannerButton = Adw.createButton("Show Info Banner (JS)", { onClick: () => {
+            const container = document.getElementById('declarative-banner-container'); // Target the new declarative container
+            if (container) Adw.createAdwBanner("This is an informational message.", { type: 'info', dismissible: true, container: container });
+            else console.error("Banner container not found for JS-triggered banner.");
+        }});
+        // bannerButtonsBox will be declarative, this JS button will be added to it if needed, or replaced.
+        // For now, let's assume the button to trigger JS banner is also declarative.
 
         // Spinners (imperative is fine, declarative showcase later)
         const spinnersTitle = Adw.createLabel("Spinners (JS Factory)", { title: 1 });
@@ -404,25 +702,29 @@ const titleLabel = Adw.createLabel("Title 1", {title: 1});`;
         const avatarCodeDetails = createCodeSampleDetails('Show Avatar Code Examples (JS Factory)', avatarCodeSample);
 
         // --- Main Content Layout (Legacy JS Factories) ---
-        const legacyContent = Adw.createBox({
-            orientation: 'vertical',
-            spacing: "l",
-            children: [
-                Adw.createLabel("Typography (Legacy JS Factory)", {title:1}), labelsBox, labelCodeDetails,
-                Adw.createLabel("Progress Bars (Legacy JS Factory)", {title:1}), progressBarBox, progressBarCodeDetails,
-                Adw.createLabel("Controls (Legacy JS Factory)", {title:1}), checkBox, checkboxCodeDetails, radioBox, radioButtonCodeDetails,
-                bannersTitle, bannerContainer, bannerButtonsBox, bannerCodeDetails,
-                spinnersTitle, spinnerBox, spinnerCodeDetails,
-                statusPagesTitle, statusPageContainer, statusPageCodeDetails,
-                splitButtonsTitle, splitButtonBox, splitButtonCodeDetails,
-                Adw.createLabel("List Boxes (Legacy JS Factory)", {title:1}), listBoxContainer, listBoxCodeDetails,
-                viewSwitcherTitle, viewSwitcher.element, viewSwitcherCodeDetails,
-                flapTitle, flapExampleBox, flapCodeDetails,
+        const legacyJsSectionTitle = document.getElementById('legacy-js-section-title');
+        const childrenForLegacyContent = [
+                // bannersTitle, bannerContainer, bannerButtonsBox, bannerCodeDetails, // Banner section is now declarative
+                // spinnersTitle, spinnerBox, spinnerCodeDetails, // Now declarative
+                // statusPagesTitle, statusPageContainer, statusPageCodeDetails, // Now declarative
+                // splitButtonsTitle, splitButtonBox, splitButtonCodeDetails, // Now declarative
+                // viewSwitcherTitle, viewSwitcher.element, viewSwitcherCodeDetails, // Now declarative
+                // flapTitle, flapExampleBox, flapCodeDetails, // Now declarative
                 accentPickerTitle, accentPickerBox, accentPickerCodeDetails,
-                avatarTitle, avatarSection, avatarCodeDetails,
-            ],
-        });
-        legacyContentTarget.appendChild(legacyContent);
+                // avatarTitle, avatarSection, avatarCodeDetails, // Now declarative
+        ];
+
+        if (childrenForLegacyContent.length > 0) {
+            if(legacyJsSectionTitle) legacyJsSectionTitle.style.display = 'block'; // Show title if there's content
+            const legacyContentFragment = document.createDocumentFragment();
+            childrenForLegacyContent.forEach(child => {
+                if (child) legacyContentFragment.appendChild(child);
+            });
+            legacyContentTarget.appendChild(legacyContentFragment);
+        } else {
+            if(legacyJsSectionTitle) legacyJsSectionTitle.style.display = 'none'; // Hide title if no legacy content
+        }
+
 
         // --- Custom Element Showcase (Generated by JS, but demonstrates declarative usage in code samples) ---
         const customElementShowcaseTitle = Adw.createLabel("Custom Element Showcase (Declarative Examples)", {title:1});

--- a/js/components/dialog.js
+++ b/js/components/dialog.js
@@ -455,18 +455,66 @@ export function createAdwAboutDialog(options = {}) {
   detailsContent.classList.add('adw-about-dialog-details-content');
   let hasDetails = false;
   // ... (createListSection and its usage from original - needs Adw.createExpanderRow or similar) ...
-  // Assuming Adw.createExpanderRow will be available globally or imported
-  const AdwGlobal = (typeof Adw !== 'undefined') ? Adw : { createExpanderRow: (o) => { let d = document.createElement('div'); if(o.content) d.appendChild(o.content); return d; } };
+  // Refactored to use document.createElement for adw-expander-row
 
+  function createListSection(title, items) {
+    if (!items || items.length === 0) return null;
+    const sectionDiv = document.createElement('div');
+    sectionDiv.classList.add('adw-about-dialog-list-section');
+    const titleEl = document.createElement('h4');
+    titleEl.textContent = title;
+    sectionDiv.appendChild(titleEl);
+    const ul = document.createElement('ul');
+    items.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      ul.appendChild(li);
+    });
+    sectionDiv.appendChild(ul);
+    hasDetails = true; // Mark that details exist
+    return sectionDiv;
+  }
 
-  function createListSection(title, items) { /* ... (same as original) ... */ hasDetails=true; /* ... */ return document.createElement('div');}
   const devList = createListSection("Developers", opts.developers); if (devList) detailsContent.appendChild(devList);
-  // ... (other list sections) ...
-  if (opts.licenseType || opts.licenseText) { /* ... */ hasDetails=true; /* ... */ }
+  const docList = createListSection("Documenters", opts.documenters); if (docList) detailsContent.appendChild(docList);
+  const designerList = createListSection("Designers", opts.designers); if (designerList) detailsContent.appendChild(designerList);
+  const artistList = createListSection("Artists", opts.artists); if (artistList) detailsContent.appendChild(artistList);
+  const translatorList = createListSection("Translators", opts.translators); if (translatorList) detailsContent.appendChild(translatorList);
+
+
+  if (opts.licenseType || opts.licenseText) {
+    const licenseSection = document.createElement('div');
+    licenseSection.classList.add('adw-about-dialog-license-section');
+    if (opts.licenseType) {
+        const licenseTypeEl = document.createElement('h4');
+        licenseTypeEl.textContent = "License"; // Or opts.licenseType as title if preferred
+        licenseSection.appendChild(licenseTypeEl);
+        const licenseP = document.createElement('p');
+        licenseP.textContent = opts.licenseType; // E.g. "GNU GPL v3"
+        licenseSection.appendChild(licenseP);
+    }
+    if (opts.licenseText) {
+        const licenseTextEl = document.createElement('pre');
+        licenseTextEl.classList.add('adw-about-dialog-license-text');
+        licenseTextEl.textContent = opts.licenseText;
+        licenseSection.appendChild(licenseTextEl);
+    }
+    detailsContent.appendChild(licenseSection);
+    hasDetails = true;
+  }
 
 
   if (hasDetails) {
-    const expander = AdwGlobal.createExpanderRow({ title: "Details", content: detailsContent, expanded: false });
+    // const expander = AdwGlobal.createExpanderRow({ title: "Details", content: detailsContent, expanded: false });
+    const expander = document.createElement('adw-expander-row');
+    expander.title = "Details";
+    // expander.subtitle = "View credits and license information"; // Optional subtitle
+    expander.expanded = false; // Default to not expanded
+    // The content of an <adw-expander-row> is typically slotted or added directly.
+    // Since detailsContent is already populated, we can append it.
+    // AdwExpanderRow's implementation needs to handle this, perhaps by looking for a specific slot.
+    // For now, let's assume it appends children to its content area or uses a default slot.
+    expander.appendChild(detailsContent);
     aboutDialogContent.appendChild(expander);
   }
 
@@ -484,27 +532,147 @@ export function createAdwAboutDialog(options = {}) {
 
 export class AdwAboutDialog extends HTMLElement { /* ... (Similar structure to AdwAlertDialog WC) ... */
     static get observedAttributes() { return ['app-name', 'open']; } // Simplified
-    constructor() { super(); this._dialogInstance = null; this._slotObserver = new MutationObserver(() => this._reRenderIfOpen());}
-    connectedCallback() { this._slotObserver.observe(this, { childList: true, subtree: true, characterData:true }); this._render(); if (this.hasAttribute('open')) this.open(); }
-    disconnectedCallback() { this._slotObserver.disconnect(); if (this._dialogInstance) this._dialogInstance.close(); }
-    _reRenderIfOpen() { if (this.hasAttribute('open') && this._dialogInstance) { this._dialogInstance.close(); this._render(); this.open(); } else { this._render(); }}
-    attributeChangedCallback(name, oldValue, newValue) { if (oldValue === newValue) return; if (name === 'open') { if (newValue !== null) this.open(); else this.close(); } else { this._reRenderIfOpen(); }}
-    _gatherOptions() { /* ... (Simplified version from original) ... */
+    constructor() {
+        super();
+        this._dialogInstance = null; // This will hold the dialog factory instance {dialog, backdrop, open, close}
+        this._slotObserver = new MutationObserver(() => this._reRenderIfOpen());
+        // No shadow DOM for modal dialogs. Content is built into a separate dialog structure.
+    }
+
+    connectedCallback() {
+        this._slotObserver.observe(this, { childList: true, subtree: true, characterData: true, attributes: true });
+        // Initial render is deferred to first open() or if 'open' attribute is present.
+        if (this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+        if (this._dialogInstance) {
+            this._dialogInstance.close(); // Ensure cleanup of the factory-created dialog
+        }
+    }
+
+    _reRenderIfOpen() {
+        // If the dialog is open and DOM/attributes change, close, rebuild, and reopen.
+        if (this.hasAttribute('open') && this._dialogInstance) {
+            this._dialogInstance.close(); // Close existing instance
+            this._dialogInstance = null; // Clear it
+            this.open(); // Re-open, which will trigger _buildDialogInstance
+        } else if (!this._dialogInstance && this.hasAttribute('open')) {
+            // If open attribute is set but no instance (e.g. on initial load with open attr)
+            this.open();
+        }
+        // If not open, changes will be picked up on next open() call.
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+        if (name === 'open') {
+            if (newValue !== null) this.open();
+            else this.close();
+        } else {
+            // For other attribute changes, trigger a re-render if the dialog is currently open.
+            this._reRenderIfOpen();
+        }
+    }
+
+    _gatherOptions() {
         const options = {};
-        ['appName', 'appIcon', 'logo', 'version', 'copyright', 'developerName', 'website', 'websiteLabel', 'licenseType', 'comments']
-            .forEach(key => { const attrName = key.replace(/([A-Z])/g, '-$1').toLowerCase(); if (this.hasAttribute(attrName)) options[key] = this.getAttribute(attrName); });
-        // Basic slot support for comments
+        const attributesToGather = [
+            'appName', 'appIcon', 'logo', 'version', 'copyright',
+            'developerName', 'website', 'websiteLabel', 'licenseType', 'comments',
+            // For list sections
+            'developers', 'documenters', 'designers', 'artists', 'translators'
+        ];
+
+        attributesToGather.forEach(key => {
+            const attrName = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+            if (this.hasAttribute(attrName)) {
+                if (['developers', 'documenters', 'designers', 'artists', 'translators'].includes(key)) {
+                    // These are expected to be comma-separated strings
+                    options[key] = this.getAttribute(attrName).split(',').map(s => s.trim()).filter(s => s);
+                } else {
+                    options[key] = this.getAttribute(attrName);
+                }
+            }
+        });
+
+        // Slot support for specific sections
         const commentsSlot = this.querySelector('[slot="comments"]');
-        if (commentsSlot) options.comments = commentsSlot.textContent.trim();
-        else if (!options.comments) {
+        if (commentsSlot) options.comments = commentsSlot.innerHTML; // Use innerHTML to preserve formatting
+        else if (!options.comments) { // Fallback to text content if no slot and no attribute
              const nonSlottedText = Array.from(this.childNodes).filter(node => node.nodeType === Node.TEXT_NODE && node.textContent.trim()).map(node => node.textContent.trim()).join('\n');
             if (nonSlottedText) options.comments = nonSlottedText;
         }
+
+        const licenseTextSlot = this.querySelector('[slot="license-text"]');
+        if (licenseTextSlot) options.licenseText = licenseTextSlot.textContent.trim();
+
+        // Example for slotted developers list (could be extended for others)
+        const developersSlot = this.querySelector('ul[slot="developers"]');
+        if (developersSlot) {
+            options.developers = Array.from(developersSlot.querySelectorAll('li')).map(li => li.textContent.trim());
+        }
+
+
+        // Check for a general "details" slot that might contain pre-formatted sections
+        const detailsSlot = this.querySelector('[slot="details"]');
+        if (detailsSlot) {
+            options.customDetailsContent = detailsSlot.cloneNode(true);
+        }
+
+
         return options;
     }
-    _render() { const options = this._gatherOptions(); this._dialogInstance = createAdwAboutDialog(options); if (this._dialogInstance.dialog) {this._dialogInstance.dialog.addEventListener('close', () => { if(this.hasAttribute('open')) this.removeAttribute('open'); this.dispatchEvent(new CustomEvent('close')); });}}
-    open() { if (!this._dialogInstance) this._render(); this._dialogInstance.open(); if (!this.hasAttribute('open')) this.setAttribute('open', '');}
-    close() { if (this._dialogInstance) this._dialogInstance.close(); }
+
+    _buildDialogInstance() {
+        // This method will now call the refactored createAdwAboutDialog factory.
+        // The factory itself is responsible for creating the dialog DOM using web components where appropriate.
+        const options = this._gatherOptions();
+        this._dialogInstance = createAdwAboutDialog(options);
+
+        // Add event listener to the factory-created dialog's close mechanism
+        // to sync the 'open' attribute of this web component.
+        // This assumes the factory's dialog object has a 'dialog' property which is the actual dialog DOM element,
+        // and that it might emit a 'close' event or the factory's close() method handles it.
+        // For createAdwDialog, the close function is part of the returned object.
+        // We need to ensure the web component's state reflects the factory dialog's state.
+
+        // Hook into the factory's close mechanism.
+        // The factory returns { dialog, backdrop, open, close }. We override its close.
+        const originalFactoryClose = this._dialogInstance.close.bind(this._dialogInstance);
+        this._dialogInstance.close = () => {
+            originalFactoryClose();
+            if (this.hasAttribute('open')) {
+                this.removeAttribute('open'); // Sync attribute
+            }
+            this.dispatchEvent(new CustomEvent('close', {bubbles: true, composed: true}));
+        };
+    }
+
+    open() {
+        if (!this._dialogInstance || !this._dialogInstance.dialog.isConnected) {
+            // If no instance, or if the dialog was closed and removed from DOM, rebuild.
+            this._buildDialogInstance();
+        }
+        this._dialogInstance.open();
+        if (!this.hasAttribute('open')) {
+            this.setAttribute('open', ''); // Sync attribute
+        }
+        this.dispatchEvent(new CustomEvent('open', {bubbles: true, composed: true}));
+    }
+
+    close() {
+        if (this._dialogInstance && this._dialogInstance.dialog.isConnected) {
+            this._dialogInstance.close(); // This will also trigger attribute removal and event
+        } else if (this.hasAttribute('open')) {
+            // If instance is gone but attribute is still there
+            this.removeAttribute('open');
+             this.dispatchEvent(new CustomEvent('close', {bubbles: true, composed: true}));
+        }
+    }
 }
 
 /**
@@ -517,22 +685,42 @@ export function createAdwPreferencesDialog(options = {}) {
   const preferencesDialogContent = document.createElement('div');
   preferencesDialogContent.classList.add('adw-preferences-dialog-content');
 
-  const AdwGlobal = (typeof Adw !== 'undefined') ? Adw : { createViewSwitcher: (o) => document.createElement('div') };
+  // Refactored to use document.createElement for adw-view-switcher
+  // const AdwGlobal = (typeof Adw !== 'undefined') ? Adw : { createViewSwitcher: (o) => document.createElement('div') };
 
+  const pages = opts.pages || [];
 
-  const viewsForSwitcher = (opts.pages || []).map(page => ({
-    name: page.name,
-    content: page.pageElement,
-    buttonOptions: { text: page.title }
-  }));
+  if (pages.length === 0) {
+    const emptyState = document.createElement('p');
+    emptyState.textContent = "No preference pages are available.";
+    emptyState.style.textAlign = 'center';
+    emptyState.style.padding = 'var(--spacing-l)';
+    preferencesDialogContent.appendChild(emptyState);
+  } else {
+    const viewSwitcher = document.createElement('adw-view-switcher');
+    viewSwitcher.setAttribute('label', "Preference Pages"); // For accessibility, though might not be directly visible
 
-  if (viewsForSwitcher.length === 0) { /* ... (empty state) ... */ }
-  else {
-    const viewSwitcher = AdwGlobal.createViewSwitcher({
-      views: viewsForSwitcher,
-      activeViewName: opts.initialPageName || (viewsForSwitcher[0] ? viewsForSwitcher[0].name : undefined),
-      label: "Preference Pages"
+    pages.forEach(pageData => {
+      const view = document.createElement('adw-view');
+      view.setAttribute('name', pageData.name);
+      view.setAttribute('title', pageData.title); // Used by adw-view-switcher for its tabs/buttons
+
+      if (pageData.pageElement instanceof Node) {
+        view.appendChild(pageData.pageElement); // pageData.pageElement is the content for the view
+      } else {
+        console.warn(`AdwPreferencesDialog: pageElement for "${pageData.name}" is not a valid Node.`);
+        const errLabel = document.createElement('adw-label');
+        errLabel.textContent = `Error loading page: ${pageData.title}`;
+        view.appendChild(errLabel);
+      }
+      viewSwitcher.appendChild(view);
     });
+
+    const initialPage = opts.initialPageName || (pages[0] ? pages[0].name : undefined);
+    if (initialPage) {
+        viewSwitcher.setAttribute('active-view-name', initialPage);
+    }
+
     viewSwitcher.classList.add('adw-preferences-dialog-view-switcher');
     preferencesDialogContent.appendChild(viewSwitcher);
   }
@@ -553,34 +741,111 @@ export function createAdwPreferencesDialog(options = {}) {
   return dialog;
 }
 
-export class AdwPreferencesDialog extends HTMLElement { /* ... (Similar structure to AdwAlertDialog WC) ... */
+export class AdwPreferencesDialog extends HTMLElement {
     static get observedAttributes() { return ['title', 'open', 'initial-page-name']; }
-    constructor() { super(); this._dialogInstance = null; this._slotObserver = new MutationObserver(() => this._reRenderIfOpen()); }
-    connectedCallback() { this._slotObserver.observe(this, { childList: true, subtree: false }); this._render(); if (this.hasAttribute('open')) this.open(); }
-    disconnectedCallback() { this._slotObserver.disconnect(); if (this._dialogInstance) this._dialogInstance.close(); }
-    _reRenderIfOpen() { if (this.hasAttribute('open') && this._dialogInstance) { this._dialogInstance.close(); this._render(); this.open(); } else { this._render(); }}
-    attributeChangedCallback(name, oldValue, newValue) { if (oldValue === newValue) return; if (name === 'open') { if (newValue !== null) this.open(); else this.close(); } else { this._reRenderIfOpen(); }}
-    _gatherPages() { /* ... (Similar to AdwTabView WC _gatherPages) ... */
+
+    constructor() {
+        super();
+        this._dialogInstance = null;
+        this._slotObserver = new MutationObserver(() => this._reRenderIfOpen());
+    }
+
+    connectedCallback() {
+        // Observe direct children for <adw-preferences-page> additions/removals
+        this._slotObserver.observe(this, { childList: true, subtree: false });
+        if (this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    disconnectedCallback() {
+        this._slotObserver.disconnect();
+        if (this._dialogInstance) {
+            this._dialogInstance.close();
+        }
+    }
+
+    _reRenderIfOpen() {
+        if (this.hasAttribute('open') && this._dialogInstance) {
+            this._dialogInstance.close();
+            this._dialogInstance = null; // Force rebuild
+            this.open();
+        } else if (!this._dialogInstance && this.hasAttribute('open')) {
+            this.open();
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+        if (name === 'open') {
+            if (newValue !== null) this.open();
+            else this.close();
+        } else {
+            this._reRenderIfOpen();
+        }
+    }
+
+    _gatherPages() {
         const pages = [];
         Array.from(this.children).forEach((child, index) => {
+            // Check if the child is an AdwPreferencesPage element or has the class
             if (child.matches('adw-preferences-page') || child.classList.contains('adw-preferences-page')) {
-                pages.push({ name: child.getAttribute('name') || `page-${index}`, title: child.getAttribute('title') || `Page ${index + 1}`, pageElement: child.cloneNode(true) });
+                // We need to pass the actual element to the factory, not a clone,
+                // if the factory is expected to append it directly.
+                // However, dialogs are often rebuilt. Cloning is safer if the original elements are to be preserved in the light DOM.
+                // The factory was updated to append pageElement directly.
+                pages.push({
+                    name: child.getAttribute('name') || `page-${index}`,
+                    title: child.getAttribute('title') || `Page ${index + 1}`,
+                    pageElement: child // Pass the live element. The factory will use it.
+                });
             }
         });
         return pages;
     }
-    _render() {
+
+    _buildDialogInstance() {
         const pages = this._gatherPages();
-        const options = { title: this.getAttribute('title') || "Preferences", pages: pages, initialPageName: this.getAttribute('initial-page-name') || undefined,
-            onClose: () => { if (this.hasAttribute('open')) this.removeAttribute('open'); this.dispatchEvent(new CustomEvent('close')); }
+        const options = {
+            title: this.getAttribute('title') || "Preferences",
+            pages: pages,
+            initialPageName: this.getAttribute('initial-page-name') || undefined,
+            // onClose handled by wrapping the factory's close method
         };
         this._dialogInstance = createAdwPreferencesDialog(options);
+
+        const originalFactoryClose = this._dialogInstance.close.bind(this._dialogInstance);
+        this._dialogInstance.close = () => {
+            originalFactoryClose();
+            if (this.hasAttribute('open')) {
+                this.removeAttribute('open');
+            }
+            this.dispatchEvent(new CustomEvent('close', {bubbles: true, composed: true}));
+        };
     }
-    open() { if (!this._dialogInstance) this._render(); this._dialogInstance.open(); if (!this.hasAttribute('open')) this.setAttribute('open', '');}
-    close() { if (this._dialogInstance) this._dialogInstance.close(); }
+
+    open() {
+        if (!this._dialogInstance || !this._dialogInstance.dialog.isConnected) {
+             this._buildDialogInstance();
+        }
+        this._dialogInstance.open();
+        if (!this.hasAttribute('open')) {
+            this.setAttribute('open', '');
+        }
+        this.dispatchEvent(new CustomEvent('open', {bubbles: true, composed: true}));
+    }
+
+    close() {
+        if (this._dialogInstance && this._dialogInstance.dialog.isConnected) {
+            this._dialogInstance.close();
+        } else if (this.hasAttribute('open')) {
+            this.removeAttribute('open');
+            this.dispatchEvent(new CustomEvent('close', {bubbles: true, composed: true}));
+        }
+    }
 }
 
-// Define other dialog-related web components if they exist (e.g. AdwAlertDialog, AdwAboutDialog, AdwPreferencesDialog)
+// Define other dialog-related web components if they exist (e.g. AdwAlertDialog)
 // Placeholder for actual Web Component class definitions for these dialogs, similar to AdwDialog.
 // For brevity in this step, only AdwDialog WC is fully fleshed out.
 // The factories are exported and can be used by their respective WCs.


### PR DESCRIPTION
- Modified index.html to use declarative web components instead of JS factories for most UI elements.
- Updated dialog component factories and their web component wrappers to correctly use `document.createElement` for child components (e.g., `adw-expander-row`, `adw-view-switcher`) instead of global Adw factories.
- Reviewed other component self-references; most use their own local factories or direct imports, which is acceptable.
- Verified that the overall structure and theming approach align with Libadwaita principles.
- Updated README.md to emphasize declarative web component usage and provide corresponding examples, while retaining JS factory documentation for imperative scenarios.