### PR TITLE
Fix: Correct syntax error in js/components/rows.js

### DIFF
--- a/js/components/rows.js
+++ b/js/components/rows.js
@@ -558,5 +558,3 @@ export class AdwButtonRow extends HTMLElement {
         containerDiv.style.justifyContent = isCentered ? 'center' : 'flex-end';
     }
 }
-
-[end of js/components/rows.js]


### PR DESCRIPTION
Overwrote js/components/rows.js with a clean version to resolve a persistent syntax error related to an unexpected '[' character reported by the browser's parser. This ensures the file is free of any hidden problematic characters or corruption.