### PR TITLE
feat: Align with Libadwaita review and implement features

### DIFF
--- a/docs/widgets/banner.md
+++ b/docs/widgets/banner.md
@@ -1,0 +1,108 @@
+# Banner
+
+An `AdwBanner` is a prominent message area typically displayed at the top of a view or window, used for important announcements or status messages that require user attention but are not necessarily modal. Adwaita-Web provides `Adw.createBanner()` and the `<adw-banner>` Web Component.
+
+## JavaScript Factory: `Adw.createBanner()`
+
+Creates an Adwaita-styled banner element.
+
+**Signature:**
+
+```javascript
+Adw.createBanner(title, options = {}) -> HTMLElement
+```
+
+**Parameters:**
+
+*   `title` (String): The main text to display in the banner. HTML can be used if `useMarkup` is true.
+*   `options` (Object, optional): Configuration options:
+    *   `useMarkup` (Boolean, optional): If `true`, the `title` string is treated as HTML. Defaults to `false`. **Use with caution and ensure any HTML is sanitized if from user input.**
+    *   `buttonLabel` (String, optional): If provided, a button with this label is added to the banner.
+    *   `onButtonClicked` (Function, optional): A callback function executed when the button is clicked. The banner instance is passed as an argument.
+    *   `type` (String, optional): Sets the visual style of the banner. Common types could be `'info'`, `'warning'`, `'error'`, `'success'`. This usually applies a corresponding CSS class (e.g., `adw-banner-warning`). Defaults to a neutral/info style.
+    *   `id` (String, optional): A specific ID to set on the banner element.
+
+**Returns:**
+
+*   `(HTMLElement)`: The created banner element (typically a `div` with class `adw-banner`).
+
+**Example:**
+
+```html
+<div id="banner-container"></div>
+<script>
+  const container = document.getElementById('banner-container');
+
+  const infoBanner = Adw.createBanner("This is an informational banner.");
+  container.appendChild(infoBanner);
+
+  const actionBanner = Adw.createBanner("Your session will expire soon.", {
+    buttonLabel: "Renew Session",
+    type: "warning",
+    onButtonClicked: (banner) => {
+      console.log("Renew Session clicked!");
+      banner.remove(); // Example: dismiss banner on action
+    }
+  });
+  container.appendChild(actionBanner);
+</script>
+```
+
+## Web Component: `<adw-banner>`
+
+A declarative way to create Adwaita banners.
+
+**HTML Tag:** `<adw-banner>`
+
+**Attributes:**
+
+*   `title` (String, required): The main text for the banner.
+*   `use-markup` (Boolean, optional): If present, treats the `title` as HTML.
+*   `button-label` (String, optional): Label for the action button.
+*   `type` (String, optional): Visual type: `'info'`, `'warning'`, `'error'`, `'success'`.
+
+**Properties:**
+*   `title` (String)
+*   `useMarkup` (Boolean)
+*   `buttonLabel` (String)
+*   `type` (String)
+
+**Events:**
+
+*   `button-clicked`: Fired when the action button (if present) is clicked. `event.detail` might contain the banner instance.
+*   `dismissed`: (Potentially) Fired if the banner has a built-in dismiss mechanism (e.g., a close button, not standard in Libadwaita banners but common in web implementations).
+
+**Slots:**
+*   If the `title` attribute is not used, the default slot can be used for the banner's main content.
+*   A named slot like `slot="action"` could be used for custom action elements instead of just `button-label`. (This would be an enhancement over basic Libadwaita).
+
+**Example:**
+
+```html
+<adw-banner title="Welcome to Adwaita-Web!"></adw-banner>
+
+<adw-banner title="<strong>Update Required!</strong> Your software is out of date."
+            use-markup
+            button-label="Update Now"
+            type="warning">
+</adw-banner>
+
+<adw-banner type="error">
+  <p>Failed to load critical data. Please try again later.</p>
+  <!-- Example of custom content via slot -->
+</adw-banner>
+```
+
+## Styling
+
+*   Primary SCSS: `scss/_banner.scss`
+*   Variables:
+    *   Uses status colors for different types, e.g., `--warning-bg-color` for `type="warning"`.
+    *   General text and button variables.
+*   Banners typically span the full width of their container.
+*   They have distinct background colors based on their `type`.
+*   The action button is usually styled as a suggested or flat button.
+
+---
+Next: [Switch](./switch.md)
+```

--- a/docs/widgets/label.md
+++ b/docs/widgets/label.md
@@ -1,0 +1,107 @@
+# Label
+
+An `AdwLabel` is used to display text. It can be configured for various text behaviors like wrapping, justification, and ellipsization. Adwaita-Web provides `Adw.createLabel()` and the `<adw-label>` Web Component.
+
+## JavaScript Factory: `Adw.createLabel()`
+
+Creates an Adwaita-styled label.
+
+**Signature:**
+
+```javascript
+Adw.createLabel(text, options = {}) -> HTMLLabelElement | HTMLSpanElement
+```
+*(Returns `HTMLLabelElement` if `mnemonicFor` is provided, otherwise `HTMLSpanElement`)*
+
+**Parameters:**
+
+*   `text` (String): The text content of the label.
+*   `options` (Object, optional): Configuration options:
+    *   `mnemonicFor` (String, optional): The ID of an activatable widget that this label is for. If provided, an `<label>` element is created with a `for` attribute, and the first character of the text that can be a mnemonic will be underlined.
+    *   `selectable` (Boolean, optional): If `true`, allows the text to be selected by the user. Defaults to `false`.
+    *   `wrap` (Boolean, optional): If `true`, the text will wrap if it exceeds the available width. Defaults to `false`. CSS `white-space: normal` is applied.
+    *   `lines` (Number, optional): The number of lines to display. If set, and text exceeds this, ellipsization might occur based on `ellipsize` mode (though primarily works with `wrap: true`).
+    *   `justify` (String, optional): Text alignment. Accepts `'left'`, `'center'`, `'right'`, `'fill'`. Defaults to `'left'`. (CSS `text-align`)
+    *   `ellipsize` (String, optional): How to ellipsize text if it overflows. Accepts `'none'`, `'start'`, `'middle'`, `'end'`. Defaults to `'none'`. (CSS `text-overflow`, often requires `overflow: hidden` and `white-space: nowrap` or line-clamping for multi-line)
+    *   `cssClass` (Array<String>, optional): Additional CSS classes to apply to the label element.
+    *   `id` (String, optional): A specific ID to set on the label element.
+
+**Returns:**
+
+*   `(HTMLLabelElement | HTMLSpanElement)`: The created label element.
+
+**Example:**
+
+```html
+<div id="js-label-container" style="width: 200px; border: 1px solid #ccc;"></div>
+<input type="text" id="my-input" />
+<script>
+  const container = document.getElementById('js-label-container');
+
+  const simpleLabel = Adw.createLabel("This is a simple label.");
+  container.appendChild(simpleLabel);
+  container.appendChild(document.createElement('br'));
+
+  const wrappedLabel = Adw.createLabel("This is a longer label that will wrap within its container.", { wrap: true });
+  container.appendChild(wrappedLabel);
+  container.appendChild(document.createElement('br'));
+
+  const selectableLabel = Adw.createLabel("This text is selectable.", { selectable: true });
+  container.appendChild(selectableLabel);
+  container.appendChild(document.createElement('br'));
+
+  const mnemonicLabel = Adw.createLabel("User_name:", { mnemonicFor: "my-input" });
+  // Assuming my-input is an existing input field
+  const inputEl = document.getElementById('my-input');
+  if (inputEl) inputEl.insertAdjacentElement('beforebegin', mnemonicLabel);
+
+</script>
+```
+
+## Web Component: `<adw-label>`
+
+A declarative way to create Adwaita labels.
+
+**HTML Tag:** `<adw-label>`
+
+**Attributes:**
+
+*   `mnemonic-for` (String, optional): The ID of an activatable widget this label is for. Renders as `<label for="...">`.
+*   `selectable` (Boolean, optional): If present, allows text selection.
+*   `wrap` (Boolean, optional): If present, enables text wrapping.
+*   `lines` (Number, optional): Preferred number of lines.
+*   `justify` (String, optional): Text alignment: `'left'`, `'center'`, `'right'`, `'fill'`.
+*   `ellipsize` (String, optional): Ellipsization mode: `'none'`, `'start'`, `'middle'`, `'end'`.
+
+**Properties:**
+*   `text` (String): Gets or sets the text content of the label.
+
+**Slots:**
+
+*   Default slot: For the text content if not set via `text` attribute or property.
+
+**Example:**
+
+```html
+<adw-label>This is a basic label.</adw-label>
+<br/>
+<adw-label selectable wrap style="max-width: 150px; border: 1px solid #eee;">
+  This label is selectable and will wrap if the text is too long to fit.
+</adw-label>
+<br/>
+<label for="input-id">Traditional Label:</label> <input id="input-id" type="text" />
+<br/>
+<adw-label mnemonic-for="input-id">_Mnemonic for Input:</adw-label>
+```
+
+## Styling
+
+*   Primary SCSS: `scss/_label.scss` (or general text styles in `_base.scss`).
+*   Variables used: `--body-font-family`, `--font-size-base`, text colors like `--window-fg-color`.
+*   `selectable` style adds `user-select: text; cursor: text;`.
+*   `wrap` style adds `white-space: normal;` (or `pre-wrap` depending on desired behavior).
+*   `ellipsize` styles can be complex, often involving `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` for single line, or `-webkit-line-clamp` for multi-line.
+*   Mnemonic underlines are typically handled by browser or via JS adding `<u>` tags.
+
+---
+Next: [ListBox](./listbox.md)

--- a/docs/widgets/switch.md
+++ b/docs/widgets/switch.md
@@ -1,0 +1,111 @@
+# Switch
+
+An `AdwSwitch` is a toggle control that allows users to switch between two states, typically "on" and "off" or "active" and "inactive". Adwaita-Web provides `Adw.createSwitch()` and the `<adw-switch>` Web Component.
+
+This component is essential for `AdwSwitchRow`.
+
+## JavaScript Factory: `Adw.createSwitch()`
+
+Creates an Adwaita-styled switch.
+
+**Signature:**
+
+```javascript
+Adw.createSwitch(options = {}) -> HTMLButtonElement (or a custom element wrapper)
+```
+*(Typically, a switch is implemented as a custom element or a styled `button` with `role="switch"`)*
+
+**Parameters:**
+
+*   `options` (Object, optional): Configuration options:
+    *   `active` (Boolean, optional): The initial state of the switch. `true` for on/active, `false` for off/inactive. Defaults to `false`.
+    *   `disabled` (Boolean, optional): If `true`, the switch is non-interactive. Defaults to `false`.
+    *   `onChange` (Function, optional): A callback function executed when the switch's state changes. It receives the new `active` state (boolean) as an argument.
+    *   `id` (String, optional): A specific ID to set on the switch element.
+    *   `cssClass` (Array<String>, optional): Additional CSS classes to apply.
+
+**Returns:**
+
+*   `(HTMLElement)`: The created switch element (e.g., `<adw-switch>` or a styled `button`).
+
+**Example:**
+
+```html
+<div id="js-switch-container" style="display: flex; flex-direction: column; gap: 10px;"></div>
+<script>
+  const container = document.getElementById('js-switch-container');
+
+  const simpleSwitch = Adw.createSwitch({
+    onChange: (isActive) => console.log("Switch 1 state:", isActive)
+  });
+  container.appendChild(simpleSwitch);
+
+  const activeSwitch = Adw.createSwitch({
+    active: true,
+    onChange: (isActive) => console.log("Switch 2 state:", isActive)
+  });
+  container.appendChild(activeSwitch);
+
+  const disabledSwitch = Adw.createSwitch({
+    active: true,
+    disabled: true
+  });
+  container.appendChild(disabledSwitch);
+</script>
+```
+
+## Web Component: `<adw-switch>`
+
+A declarative way to create Adwaita switches.
+
+**HTML Tag:** `<adw-switch>`
+
+**Attributes:**
+
+*   `active` (Boolean, optional): If present, the switch is initially "on". Can be dynamically changed.
+*   `disabled` (Boolean, optional): If present, the switch is non-interactive.
+
+**Properties:**
+*   `active` (Boolean): Gets or sets the state of the switch.
+*   `disabled` (Boolean): Gets or sets the disabled state of the switch.
+
+**Events:**
+
+*   `change`: Fired when the switch state changes. `event.detail` often contains an object like `{ active: true/false }`.
+*   `input`: Similar to `change`, may fire as the user interacts. (Standard for form-like elements)
+
+**Example:**
+
+```html
+<adw-switch></adw-switch> <!-- Off by default -->
+<br/>
+<adw-switch active></adw-switch> <!-- On by default -->
+<br/>
+<adw-switch active disabled></adw-switch> <!-- On and disabled -->
+<br/>
+<adw-switch id="my-dynamic-switch"></adw-switch>
+<script>
+  const mySwitch = document.getElementById('my-dynamic-switch');
+  mySwitch.addEventListener('change', (event) => {
+    console.log('Switch changed:', event.target.active);
+    // Or console.log('Switch changed via event.detail:', event.detail.active);
+  });
+  // To change programmatically:
+  // mySwitch.active = true;
+</script>
+```
+
+## Styling
+
+*   Primary SCSS: `scss/_switch.scss`
+*   Variables:
+    *   `--switch-knob-bg-color`, `--switch-slider-off-bg-color`.
+    *   Uses `--accent-bg-color` for the slider when the switch is active.
+    *   Disabled states use variables like `--switch-knob-disabled-bg-color`, `--switch-slider-disabled-off-bg-color`.
+*   The switch consists of a "slider" (the track) and a "knob" (the movable part).
+*   Visual state changes significantly between active/inactive and enabled/disabled states.
+*   Focus indicators are important for accessibility.
+
+---
+Related: [SwitchRow](./switchrow.md) (uses `AdwSwitch`)
+```

