### PR TITLE
Fix: Correct JavaScript syntax error in rows.js

### DIFF
--- a/js/components/rows.js
+++ b/js/components/rows.js
@@ -559,6 +559,4 @@ export class AdwButtonRow extends HTMLElement {
     }
 }
 
-// No customElements.define here
-
 [end of js/components/rows.js]


### PR DESCRIPTION
The file js/components/rows.js had a syntax error reported as "missing ] after element list" at the end of the file. This was likely caused by a problematic trailing comment or stray characters.

This commit removes the trailing comment to resolve the syntax error, allowing components.js to load correctly and preventing subsequent "Adw object not found" errors.