--- a/docs/widgets/toast.md
+++ b/docs/widgets/toast.md
@@ -1,0 +1,113 @@
+# Toast
+
+An `AdwToast` is a small, non-modal notification that appears briefly to provide feedback or information to the user. Toasts are often managed by a central overlay or toast manager. Adwaita-Web provides `Adw.createToast()` for imperative creation and an `<adw-toast>` Web Component (though toasts are often created dynamically).
+
+## JavaScript Factory: `Adw.createToast()`
+
+Creates an Adwaita-styled toast element. This function typically creates the toast element, which then needs to be added to an appropriate toast overlay or container by application code.
+
+**Signature:**
+
+```javascript
+Adw.createToast(title, options = {}) -> HTMLElement
+```
+
+**Parameters:**
+
+*   `title` (String): The main text to display in the toast.
+*   `options` (Object, optional): Configuration options:
+    *   `timeout` (Number, optional): Duration in milliseconds before the toast automatically dismisses. Defaults to `3000` (3 seconds). A value of `0` or negative might mean it persists until an action or manual dismissal.
+    *   `actionName` (String, optional): If provided, an action button with this label is added to the toast.
+    *   `onAction` (Function, optional): A callback function executed when the action button is clicked. The toast instance is passed as an argument.
+    *   `priority` (String, optional): Priority of the toast. Can be `'normal'` or `'high'`. High priority toasts might be styled differently or placed above normal priority ones. Defaults to `'normal'`.
+    *   `id` (String, optional): A specific ID to set on the toast element.
+
+**Returns:**
+
+*   `(HTMLElement)`: The created toast element (typically a `div` with class `adw-toast`).
+
+**Example (Conceptual - requires a toast manager/overlay):**
+
+```html
+<div id="toast-container" style="position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 1500; display: flex; flex-direction: column; gap: 10px;"></div>
+<button id="show-toast-btn">Show Toast</button>
+<button id="show-action-toast-btn">Show Toast with Action</button>
+
+<script>
+  const toastContainer = document.getElementById('toast-container');
+
+  function showToast(toastElement) {
+    toastContainer.appendChild(toastElement);
+    // Basic dismissal logic for example
+    const timeout = parseInt(toastElement.dataset.timeout, 10) || 3000;
+    if (timeout > 0) {
+      setTimeout(() => {
+        toastElement.remove();
+      }, timeout);
+    }
+  }
+
+  document.getElementById('show-toast-btn').addEventListener('click', () => {
+    const myToast = Adw.createToast("File saved successfully!");
+    showToast(myToast);
+  });
+
+  document.getElementById('show-action-toast-btn').addEventListener('click', () => {
+    const actionToast = Adw.createToast("Update available.", {
+      actionName: "Install",
+      timeout: 5000, // 5 seconds
+      onAction: (toast) => {
+        console.log("Install action clicked!");
+        toast.remove(); // Dismiss toast after action
+      }
+    });
+    showToast(actionToast);
+  });
+</script>
+```
+
+## Web Component: `<adw-toast>`
+
+While toasts are often created dynamically via the factory, a web component can be used for declarative scenarios or within other components.
+
+**HTML Tag:** `<adw-toast>`
+
+**Attributes:**
+
+*   `title` (String, required): The main text for the toast.
+*   `timeout` (Number, optional): Duration in milliseconds. Defaults to `3000`.
+*   `action-name` (String, optional): Label for the action button.
+*   `priority` (String, optional): `'normal'` or `'high'`. Defaults to `'normal'`.
+
+**Properties:**
+*   `title` (String)
+*   `timeout` (Number)
+*   `actionName` (String)
+*   `priority` (String)
+
+**Events:**
+
+*   `action-clicked`: Fired when the action button is clicked. `event.detail` might contain the toast instance.
+*   `dismissed`: Fired when the toast is dismissed (either by timeout or interaction).
+
+**Example (Declarative, if part of a static view - less common for toasts):**
+
+```html
+<!-- This toast would need to be managed (shown/hidden) by parent component logic -->
+<adw-toast title="Profile updated" timeout="2000" style="display: none;"></adw-toast>
+```
+*Usage note: `<adw-toast>` elements are typically added and removed from the DOM dynamically by a toast management system rather than being statically placed in HTML and hidden/shown.*
+
+## Styling
+
+*   Primary SCSS: `scss/_toast.scss`
+*   Variables:
+    *   `--toast-bg-color`, `--toast-fg-color` (from `_variables.scss`).
+    *   `--toast-box-shadow`.
+    *   Uses accent colors for the action button if present.
+*   Toasts are usually absolutely positioned within a container at the bottom or top of the viewport.
+*   High priority toasts might have a different background or border color.
+
+---
+Next: [Banner](./banner.md)
+```

--- a/js/components.js
+++ b/js/components.js
@@ -13,6 +13,7 @@ import * as misc from './components/misc.js';
 import * as controls from './components/controls.js';
 import * as views from './components/views.js'; // This includes Tab, Navigation, Toolbar views etc.
 import * as layouts from './components/layouts.js'; // Added import for layouts
+import * as listbox from './components/listbox.js'; // Import AdwListBox
 
 // Theme and Accent functions are in utils, already exported from there.
 // adwGenerateId is also in utils.
@@ -57,6 +58,7 @@ const Adw = {
     createProgressBar: misc.createAdwProgressBar,
     createToast: misc.createAdwToast,
     createBanner: misc.createAdwBanner, // Renamed from createAdwBanner in original global
+    createIcon: misc.createAdwIcon, // Add Icon factory
     // Controls
     createSwitch: controls.createAdwSwitch,
     createCheckbox: controls.createAdwCheckbox,
@@ -72,6 +74,7 @@ const Adw = {
     createWrapBox: layouts.createAdwWrapBox, // Corrected: from layouts.js
     createClamp: layouts.createAdwClamp, // Corrected: from layouts.js
     createBreakpointBin: layouts.createAdwBreakpointBin, // Corrected: from layouts.js
+    createListBox: listbox.createAdwListBox, // Add ListBox factory
     createViewSwitcher: views.createAdwViewSwitcher,
     createToolbarView: views.createAdwToolbarView,
     createCarousel: views.createAdwCarousel, // Renamed createAdwCarousel to createCarousel
@@ -109,6 +112,7 @@ const Adw = {
     ProgressBar: misc.AdwProgressBar,
     Toast: misc.AdwToast, // Web component might not be necessary if always imperative
     Banner: misc.AdwBanner, // Web component might not be necessary
+    Icon: misc.AdwIcon, // Add Icon Web Component Class
     PreferencesView: misc.AdwPreferencesView,
     PreferencesPage: misc.AdwPreferencesPage,
     PreferencesGroup: misc.AdwPreferencesGroup,
@@ -126,6 +130,7 @@ const Adw = {
     WrapBox: layouts.AdwWrapBox,
     Clamp: layouts.AdwClamp,
     BreakpointBin: layouts.AdwBreakpointBin,
+    ListBox: listbox.AdwListBox, // Add ListBox Web Component Class
     // Views from views.js
     ViewSwitcher: views.AdwViewSwitcher,
     ToolbarView: views.AdwToolbarView,
@@ -177,6 +182,7 @@ if (typeof customElements !== 'undefined') {
     if (!customElements.get('adw-preferences-view')) customElements.define('adw-preferences-view', Adw.PreferencesView);
     if (!customElements.get('adw-preferences-page')) customElements.define('adw-preferences-page', Adw.PreferencesPage);
     if (!customElements.get('adw-preferences-group')) customElements.define('adw-preferences-group', Adw.PreferencesGroup);
+    if (!customElements.get('adw-icon')) customElements.define('adw-icon', Adw.Icon); // Register AdwIcon
     // From controls.js
     if (!customElements.get('adw-switch')) customElements.define('adw-switch', Adw.Switch);
     if (!customElements.get('adw-checkbox')) customElements.define('adw-checkbox', Adw.Checkbox);
@@ -192,6 +198,8 @@ if (typeof customElements !== 'undefined') {
     if (!customElements.get('adw-wrap-box')) customElements.define('adw-wrap-box', Adw.WrapBox);
     if (!customElements.get('adw-clamp')) customElements.define('adw-clamp', Adw.Clamp);
     if (!customElements.get('adw-breakpoint-bin')) customElements.define('adw-breakpoint-bin', Adw.BreakpointBin);
+    // From listbox.js
+    if (!customElements.get('adw-list-box')) customElements.define('adw-list-box', Adw.ListBox);
     // From views.js
     if (!customElements.get('adw-view-switcher')) customElements.define('adw-view-switcher', Adw.ViewSwitcher);
     if (!customElements.get('adw-toolbar-view')) customElements.define('adw-toolbar-view', Adw.ToolbarView);

--- a/js/components/listbox.js
+++ b/js/components/listbox.js
@@ -1,0 +1,162 @@
+/**
+ * AdwListBox Component
+ *
+ * A container for rows, implementing Libadwaita's ListBox patterns.
+ * It can display a list of AdwRow (or row-like) elements, grouped visually.
+ */
+
+import { adwGenerateId } from './utils.js';
+
+const LISTBOX_BASE_CLASS = 'adw-list-box';
+
+/**
+ * Creates an Adwaita-styled listbox container.
+ *
+ * @param {object} options - Configuration options.
+ * @param {Array<HTMLElement>} [options.children] - An array of row elements to populate the listbox.
+ * @param {boolean} [options.isFlat=false] - If true, removes the default box-shadow/card appearance.
+ * @param {boolean} [options.selectable=false] - If true, indicates rows can be selected (sets ARIA role).
+ * @returns {HTMLDivElement} The created <div> element representing the listbox.
+ */
+export function createAdwListBox(options = {}) {
+    const { children = [], isFlat = false, selectable = false } = options;
+
+    const listBox = document.createElement('div');
+    listBox.classList.add(LISTBOX_BASE_CLASS);
+    listBox.id = adwGenerateId(LISTBOX_BASE_CLASS);
+
+    if (isFlat) {
+        listBox.classList.add(`${LISTBOX_BASE_CLASS}-flat`); // SCSS expects a class
+    }
+
+    if (selectable) {
+        listBox.setAttribute('role', 'listbox');
+    }
+
+    children.forEach(child => {
+        if (child instanceof HTMLElement) {
+            listBox.appendChild(child);
+        } else {
+            console.warn('Adw.createListBox: Provided child is not an HTMLElement and will be ignored.', child);
+        }
+    });
+
+    return listBox;
+}
+
+/**
+ * <adw-list-box> Web Component
+ *
+ * A declarative way to create Adwaita listboxes.
+ *
+ * @example
+ * <adw-list-box selectable>
+ *   <adw-action-row title="Appearance"></adw-action-row>
+ *   <adw-entry-row title="Device Name"></adw-entry-row>
+ * </adw-list-box>
+ */
+export class AdwListBox extends HTMLElement {
+    constructor() {
+        super();
+        // No shadow DOM, manages light DOM children (rows) via <slot>
+    }
+
+    static get observedAttributes() {
+        return ['flat', 'selectable'];
+    }
+
+    connectedCallback() {
+        this.classList.add(LISTBOX_BASE_CLASS);
+        if (!this.id) {
+            this.id = adwGenerateId(LISTBOX_BASE_CLASS);
+        }
+
+        // Initial attribute handling
+        this._updateFlat();
+        this._updateSelectable();
+
+        // Ensure a slot exists if not already there (e.g. if created via JS new AdwListBox())
+        // If created declaratively, slot content will be projected automatically.
+        // This is more for robustness if the component is manipulated dynamically.
+        if (!this.querySelector('slot')) {
+            const slot = document.createElement('slot');
+            // Prepending might be better if there's any internal structure later
+            this.appendChild(slot);
+        }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (oldValue === newValue) return;
+        switch (name) {
+            case 'flat':
+                this._updateFlat();
+                break;
+            case 'selectable':
+                this._updateSelectable();
+                break;
+        }
+    }
+
+    _updateFlat() {
+        // The presence of the 'flat' attribute itself drives the styling via CSS attribute selector .adw-list-box[flat]
+        // No class manipulation needed here if SCSS is updated.
+        // Forcing a style recalc or reflecting to a class might be needed if CSS alone isn't enough.
+        // However, the current SCSS uses .adw-list-box.flat, so we'll stick to class for now.
+        if (this.hasAttribute('flat')) {
+            this.classList.add(`${LISTBOX_BASE_CLASS}-flat`);
+        } else {
+            this.classList.remove(`${LISTBOX_BASE_CLASS}-flat`);
+        }
+    }
+
+    _updateSelectable() {
+        if (this.hasAttribute('selectable')) {
+            this.setAttribute('role', 'listbox');
+        } else {
+            this.removeAttribute('role');
+        }
+    }
+
+    /**
+     * Adds a row element to the list box.
+     * @param {HTMLElement} rowElement - The row element to add.
+     */
+    addRow(rowElement) {
+        if (rowElement instanceof HTMLElement) {
+            this.appendChild(rowElement);
+        } else {
+            console.warn('AdwListBox.addRow: Provided element is not an HTMLElement.', rowElement);
+        }
+    }
+
+    /**
+     * Removes a row element from the list box.
+     * @param {HTMLElement} rowElement - The row element to remove.
+     */
+    removeRow(rowElement) {
+        if (rowElement instanceof HTMLElement && rowElement.parentElement === this) {
+            this.removeChild(rowElement);
+        } else {
+            console.warn('AdwListBox.removeRow: Provided element is not a child of this list box or not an HTMLElement.', rowElement);
+        }
+    }
+
+    /**
+     * Gets all row elements in the list box.
+     * This will return all direct children. Specific filtering for `adw-row` etc. could be added if needed.
+     * @returns {HTMLCollection}
+     */
+    getRows() {
+        // If using Shadow DOM and a slot:
+        // const slot = this.shadowRoot.querySelector('slot');
+        // if (slot) {
+        //     return slot.assignedElements();
+        // }
+        // return [];
+
+        // If using Light DOM (as implied by current setup and docs):
+        // Filter out any <slot> elements if they were manually added by connectedCallback,
+        // though typically projected content doesn't make the <slot> element a "row".
+        return Array.from(this.children).filter(el => el.tagName !== 'SLOT');
+    }
+}

--- a/scss/_button.scss
+++ b/scss/_button.scss
@@ -94,15 +94,31 @@
   }
 
   // Icon support within buttons (common in libadwaita)
-  .icon {
+  // Targets the .adw-icon span created by Adw.createIcon
+  > .adw-icon {
     margin-right: var(--spacing-xs);
+    // Icons are typically 16x16 or 1em. Ensure they align well.
+    width: 1em; // Or a fixed size like 16px
+    height: 1em; // Or a fixed size like 16px
+    display: inline-flex; // Helps with alignment
+    align-items: center;
+    justify-content: center;
   }
 
+  // If button has only an icon and no text, remove text-specific padding adjustments
+  // This is tricky without JS, but for circular buttons it's handled.
+  // For non-circular icon-only buttons, the padding might need to be adjusted if text is empty.
+  // Example: .adw-button:not(.circular):has(> .adw-icon:only-child) { padding: var(--spacing-s); }
+
   &.circular { // For icon-only circular buttons
-    padding: var(--spacing-s);
+    padding: var(--spacing-s); // Adjust padding for circular icon buttons
     border-radius: 50%;
-    .icon {
-      margin-right: 0;
+    > .adw-icon {
+      margin-right: 0; // No margin if it's the only child in a circular button
     }
   }
+
+  // When icon is present and there's text, ensure text doesn't hug the icon too much.
+  // The default margin-right on .adw-icon handles this for icon-first.
+  // If icon can be trailing, specific styles would be needed.
 }

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -1,0 +1,22 @@
+// scss/_icon.scss
+@use 'variables';
+
+.adw-icon {
+  display: inline-flex; // Use inline-flex for better alignment control
+  align-items: center;
+  justify-content: center;
+  width: 1em; // Default size, can be overridden by context
+  height: 1em; // Default size, can be overridden by context
+  vertical-align: middle; // Align with surrounding text
+
+  > svg {
+    width: 100%; // SVG should fill the container
+    height: 100%;
+    // fill: currentColor; // Already set by JS, but can be reinforced here if needed
+  }
+
+  &.adw-icon-error {
+    color: var(--destructive-color, red); // Use destructive color for error state
+    font-weight: bold;
+  }
+}

--- a/scss/_listbox.scss
+++ b/scss/_listbox.scss
@@ -12,7 +12,7 @@
     display: flex;
     align-items: center;
     padding: var(--spacing-m);
-    border-bottom: var(--border-width) solid var(--borders-color); // Use theme-aware --borders-color
+    border-bottom: var(--border-width) solid var(--card-shade-color); // Use --card-shade-color for separators
     transition: background-color 0.1s ease-out, color 0.1s ease-out, outline-offset 0.1s ease-out;
     cursor: default; // Default cursor, change if rows are interactive
     outline-offset: -2px; // For focus outline to be inset

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,62 +1,82 @@
 @mixin light-theme {
-  --accent-bg-color: var(--accent-blue-light-bg); // Default accent
-  --accent-fg-color: var(--accent-blue-light-fg); // Default accent
-  --accent-color: var(--accent-blue-standalone); // Default accent - for elements that use a single color for emphasis
-  --accent-bg-hover-color: var(--accent-blue-light-bg-hover);
-  --accent-bg-active-color: var(--accent-blue-light-bg-active);
+  // Default Accent (Blue)
+  --accent-color: #1c71d8; // @accent_color Light
+  --accent-bg-color: #3584e4; // @accent_bg_color Light
+  --accent-fg-color: #ffffff; // @accent_fg_color Light
+  --accent-bg-hover-color: var(--accent-blue-light-bg-hover); // Custom, derived
+  --accent-bg-active-color: var(--accent-blue-light-bg-active); // Custom, derived
 
-  --destructive-bg-color: var(--accent-red-light-bg);
-  --destructive-fg-color: var(--accent-red-light-fg);
-  --destructive-bg-hover-color: var(--accent-red-light-bg-hover);
-  --destructive-bg-active-color: var(--accent-red-light-bg-active);
-  // --destructive-color removed. Use --accent-red-standalone for single emphasis.
+  // Destructive State
+  --destructive-color: #c01c28;         // @destructive_color Light
+  --destructive-bg-color: #e01b24;      // @destructive_bg_color Light
+  --destructive-fg-color: #ffffff;      // @destructive_fg_color Light
+  --destructive-bg-hover-color: var(--accent-red-light-bg-hover); // Custom, derived from red accent
+  --destructive-bg-active-color: var(--accent-red-light-bg-active); // Custom, derived from red accent
 
-  // Status colors using adw-palette variables or official Libadwaita hex values
-  --info-bg-color: var(--adw-blue-1); // #99c1f1
-  --info-fg-color: var(--adw-blue-5); // #1a5fb4
-  // --info-border-color removed.
+  // Success State
+  --success-color: #1b8553;           // @success_color Light
+  --success-bg-color: #2ec27e;        // @success_bg_color Light
+  --success-fg-color: #ffffff;        // @success_fg_color Light
 
-  --success-bg-color: #2ec27e; // Official Libadwaita Light
-  --success-fg-color: #ffffff; // Official Libadwaita Light
-  // --success-border-color removed.
-  // --success-color removed. Use --accent-green-standalone for single emphasis.
+  // Warning State
+  --warning-color: #9c6e03;           // @warning_color Light
+  --warning-bg-color: #e5a50a;        // @warning_bg_color Light
+  --warning-fg-color: rgba(0, 0, 0, 0.8); // @warning_fg_color Light
 
-  --warning-bg-color: #e5a50a; // Official Libadwaita Light
-  --warning-fg-color: rgba(0, 0, 0, 0.8); // Official Libadwaita Light & Dark
-  // --warning-border-color removed.
-  // --warning-color removed. Use --accent-yellow-standalone for single emphasis.
+  // Error State
+  --error-color: #c01c28;             // @error_color Light (same as destructive)
+  --error-bg-color: #e01b24;          // @error_bg_color Light (same as destructive)
+  --error-fg-color: #ffffff;          // @error_fg_color Light (same as destructive)
 
-  --error-bg-color: #e01b24; // Official Libadwaita Light (often same as destructive-bg)
-  --error-fg-color: #ffffff; // Official Libadwaita Light
-  // --error-border-color removed.
-  // --error-color removed. Use --accent-red-standalone for single emphasis.
+  // Info colors (using blue accent as per common practice, though Libadwaita doesn't define specific "info" state colors)
+  --info-color: var(--accent-blue-standalone); // Standalone blue
+  --info-bg-color: var(--accent-blue-light-bg); // Light blue bg
+  --info-fg-color: var(--accent-blue-light-fg); // White fg
 
-  --window-bg-color: #fafafa; // Official Libadwaita Light
-  --window-fg-color: rgba(0, 0, 0, 0.8);
-  --view-bg-color: #ffffff;
-  --view-fg-color: rgba(0, 0, 0, 0.8);
+  // Base UI Colors from Libadwaita 1.5
+  --window-bg-color: #fafafa;                     // @window_bg_color Light
+  --window-fg-color: rgba(0, 0, 0, 0.8);         // @window_fg_color Light
+  --view-bg-color: #ffffff;                       // @view_bg_color Light
+  --view-fg-color: rgba(0, 0, 0, 0.8);           // @view_fg_color Light
 
-  --headerbar-bg-color: #ffffff; // Official Libadwaita Light
-  --headerbar-fg-color: rgba(0, 0, 0, 0.8);
-  --headerbar-border-color: rgba(0, 0, 0, 0.8); // Official: same as fg_color by default
-  --headerbar-backdrop-color: var(--window-bg-color); // Correct: alias of window_bg_color
-  --headerbar-shade-color: rgba(0, 0, 0, 0.12); // Official Libadwaita Light
-  --headerbar-darker-shade-color: rgba(0, 0, 0, 0.12); // Official Libadwaita Light
+  --headerbar-bg-color: #ffffff;                  // @headerbar_bg_color Light
+  --headerbar-fg-color: rgba(0, 0, 0, 0.8);       // @headerbar_fg_color Light
+  --headerbar-border-color: rgba(0, 0, 0, 0.8);   // @headerbar_border_color Light (same as fg)
+  --headerbar-backdrop-color: #fafafa;            // @headerbar_backdrop_color Light (alias of window_bg_color)
+  --headerbar-shade-color: rgba(0, 0, 0, 0.12);   // @headerbar_shade_color Light
+  --headerbar-darker-shade-color: rgba(0, 0, 0, 0.12); // @headerbar_darker_shade_color Light (No specific darker in 1.5, using shade)
 
-  --sidebar-backdrop-color: #f2f2f2; // Official Libadwaita Light
+  --sidebar-bg-color: #ebebeb;                     // @sidebar_bg_color Light
+  --sidebar-fg-color: rgba(0, 0, 0, 0.8);         // @sidebar_fg_color Light
+  --sidebar-backdrop-color: #f2f2f2;              // @sidebar_backdrop_color Light
+  --sidebar-border-color: rgba(0, 0, 0, 0.07);    // @sidebar_border_color Light
+  --sidebar-shade-color: rgba(0, 0, 0, 0.07);     // @sidebar_shade_color Light
 
-  --secondary-sidebar-backdrop-color: #f6f6f6; // Official Libadwaita Light
+  --secondary-sidebar-bg-color: #f3f3f3;          // @secondary_sidebar_bg_color Light
+  --secondary-sidebar-fg-color: rgba(0, 0, 0, 0.8); // @secondary_sidebar_fg_color Light
+  --secondary-sidebar-backdrop-color: #f6f6f6;    // @secondary_sidebar_backdrop_color Light
+  --secondary-sidebar-border-color: rgba(0, 0, 0, 0.07); // @secondary_sidebar_border_color Light
+  --secondary-sidebar-shade-color: rgba(0, 0, 0, 0.07);  // @secondary_sidebar_shade_color Light
 
-  --borders-color: rgba(0, 0, 0, 0.15); // Conceptual mapping for light theme (currentColor is usually dark)
+  --card-bg-color: #ffffff;                       // @card_bg_color Light
+  --card-fg-color: rgba(0, 0, 0, 0.8);           // @card_fg_color Light
+  --card-shade-color: rgba(0, 0, 0, 0.07);        // @card_shade_color Light
 
-  --card-bg-color: #ffffff;
-  --card-fg-color: rgba(0, 0, 0, 0.8);
-  --card-shade-color: rgba(0, 0, 0, 0.07);
+  --popover-bg-color: #ffffff;                    // @popover_bg_color Light
+  --popover-fg-color: rgba(0, 0, 0, 0.8);        // @popover_fg_color Light
+  --popover-shade-color: rgba(0, 0, 0, 0.07);     // @popover_shade_color Light (from 1.4)
 
-  --popover-bg-color: #ffffff;
-  --popover-fg-color: rgba(0, 0, 0, 0.8);
-  --popover-shade-color: rgba(0, 0, 0, 0.07);
+  --dialog-bg-color: #fafafa;                     // @dialog_bg_color Light
+  --dialog-fg-color: rgba(0, 0, 0, 0.8);         // @dialog_fg_color Light
 
+  --thumbnail-bg-color: #ffffff;                  // @thumbnail_bg_color Light
+  --thumbnail-fg-color: rgba(0, 0, 0, 0.8);      // @thumbnail_fg_color Light
+
+  --borders-color: alpha(currentColor, 0.15);     // @borders Light (derived)
+  --shade-color: rgba(0, 0, 0, 0.07);             // @shade_color Light
+  --scrollbar-outline-color: #ffffff;             // @scrollbar_outline_color Light
+
+  // Component-specific, kept from original if not directly covered by Libadwaita general colors
   --button-bg-color: #ebeae9;
   --button-fg-color: rgba(0, 0, 0, 0.8);
   --button-border-color: rgba(0, 0, 0, 0.12);
@@ -67,116 +87,113 @@
   --button-flat-hover-bg-color: rgba(0, 0, 0, 0.05);
   --button-flat-active-bg-color: rgba(0, 0, 0, 0.1);
 
-  --sidebar-bg-color: #ebebeb; // Official Libadwaita Light
-  --sidebar-fg-color: rgba(0,0,0,0.8);
-  --sidebar-border-color: rgba(0,0,0,0.07); // Official Libadwaita Light
-  --sidebar-shade-color: rgba(0, 0, 0, 0.07); // Official Libadwaita Light
-
-  --secondary-sidebar-bg-color: #f3f3f3; // Official Libadwaita Light
-  --secondary-sidebar-fg-color: rgba(0,0,0,0.8);
-  --secondary-sidebar-border-color: rgba(0,0,0,0.07); // Official Libadwaita Light
-  --secondary-sidebar-shade-color: rgba(0, 0, 0, 0.07); // Official Libadwaita Light
-
-  --dialog-bg-color: #fafafa; // Official Libadwaita Light
-  --dialog-fg-color: rgba(0, 0, 0, 0.8);
-
-  --thumbnail-bg-color: #ffffff;
-  --thumbnail-fg-color: rgba(0, 0, 0, 0.8);
-
-  --shade-color: rgba(0, 0, 0, 0.07); // Official Libadwaita Light
-  --scrollbar-outline-color: #ffffff;
   --link-color: var(--accent-bg-color);
-  --link-visited-color: #5a5a5a;
+  --link-visited-color: #5a5a5a; // Keep existing, or use a purple from palette e.g. var(--adw-purple-4)
 
   --progress-bar-track-color: var(--shade-color);
   --progress-bar-fill-color: var(--accent-bg-color);
 
-  // Toast
-  --toast-bg-color: #303030; // Dark grey
+  --toast-bg-color: #303030;
   --toast-fg-color: #ffffff;
   --toast-box-shadow: var(--popover-box-shadow-light);
-  --secondary-text-color: rgba(0,0,0,0.7); // For less important text
+  --secondary-text-color: rgba(0,0,0,0.7);
   --dialog-box-shadow: var(--dialog-box-shadow-light);
   --dialog-backdrop-color: rgba(0, 0, 0, 0.25);
 
-  // List Row states
   --list-row-hover-bg-color: rgba(0,0,0,0.04);
   --list-row-active-bg-color: rgba(0,0,0,0.08);
   --list-row-selected-bg-color: var(--adw-blue-1); // #99c1f1
   --list-row-selected-fg-color: var(--adw-blue-5); // #1a5fb4
   --expander-content-bg-color: rgba(0,0,0,0.03);
 
-  // Entry states
   --entry-disabled-bg-color: rgba(0,0,0,0.04);
   --entry-disabled-border-color: rgba(0,0,0,0.1);
 
-  // Switch states
   --switch-knob-bg-color: #ffffff;
   --switch-slider-off-bg-color: rgba(0,0,0,0.15);
-  --switch-knob-disabled-bg-color: rgba(0,0,0,0.2); // Darker than regular knob on light
+  --switch-knob-disabled-bg-color: rgba(0,0,0,0.2);
   --switch-slider-disabled-off-bg-color: rgba(0,0,0,0.1);
-  // For disabled-on, we'll use accent-color with opacity applied in component
 }
 
 @mixin dark-theme {
-  --accent-bg-color: var(--accent-blue-dark-bg); // Default accent
-  --accent-fg-color: var(--accent-blue-dark-fg); // Default accent
-  --accent-color: var(--accent-blue-dark-standalone); // Default accent - for elements that use a single color for emphasis
-  --accent-bg-hover-color: var(--accent-blue-dark-bg-hover);
-  --accent-bg-active-color: var(--accent-blue-dark-bg-active);
+  // Default Accent (Blue)
+  --accent-color: #78aeed;             // @accent_color Dark
+  --accent-bg-color: #3584e4;          // @accent_bg_color Dark
+  --accent-fg-color: #ffffff;          // @accent_fg_color Dark
+  --accent-bg-hover-color: var(--accent-blue-dark-bg-hover); // Custom, derived
+  --accent-bg-active-color: var(--accent-blue-dark-bg-active); // Custom, derived
 
-  --destructive-bg-color: var(--accent-red-dark-bg);
-  --destructive-fg-color: var(--accent-red-dark-fg);
-  --destructive-bg-hover-color: var(--accent-red-dark-bg-hover);
-  --destructive-bg-active-color: var(--accent-red-dark-bg-active);
-  // --destructive-color removed. Use --accent-red-dark-standalone for single emphasis.
+  // Destructive State
+  --destructive-color: #ff7b63;         // @destructive_color Dark
+  --destructive-bg-color: #c01c28;      // @destructive_bg_color Dark
+  --destructive-fg-color: #ffffff;      // @destructive_fg_color Dark
+  --destructive-bg-hover-color: var(--accent-red-dark-bg-hover); // Custom, derived from red accent
+  --destructive-bg-active-color: var(--accent-red-dark-bg-active); // Custom, derived from red accent
 
-  // Status colors using adw-palette variables or official Libadwaita hex values
-  --info-bg-color: var(--adw-blue-5); // #1a5fb4
-  --info-fg-color: var(--adw-blue-1); // #99c1f1
-  // --info-border-color removed.
+  // Success State
+  --success-color: #8ff0a4;           // @success_color Dark
+  --success-bg-color: #26a269;        // @success_bg_color Dark
+  --success-fg-color: #ffffff;        // @success_fg_color Dark (Note: Libadwaita doc has #ffffff, current has #000000. Using doc.)
 
-  --success-bg-color: #26a269; // Official Libadwaita Dark
-  --success-fg-color: #ffffff; // Official Libadwaita Dark
-  // --success-border-color removed.
-  // --success-color removed. Use --accent-green-dark-standalone for single emphasis.
+  // Warning State
+  --warning-color: #f8e45c;           // @warning_color Dark
+  --warning-bg-color: #cd9309;        // @warning_bg_color Dark
+  --warning-fg-color: rgba(0, 0, 0, 0.8); // @warning_fg_color Dark
 
-  --warning-bg-color: #cd9309; // Official Libadwaita Dark
-  --warning-fg-color: rgba(0,0,0,0.8); // Official Libadwaita Light & Dark
-  // --warning-border-color removed.
-  // --warning-color removed. Use --accent-yellow-dark-standalone for single emphasis.
+  // Error State
+  --error-color: #ff7b63;             // @error_color Dark (same as destructive)
+  --error-bg-color: #c01c28;          // @error_bg_color Dark (same as destructive)
+  --error-fg-color: #ffffff;          // @error_fg_color Dark (same as destructive)
 
-  --error-bg-color: #c01c28; // Official Libadwaita Dark (often same as destructive-bg)
-  --error-fg-color: #ffffff; // Official Libadwaita Dark
-  // --error-border-color removed.
-  // --error-color removed. Use --accent-red-dark-standalone for single emphasis.
+  // Info colors (using blue accent as per common practice)
+  --info-color: var(--accent-blue-dark-standalone);
+  --info-bg-color: var(--accent-blue-dark-bg);
+  --info-fg-color: var(--accent-blue-dark-fg);
 
-  --window-bg-color: #242424; // Official Libadwaita Dark
-  --window-fg-color: #ffffff;
-  --view-bg-color: #1e1e1e; // Official Libadwaita Dark
-  --view-fg-color: #ffffff;
+  // Base UI Colors from Libadwaita 1.5
+  --window-bg-color: #242424;                     // @window_bg_color Dark (Libadwaita 1.7 says #222226, using 1.5 for now)
+  --window-fg-color: #ffffff;                     // @window_fg_color Dark
+  --view-bg-color: #1e1e1e;                       // @view_bg_color Dark
+  --view-fg-color: #ffffff;                       // @view_fg_color Dark
 
-  --headerbar-bg-color: #303030; // Official Libadwaita Dark
-  --headerbar-fg-color: #ffffff;
-  --headerbar-border-color: #ffffff; // Official: same as fg_color by default
-  --headerbar-backdrop-color: var(--window-bg-color); // Correct: alias of window_bg_color
-  --headerbar-shade-color: rgba(0, 0, 0, 0.36); // Official Libadwaita Dark
-  --headerbar-darker-shade-color: rgba(0, 0, 0, 0.9); // Official Libadwaita Dark
+  --headerbar-bg-color: #303030;                  // @headerbar_bg_color Dark
+  --headerbar-fg-color: #ffffff;                  // @headerbar_fg_color Dark
+  --headerbar-border-color: #ffffff;              // @headerbar_border_color Dark (same as fg)
+  --headerbar-backdrop-color: #242424;            // @headerbar_backdrop_color Dark (alias of window_bg_color)
+  --headerbar-shade-color: rgba(0, 0, 0, 0.36);   // @headerbar_shade_color Dark
+  --headerbar-darker-shade-color: rgba(0, 0, 0, 0.9); // @headerbar_darker_shade_color Dark
 
-  --sidebar-backdrop-color: #2a2a2a; // Official Libadwaita Dark
+  --sidebar-bg-color: #303030;                     // @sidebar_bg_color Dark
+  --sidebar-fg-color: #ffffff;                     // @sidebar_fg_color Dark
+  --sidebar-backdrop-color: #2a2a2a;              // @sidebar_backdrop_color Dark
+  --sidebar-border-color: rgba(0, 0, 0, 0.36);    // @sidebar_border_color Dark
+  --sidebar-shade-color: rgba(0, 0, 0, 0.25);     // @sidebar_shade_color Dark
 
-  --secondary-sidebar-backdrop-color: #272727; // Official Libadwaita Dark
+  --secondary-sidebar-bg-color: #2a2a2a;          // @secondary_sidebar_bg_color Dark
+  --secondary-sidebar-fg-color: #ffffff;          // @secondary_sidebar_fg_color Dark
+  --secondary-sidebar-backdrop-color: #272727;    // @secondary_sidebar_backdrop_color Dark
+  --secondary-sidebar-border-color: rgba(0, 0, 0, 0.36); // @secondary_sidebar_border_color Dark
+  --secondary-sidebar-shade-color: rgba(0, 0, 0, 0.25);  // @secondary_sidebar_shade_color Dark
 
-  --borders-color: rgba(255, 255, 255, 0.5); // Conceptual mapping for dark theme (currentColor is usually light)
+  --card-bg-color: rgba(255, 255, 255, 0.08);     // @card_bg_color Dark
+  --card-fg-color: #ffffff;                       // @card_fg_color Dark
+  --card-shade-color: rgba(0, 0, 0, 0.36);        // @card_shade_color Dark
 
-  --card-bg-color: rgba(255, 255, 255, 0.08); // Official Libadwaita Dark
-  --card-fg-color: #ffffff;
-  --card-shade-color: rgba(0, 0, 0, 0.36);
+  --popover-bg-color: #383838;                    // @popover_bg_color Dark
+  --popover-fg-color: #ffffff;                    // @popover_fg_color Dark
+  --popover-shade-color: rgba(0, 0, 0, 0.25);     // @popover_shade_color Dark (from 1.4)
 
-  --popover-bg-color: #383838; // Official Libadwaita Dark
-  --popover-fg-color: #ffffff;
-  --popover-shade-color: rgba(0, 0, 0, 0.25); // Official Libadwaita Dark
+  --dialog-bg-color: #383838;                     // @dialog_bg_color Dark
+  --dialog-fg-color: #ffffff;                     // @dialog_fg_color Dark
 
+  --thumbnail-bg-color: #383838;                  // @thumbnail_bg_color Dark
+  --thumbnail-fg-color: #ffffff;                  // @thumbnail_fg_color Dark
+
+  --borders-color: alpha(currentColor, 0.5);      // @borders Dark (derived, high contrast value)
+  --shade-color: rgba(0, 0, 0, 0.25);             // @shade_color Dark
+  --scrollbar-outline-color: rgba(0, 0, 0, 0.5);  // @scrollbar_outline_color Dark
+
+  // Component-specific, kept from original
   --button-bg-color: #4d4d4d;
   --button-fg-color: #ffffff;
   --button-border-color: rgba(255, 255, 255, 0.07);
@@ -187,55 +204,32 @@
   --button-flat-hover-bg-color: rgba(255, 255, 255, 0.08);
   --button-flat-active-bg-color: rgba(255, 255, 255, 0.12);
 
-  --sidebar-bg-color: #303030; // Official Libadwaita Dark
-  --sidebar-fg-color: #ffffff;
-  --sidebar-border-color: rgba(0,0,0,0.36); // Official Libadwaita Dark
-  --sidebar-shade-color: rgba(0,0,0,0.25); // Official Libadwaita Dark
-
-  --secondary-sidebar-bg-color: #2a2a2a; // Official Libadwaita Dark
-  --secondary-sidebar-fg-color: #ffffff;
-  --secondary-sidebar-border-color: rgba(0,0,0,0.36); // Official Libadwaita Dark
-  --secondary-sidebar-shade-color: rgba(0,0,0,0.25); // Official Libadwaita Dark
-
-  --dialog-bg-color: #383838; // Official Libadwaita Dark
-  --dialog-fg-color: #ffffff;
-
-  --thumbnail-bg-color: #383838; // Official Libadwaita Dark
-  --thumbnail-fg-color: #ffffff;
-
-  --shade-color: rgba(0, 0, 0, 0.25); // Official Libadwaita Dark
-  --scrollbar-outline-color: rgba(0, 0, 0, 0.5);
   --link-color: var(--accent-bg-color);
-  --link-visited-color: #c0c0c0; // Lighter visited link for dark theme
+  --link-visited-color: #c0c0c0; // Keep existing, or use a purple from palette e.g. var(--adw-purple-1)
 
   --progress-bar-track-color: var(--shade-color);
   --progress-bar-fill-color: var(--accent-bg-color);
 
-  // Toast
-  --toast-bg-color: #424242; // Slightly lighter dark grey for dark theme
+  --toast-bg-color: #424242;
   --toast-fg-color: #ffffff;
   --toast-box-shadow: var(--popover-box-shadow-dark);
-  --secondary-text-color: rgba(255,255,255,0.7); // For less important text
+  --secondary-text-color: rgba(255,255,255,0.7);
   --dialog-box-shadow: var(--dialog-box-shadow-dark);
-  --dialog-backdrop-color: rgba(0, 0, 0, 0.4); // Slightly more opaque for dark theme
+  --dialog-backdrop-color: rgba(0, 0, 0, 0.4);
 
-  // List Row states
   --list-row-hover-bg-color: rgba(255,255,255,0.06);
   --list-row-active-bg-color: rgba(255,255,255,0.1);
   --list-row-selected-bg-color: var(--adw-blue-5); // #1a5fb4
   --list-row-selected-fg-color: var(--adw-blue-1); // #99c1f1
   --expander-content-bg-color: rgba(255,255,255,0.03);
 
-  // Entry states
   --entry-disabled-bg-color: rgba(255,255,255,0.04);
   --entry-disabled-border-color: rgba(255,255,255,0.1);
 
-  // Switch states
-  --switch-knob-bg-color: #ffffff; // Remains white in dark theme too
+  --switch-knob-bg-color: #ffffff;
   --switch-slider-off-bg-color: rgba(255,255,255,0.15);
-  --switch-knob-disabled-bg-color: rgba(255,255,255,0.2); // Lighter than regular knob on dark
+  --switch-knob-disabled-bg-color: rgba(255,255,255,0.2);
   --switch-slider-disabled-off-bg-color: rgba(255,255,255,0.1);
-  // For disabled-on, we'll use accent-color with opacity applied in component
 }
 
 // Helper Variables (inspired by libadwaita, but not direct libadwaita variables)
@@ -280,9 +274,6 @@
   --border-color-light: rgba(0, 0, 0, 0.12);
   --border-color-dark: rgba(255, 255, 255, 0.07);
 
-  // Note: --accent-fg-color-rgb was removed as SCSS cannot use CSS variables in rgba() directly.
-  // Direct values (e.g., 255,255,255 for white) should be used in rgba() within component SCSS if needed.
-
   // GNOME Color Palette
   // Blue
   --adw-blue-1: #99c1f1;
@@ -320,12 +311,24 @@
   --adw-purple-3: #9141ac;
   --adw-purple-4: #813d9c;
   --adw-purple-5: #613583;
-  // Brown
+  // Brown (Used for "Slate" request)
   --adw-brown-1: #cdab8f;
   --adw-brown-2: #b5835a;
   --adw-brown-3: #986a44;
   --adw-brown-4: #865e3c;
   --adw-brown-5: #63452c;
+  // Teal (New addition)
+  --adw-teal-1: #66d9cf; // Example, pick from a standard palette if available or generate shades
+  --adw-teal-2: #40bfb3;
+  --adw-teal-3: #29a698;
+  --adw-teal-4: #1f8073;
+  --adw-teal-5: #15594e;
+  // Pink (New addition)
+  --adw-pink-1: #f9aac9; // Example, pick from a standard palette if available or generate shades
+  --adw-pink-2: #f582ae;
+  --adw-pink-3: #f05993;
+  --adw-pink-4: #e83178;
+  --adw-pink-5: #c41a5f;
   // Light (Greys)
   --adw-light-1: #ffffff;
   --adw-light-2: #f6f5f4;
@@ -339,65 +342,109 @@
   --adw-dark-4: #241f31;
   --adw-dark-5: #000000;
 
-  // Darker shades for specific dark theme backgrounds (can be derived or specific)
-  // These were used previously for info/success etc. bg, will review their usage.
-  // For now, keeping them as they might be tuned variations of the main palette.
-  // Commented out lines below are confirmed dead code and removed.
-
-
   // Definitive Accent Color Variables (to be used by JS)
-  // These provide a layer of abstraction. JS sets --accent-bg-color to one of these.
 
-  // Default Blue Accent (matches Libadwaita default)
-  --accent-blue-light-bg: var(--adw-blue-3); // #3584e4
-  --accent-blue-light-fg: var(--adw-light-1); // #ffffff
-  --accent-blue-standalone: #1c71d8; // Official Libadwaita Hex
+  // Default Blue Accent (Matches Libadwaita Default)
+  --accent-blue-light-bg: var(--adw-blue-3);     // #3584e4
+  --accent-blue-light-fg: var(--adw-light-1);     // #ffffff
+  --accent-blue-standalone: var(--adw-blue-4);  // #1c71d8 (Libadwaita @accent_color light)
 
-  --accent-blue-dark-bg: var(--adw-blue-3); // #3584e4
-  --accent-blue-dark-fg: var(--adw-light-1); // #ffffff
-  --accent-blue-dark-standalone: #78aeed; // Official Libadwaita Hex (as per comment analysis)
+  --accent-blue-dark-bg: var(--adw-blue-3);      // #3584e4 (Libadwaita @accent_bg_color dark)
+  --accent-blue-dark-fg: var(--adw-light-1);      // #ffffff (Libadwaita @accent_fg_color dark)
+  --accent-blue-dark-standalone: var(--adw-blue-2); // #78aeed (Libadwaita @accent_color dark uses #78aeed, which is closer to adw-blue-2 #62a0ea or adw-blue-1 #99c1f1. Using adw-blue-2 for now)
+                                                 // Official @accent_color dark is #78aeed.
 
-  // Other Accent Colors
-  --accent-green-light-bg: var(--adw-green-4); // #2ec27e
-  --accent-green-light-fg: var(--adw-light-1); // #ffffff
-  --accent-green-standalone: #1b8553; // Official Libadwaita Hex
+  // Green Accent
+  --accent-green-light-bg: var(--adw-green-4);    // #2ec27e (Libadwaita @success_bg_color light)
+  --accent-green-light-fg: var(--adw-light-1);    // #ffffff
+  --accent-green-standalone: var(--adw-green-5);  // #1b8553 (Libadwaita @success_color light is #1b8553, which is adw-green-5 #26a269. Using adw-green-5)
+                                                 // Official @success_color light is #1b8553.
 
-  --accent-red-light-bg: var(--adw-red-3); // #e01b24
-  --accent-red-light-fg: var(--adw-light-1); // #ffffff
-  --accent-red-standalone: #c01c28; // Official Libadwaita Hex
+  --accent-green-dark-bg: var(--adw-green-5);     // #26a269 (Libadwaita @success_bg_color dark)
+  --accent-green-dark-fg: var(--adw-light-1);     // #ffffff
+  --accent-green-dark-standalone: var(--adw-green-1); // #8ff0a4 (Libadwaita @success_color dark)
 
-  --accent-yellow-light-bg: var(--adw-yellow-5); // #e5a50a
-  --accent-yellow-light-fg: rgba(0,0,0,0.87); // Dark text for yellow
-  --accent-yellow-standalone: #9c6e03; // Official Libadwaita Hex
+  // Red Accent (Used for Destructive actions)
+  --accent-red-light-bg: var(--adw-red-3);        // #e01b24 (Libadwaita @destructive_bg_color light)
+  --accent-red-light-fg: var(--adw-light-1);        // #ffffff
+  --accent-red-standalone: var(--adw-red-4);      // #c01c28 (Libadwaita @destructive_color light)
 
-  --accent-purple-light-bg: var(--adw-purple-3); // #9141ac
-  --accent-purple-light-fg: var(--adw-light-1); // #ffffff
-  --accent-purple-standalone: #813d9c; // Official Libadwaita Hex
+  --accent-red-dark-bg: var(--adw-red-4);         // #c01c28 (Libadwaita @destructive_bg_color dark)
+  --accent-red-dark-fg: var(--adw-light-1);         // #ffffff
+  --accent-red-dark-standalone: var(--adw-red-1);   // #ff7b63 (Libadwaita @destructive_color dark is #ff7b63, closer to adw-red-1 #f66151. Using adw-red-1)
+                                                 // Official @destructive_color dark is #ff7b63
 
-  --accent-orange-light-bg: var(--adw-orange-3); // #ff7800
-  --accent-orange-light-fg: var(--adw-light-1); // #ffffff
-  --accent-orange-standalone: #e66100; // Official Libadwaita Hex
+  // Yellow Accent (Used for Warning states)
+  --accent-yellow-light-bg: var(--adw-yellow-5);  // #e5a50a (Libadwaita @warning_bg_color light)
+  --accent-yellow-light-fg: rgba(0,0,0,0.8);    // Dark text for yellow bg (Libadwaita @warning_fg_color light)
+  --accent-yellow-standalone: var(--adw-yellow-5); // #9c6e03 (Libadwaita @warning_color light is #9c6e03, which is not directly in palette. Closest is adw-yellow-5 #e5a50a, or a darker custom shade. Using adw-yellow-5 for now, but it's lighter than #9c6e03)
+                                                 // Official @warning_color light is #9c6e03. Let's use this directly.
+                                                 // --accent-yellow-standalone: #9c6e03; (Corrected below)
 
-  // Dark Theme Accents
-  --accent-green-dark-bg: var(--adw-green-4); // #2ec27e (Libadwaita uses #26a269 for dark bg - adw-green-5)
-  --accent-green-dark-fg: var(--adw-light-1);   // #ffffff
-  --accent-green-dark-standalone: #8ff0a4; // Official Libadwaita Hex
 
-  --accent-red-dark-bg: var(--adw-red-4); // #c01c28
-  --accent-red-dark-fg: var(--adw-light-1); // #ffffff
-  --accent-red-dark-standalone: #ff7b63; // Official Libadwaita Hex
+  --accent-yellow-dark-bg: var(--adw-yellow-5);   // #cd9309 (Libadwaita @warning_bg_color dark)
+  --accent-yellow-dark-fg: rgba(0,0,0,0.8);     // Dark text (Libadwaita @warning_fg_color dark)
+  --accent-yellow-dark-standalone: var(--adw-yellow-2); // #f8e45c (Libadwaita @warning_color dark)
 
-  --accent-yellow-dark-bg: var(--adw-yellow-5); // #e5a50a (Libadwaita uses #cd9309 for dark bg)
-  --accent-yellow-dark-fg: rgba(0,0,0,0.87);  // Dark text
-  --accent-yellow-dark-standalone: #f8e45c; // Official Libadwaita Hex
+  // Purple Accent
+  --accent-purple-light-bg: var(--adw-purple-3);  // #9141ac
+  --accent-purple-light-fg: var(--adw-light-1);   // #ffffff
+  --accent-purple-standalone: var(--adw-purple-4); // #813d9c (Standalone often one step darker/more saturated)
 
-  --accent-purple-dark-bg: var(--adw-purple-3); // #9141ac
-  --accent-purple-dark-fg: var(--adw-light-1);  // #ffffff
-  --accent-purple-dark-standalone: #dc8add; // Official Libadwaita Hex
+  --accent-purple-dark-bg: var(--adw-purple-3);   // #9141ac (Dark theme often uses same bg as light for vivid accents, or one step darker from palette if available)
+  --accent-purple-dark-fg: var(--adw-light-1);    // #ffffff
+  --accent-purple-dark-standalone: var(--adw-purple-1); // #dc8add (Standalone often one step lighter for dark)
 
-  --accent-orange-dark-bg: var(--adw-orange-3); // #ff7800
-  --accent-orange-dark-fg: var(--adw-light-1);  // #ffffff
-  --accent-orange-dark-standalone: #ffbe6f; // Official Libadwaita Hex
+  // Orange Accent
+  --accent-orange-light-bg: var(--adw-orange-3);  // #ff7800
+  --accent-orange-light-fg: var(--adw-light-1);   // #ffffff (or dark text if contrast is an issue, but white is common)
+  --accent-orange-standalone: var(--adw-orange-4); // #e66100
+
+  --accent-orange-dark-bg: var(--adw-orange-3);   // #ff7800
+  --accent-orange-dark-fg: var(--adw-light-1);
+  --accent-orange-dark-standalone: var(--adw-orange-1); // #ffbe6f
+
+  // Teal Accent (New) - Values chosen based on typical relationships
+  --accent-teal-light-bg: var(--adw-teal-3);
+  --accent-teal-light-fg: var(--adw-light-1);
+  --accent-teal-standalone: var(--adw-teal-4);
+
+  --accent-teal-dark-bg: var(--adw-teal-3);
+  --accent-teal-dark-fg: var(--adw-light-1);
+  --accent-teal-dark-standalone: var(--adw-teal-1);
+
+  // Pink Accent (New) - Values chosen based on typical relationships
+  --accent-pink-light-bg: var(--adw-pink-3);
+  --accent-pink-light-fg: var(--adw-light-1);
+  --accent-pink-standalone: var(--adw-pink-4);
+
+  --accent-pink-dark-bg: var(--adw-pink-3);
+  --accent-pink-dark-fg: var(--adw-light-1);
+  --accent-pink-dark-standalone: var(--adw-pink-1);
+
+  // Brown Accent (for "Slate") - Values chosen based on typical relationships
+  --accent-brown-light-bg: var(--adw-brown-3);    // #986a44
+  --accent-brown-light-fg: var(--adw-light-1);    // #ffffff
+  --accent-brown-standalone: var(--adw-brown-4);  // #865e3c
+
+  --accent-brown-dark-bg: var(--adw-brown-3);     // #986a44
+  --accent-brown-dark-fg: var(--adw-light-1);
+  --accent-brown-dark-standalone: var(--adw-brown-1); // #cdab8f
+
+
+  // Correcting standalone yellow based on direct Libadwaita values
+  --accent-yellow-standalone: #9c6e03; // Official Libadwaita @warning_color Light
+  --accent-yellow-dark-standalone: #f8e45c; // Official Libadwaita @warning_color Dark
+
+  // Correcting standalone blue dark based on direct Libadwaita values
+  --accent-blue-dark-standalone: #78aeed; // Official Libadwaita @accent_color Dark
+
+  // Correcting standalone green light based on direct Libadwaita values
+  --accent-green-standalone: #1b8553; // Official Libadwaita @success_color Light
+
+  // Correcting standalone red dark based on direct Libadwaita values
+  --accent-red-dark-standalone: #ff7b63; // Official Libadwaita @destructive_color Dark
+
 
   // Hover/Active states for default accents (Blue, Red)
   // Light Theme
@@ -422,7 +469,7 @@
   // Explicitly setting default accent here for clarity, matching what's in mixin.
   --accent-bg-color: var(--accent-blue-dark-bg);
   --accent-fg-color: var(--accent-blue-dark-fg);
-  --accent-color: var(--accent-blue-dark-standalone);
+  --accent-color: var(--accent-blue-dark-standalone); // This is the standalone color
 }
 
 body.light-theme {
@@ -432,7 +479,7 @@ body.light-theme {
   // Explicitly setting default accent here for clarity, matching what's in mixin.
   --accent-bg-color: var(--accent-blue-light-bg);
   --accent-fg-color: var(--accent-blue-light-fg);
-  --accent-color: var(--accent-blue-standalone);
+  --accent-color: var(--accent-blue-standalone); // This is the standalone color
 }
 
 // Note on JavaScript interaction for theme loading (loadSavedTheme function):
@@ -452,14 +499,23 @@ body.light-theme {
 // to make colors available to the GTK C API.
 // We'll keep them and map them to our CSS variables.
 @mixin define-gtk-colors() {
+  @define-color accent_color var(--accent-color); // Standalone accent color
   @define-color accent_bg_color var(--accent-bg-color);
   @define-color accent_fg_color var(--accent-fg-color);
+
+  @define-color destructive_color var(--destructive-color); // Standalone destructive
   @define-color destructive_bg_color var(--destructive-bg-color);
   @define-color destructive_fg_color var(--destructive-fg-color);
+
+  @define-color success_color var(--success-color); // Standalone success
   @define-color success_bg_color var(--success-bg-color);
   @define-color success_fg_color var(--success-fg-color);
+
+  @define-color warning_color var(--warning-color); // Standalone warning
   @define-color warning_bg_color var(--warning-bg-color);
   @define-color warning_fg_color var(--warning-fg-color);
+
+  @define-color error_color var(--error-color);     // Standalone error
   @define-color error_bg_color var(--error-bg-color);
   @define-color error_fg_color var(--error-fg-color);
 
@@ -475,10 +531,17 @@ body.light-theme {
   @define-color headerbar_shade_color var(--headerbar-shade-color);
   @define-color headerbar_darker_shade_color var(--headerbar-darker-shade-color);
 
+  @define-color sidebar_bg_color var(--sidebar-bg-color);
+  @define-color sidebar_fg_color var(--sidebar-fg-color);
   @define-color sidebar_backdrop_color var(--sidebar-backdrop-color);
-  @define-color secondary_sidebar_backdrop_color var(--secondary-sidebar-backdrop-color);
+  @define-color sidebar_border_color var(--sidebar-border-color);
+  @define-color sidebar_shade_color var(--sidebar-shade-color);
 
-  @define-color borders_color var(--borders-color);
+  @define-color secondary_sidebar_bg_color var(--secondary-sidebar-bg-color);
+  @define-color secondary_sidebar_fg_color var(--secondary-sidebar-fg-color);
+  @define-color secondary_sidebar_backdrop_color var(--secondary-sidebar-backdrop-color);
+  @define-color secondary_sidebar_border_color var(--secondary-sidebar-border-color);
+  @define-color secondary_sidebar_shade_color var(--secondary-sidebar-shade-color);
 
   @define-color card_bg_color var(--card-bg-color);
   @define-color card_fg_color var(--card-fg-color);
@@ -494,32 +557,11 @@ body.light-theme {
   @define-color thumbnail_bg_color var(--thumbnail-bg-color);
   @define-color thumbnail_fg_color var(--thumbnail-fg-color);
 
-  @define-color sidebar_bg_color var(--sidebar-bg-color);
-  @define-color sidebar_fg_color var(--sidebar-fg-color);
-  @define-color sidebar_border_color var(--sidebar-border-color);
-  @define-color sidebar_shade_color var(--sidebar-shade-color);
-
-  @define-color secondary_sidebar_bg_color var(--secondary-sidebar-bg-color);
-  @define-color secondary_sidebar_fg_color var(--secondary-sidebar-fg-color);
-  @define-color secondary_sidebar_border_color var(--secondary-sidebar-border-color);
-  @define-color secondary_sidebar_shade_color var(--secondary-sidebar-shade-color);
-
+  @define-color borders_color var(--borders-color);
   @define-color shade_color var(--shade-color);
   @define-color scrollbar_outline_color var(--scrollbar-outline-color);
   @define-color progress_bar_track_color var(--progress-bar-track-color);
   @define-color progress_bar_fill_color var(--progress-bar-fill-color);
-  @define-color accent_color var(--accent-color);
-
-  // These are not direct libadwaita CSS variables but often derived or context-specific.
-  // We'll keep the ones that are broadly applicable.
-  // --active-toggle-bg-color & --active-toggle-fg-color are very specific, handle in component SCSS.
-  // --overview-bg-color & --overview-fg-color are specific, handle in component/view SCSS.
-
-  // Oklab derived colors are a more advanced GTK feature for color manipulation.
-  // Libadwaita itself doesn't expose --accent-color directly in its public CSS variables,
-  // it's usually derived by applications if needed.
-  // For now, we will remove the oklab definitions here to keep it simpler and closer
-  // to standard CSS usage. If an application needs oklab, it can define it.
 }
 
 // Z-indexes

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -3,6 +3,7 @@
 // @use "theme"; // Removed as _theme.scss is deleted and its functionality is covered by _variables.scss
 @use "base";
 @use "mixins";
+@use "icon"; // Add icon styles
 @use "action_row";
 @use "avatar";
 @use "banner";


### PR DESCRIPTION
This commit addresses multiple areas from the review:

1.  **Color Palette Alignment:**
    - Updated `scss/_variables.scss` to match Libadwaita 1.5/1.7 named colors.
    - Corrected base UI colors, accent colors (all 9: Blue, Green, Yellow, Orange, Purple, Red, Teal, Pink, Brown/Slate) with bg/fg/standalone versions, and status colors (destructive, success, warning, error) with their specific standalone hexes.

2.  **JavaScript Implementation:**
    - Implemented `AdwListBox` factory (`createAdwListBox`) and web component (`<adw-list-box>`) in `js/components/listbox.js`.
    - Integrated it into the main `Adw` object in `js/components.js`.
    - Ensured SCSS for listbox uses `--card-shade-color` for separators.

3.  **Documentation Updates:**
    - Created missing documentation files: `docs/widgets/label.md`, `docs/widgets/toast.md`, `docs/widgets/banner.md`, `docs/widgets/switch.md`.
    - Updated `AdwListBox` documentation (implicitly, by implementing to its spec and refining SCSS).
    - Resolved inconsistency in `AdwAlertDialog`: JS now correctly handles `<button slot="choice">` as per documentation.

4.  **SVG Icon Integration:**
    - Added `AdwIcon` component (`createAdwIcon` factory and `<adw-icon>` web component) in `js/components/misc.js` for dynamic loading and display of SVG icons from `data/icons/symbolic/`.
    - Icons are cached and styled to use `currentColor` for fills.
    - Integrated `AdwIcon` into `AdwButton` component (factory and web component) via a new `iconName` option / `icon-name` attribute.
    - Added general SCSS for `.adw-icon` in `scss/_icon.scss`.

5.  **Testing and Refinement:**
    - Reviewed all changes for correctness and consistency.
    - Ensured ARIA attributes and basic error handling are in place where appropriate.