### PR TITLE
Refine Adwaita widget styles and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Vanilla JavaScript UI framework that mimics the look and feel of GNOME's GTK4 an
 
 - **Adwaita Styling:** Aims to closely follow the visual style and naming conventions of libadwaita for a consistent GNOME desktop look on the web.
 - **Light and Dark Themes:** Built-in support for both light and dark themes. Includes automatic detection of system preference via `prefers-color-scheme`, manual toggling, and remembers the user's choice via `localStorage`.
-- **Component-Based:** Provides a suite of reusable UI components as JavaScript functions (e.g., Buttons, Entries, Switches, ViewSwitcher, Flap).
+- **Component-Based:** Primarily delivered as [Custom Elements (Web Components)](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for easy declarative use in HTML. Helper JavaScript factory functions are also provided for imperative creation.
 - **CSS Variables:** Extensively uses CSS custom properties (variables) for theming, making customization of colors, fonts, and spacing straightforward, inspired by libadwaita's own variable system.
 - **Accent Colors:** Supports dynamic accent color switching, allowing users to choose from a predefined palette, with preferences saved.
 - **Responsive Design:** Components are designed to be reasonably responsive where applicable.

--- a/docs/widgets/aboutdialog.md
+++ b/docs/widgets/aboutdialog.md
@@ -20,18 +20,26 @@ Adw.createAboutDialog(options = {}) -> { dialog: HTMLDivElement, open: function,
     *   `logo` (String, optional): URL for a larger logo image displayed prominently.
     *   `version` (String, optional): Application version string.
     *   `copyright` (String, optional): Copyright information (e.g., "© 2023 Your Name").
-    *   `developerName` (String | Array<String>, optional): Name(s) of the primary developer(s).
+    *   `developerName` (String | Array<String>, optional): Name(s) of the primary
+        developer(s).
     *   `website` (String, optional): URL of the application's or developer's website.
-    *   `websiteLabel` (String, optional): Custom label for the website link (defaults to the URL itself).
-    *   `licenseType` (String, optional): SPDX license identifier (e.g., "MIT", "GPL-3.0-or-later"). Will attempt to link to spdx.org.
-    *   `licenseText` (String, optional): The full text of the license, if not using a standard SPDX type or for custom licenses. Often displayed in a scrollable area or expander.
-    *   `comments` (String, optional): General comments or a brief description of the application.
+    *   `websiteLabel` (String, optional): Custom label for the website link
+        (defaults to the URL itself).
+    *   `licenseType` (String, optional): SPDX license identifier (e.g., "MIT",
+        "GPL-3.0-or-later"). Will attempt to link to spdx.org.
+    *   `licenseText` (String, optional): The full text of the license, if not
+        using a standard SPDX type or for custom licenses. Often displayed in a
+        scrollable area or expander.
+    *   `comments` (String, optional): General comments or a brief description of the
+        application.
     *   `developers` (Array<String>, optional): List of developers.
     *   `designers` (Array<String>, optional): List of designers.
     *   `documenters` (Array<String>, optional): List of documenters.
     *   `translatorCredits` (String, optional): Credits for translators.
     *   `artists` (Array<String>, optional): List of artists.
-    *   `acknowledgements` (Array<String | Object>, optional): List of acknowledgements. Can be strings or objects like `{title: "Group Name", names: ["Person A", "Library B"]}`.
+    *   `acknowledgements` (Array<String | Object>, optional): List of
+        acknowledgements. Can be strings or objects like
+        `{title: "Group Name", names: ["Person A", "Library B"]}`.
     *   `onClose` (Function, optional): Callback executed when the dialog is closed.
 
 **Returns:**
@@ -56,7 +64,8 @@ Adw.createAboutDialog(options = {}) -> { dialog: HTMLDivElement, open: function,
         developerName: "The Developer Team",
         website: "https://example.com",
         websiteLabel: "Visit our Website",
-        comments: "This application helps you do amazing things with web technologies, styled with Adwaita!",
+        comments: "This application helps you do amazing things with web " +
+                  "technologies, styled with Adwaita!",
         licenseType: "GPL-3.0-or-later",
         // licenseText: "Full license text here if not using SPDX or for custom details...",
         developers: ["Dev A", "Dev B"],
@@ -130,7 +139,8 @@ A declarative way to define Adwaita "About" dialogs.
   website="https://acme.example.com"
   license-type="MIT">
   <!-- Logo via slot -->
-  <img slot="logo" src="app-demo/static/img/default_avatar.png" alt="App Logo" style="width: 64px; height: 64px; border-radius: var(--border-radius-default);">
+  <img slot="logo" src="app-demo/static/img/default_avatar.png" alt="App Logo"
+       style="width: 64px; height: 64px; border-radius: var(--border-radius-default);">
   <!-- Comments via slot -->
   <p slot="comments">
     This is a demonstration of the Adwaita-Web About Dialog using Web Components.

--- a/docs/widgets/actionrow.md
+++ b/docs/widgets/actionrow.md
@@ -16,12 +16,21 @@ Adw.createActionRow(options = {}) -> HTMLDivElement
 
 *   `options` (Object, optional): Configuration options:
     *   `title` (String, required): The main title text of the row.
-    *   `subtitle` (String, optional): Additional descriptive text displayed below the title.
-    *   `iconHTML` (String, optional): HTML string for an SVG icon or an icon font class to be displayed at the start of the row. *Security: Ensure trusted/sanitized HTML if user-supplied.*
-    *   `onClick` (Function, optional): Callback function executed when the row is clicked. Makes the row interactive.
-    *   `showChevron` (Boolean, optional): If `true`, displays a chevron (navigation arrow) at the end of the row, indicating it leads to another view. Defaults to `false` but might be implied if `onClick` is present and it's a navigation action.
-    *   `suffix` (HTMLElement, optional): An element to place at the end of the row, before any chevron (e.g., a switch, a small button, a spinner).
-    *   `disabled` (Boolean, optional): If `true`, disables the row, making it non-interactive and visually muted.
+    *   `subtitle` (String, optional): Additional descriptive text displayed
+        below the title.
+    *   `iconHTML` (String, optional): HTML string for an SVG icon or an icon font
+        class to be displayed at the start of the row. *Security: Ensure
+        trusted/sanitized HTML if user-supplied.*
+    *   `onClick` (Function, optional): Callback function executed when the row is
+        clicked. Makes the row interactive.
+    *   `showChevron` (Boolean, optional): If `true`, displays a chevron (navigation
+        arrow) at the end of the row, indicating it leads to another view.
+        Defaults to `false` but might be implied if `onClick` is present and
+        it's a navigation action.
+    *   `suffix` (HTMLElement, optional): An element to place at the end of the row,
+        before any chevron (e.g., a switch, a small button, a spinner).
+    *   `disabled` (Boolean, optional): If `true`, disables the row, making it
+        non-interactive and visually muted.
 
 **Returns:**
 
@@ -40,7 +49,8 @@ Adw.createActionRow(options = {}) -> HTMLDivElement
   const networkRow = Adw.createActionRow({
     title: "Network",
     subtitle: "Wi-Fi, Ethernet, VPN",
-    iconHTML: '<svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 0C3.582 0 0 3.582 0 8s3.582 8 8 8 8-3.582 8-8-3.582-8-8-8Zm0 1c3.866 0 7 3.134 7 7s-3.134 7-7 7-7-3.134-7-7 3.134-7 7-7Z"/><path d="M7.5 4.5h1v3h-1v-3Zm0 4h1v3h-1v-3Z"/></svg>', // Example icon
+    // Example icon (details omitted for brevity)
+    iconHTML: '<svg viewBox="0 0 16 16"><path d="M8 0C3.582Z"/></svg>',
     showChevron: true,
     onClick: () => Adw.createToast("Navigate to Network Settings")
   });
@@ -77,8 +87,10 @@ A declarative way to define Adwaita action rows.
 
 *   `title` (String, required): The main title text.
 *   `subtitle` (String, optional): Subtitle text.
-*   `icon` (String, optional): HTML string for an SVG icon or an icon font class for the start icon.
-*   `show-chevron` (Boolean, optional): If present, displays a navigation chevron at the end.
+*   `icon` (String, optional): HTML string for an SVG icon or an icon font class
+    for the start icon.
+*   `show-chevron` (Boolean, optional): If present, displays a navigation chevron
+    at the end.
 *   `disabled` (Boolean, optional): If present, disables the row.
 
 **Slots:**
@@ -95,19 +107,24 @@ A declarative way to define Adwaita action rows.
 
 ```html
 <adw-list-box style="max-width: 450px;">
-  <adw-action-row title="Display" subtitle="Resolution, Brightness, Night Light" show-chevron>
+  <adw-action-row title="Display" subtitle="Resolution, Brightness, Night Light"
+                  show-chevron>
     <!-- You can also put an icon via attribute or slot="prefix" -->
-    <span slot="prefix" style="font-size: 20px; margin-right: var(--spacing-s);">🖥️</span>
+    <span slot="prefix"
+          style="font-size: 20px; margin-right: var(--spacing-s);">🖥️</span>
   </adw-action-row>
 
   <adw-action-row title="Sound" show-chevron>
     <adw-spinner slot="suffix" active size="small"></adw-spinner>
   </adw-action-row>
 
-  <adw-action-row title="Privacy" subtitle="Location Services, Camera Access" icon="<svg viewBox='0 0 16 16'><!-- lock icon --><path d='M8 1a2 2 0 00-2 2v2H5a1 1 0 00-1 1v5a1 1 0 001 1h6a1 1 0 001-1V6a1 1 0 00-1-1H9V3a2 2 0 00-2-2zm0 1a1 1 0 011 1v2H7V3a1 1 0 011-1z'/></svg>" show-chevron>
+  <adw-action-row title="Privacy" subtitle="Location Services, Camera Access"
+                  icon="<svg viewBox='0 0 16 16'><!-- lock icon --><path d='M8 1a2...'/></svg>"
+                  show-chevron>
   </adw-action-row>
 
-  <adw-action-row title="Disabled Action" subtitle="This action is not available" disabled show-chevron>
+  <adw-action-row title="Disabled Action" subtitle="This action is not available"
+                  disabled show-chevron>
   </adw-action-row>
 </adw-list-box>
 

--- a/docs/widgets/alertdialog.md
+++ b/docs/widgets/alertdialog.md
@@ -17,14 +17,23 @@ Adw.createAlertDialog(body, options = {}) -> { dialog: HTMLDivElement, open: fun
 *   `body` (String, required): The main message/body text of the alert.
 *   `options` (Object, optional): Configuration options:
     *   `heading` (String, optional): An optional heading for the alert dialog.
-    *   `choices` (Array<Object>, optional): An array of choice objects to create buttons. Each object:
+    *   `choices` (Array<Object>, optional): An array of choice objects to create
+        buttons. Each object:
         *   `label` (String, required): Text for the button.
-        *   `value` (String, required): A value associated with this choice, passed to `onResponse`.
-        *   `style` (String, optional): Style for the button. Can be `'default'`, `'suggested'`, or `'destructive'`.
+        *   `value` (String, required): A value associated with this choice, passed
+            to `onResponse`.
+        *   `style` (String, optional): Style for the button. Can be `'default'`,
+            `'suggested'`, or `'destructive'`.
         If no choices are provided, a default "OK" button is usually created.
-    *   `onResponse` (Function, optional): Callback function executed when a choice button is clicked. Receives the `value` of the chosen option as an argument. The dialog automatically closes after a response.
-    *   `customContent` (HTMLElement, optional): Optional custom HTML element to use as the dialog's content instead of the `body` string. If provided, `body` string might be ignored or used as a fallback label.
-    *   `closeOnBackdropClick` (Boolean, optional): Whether clicking the backdrop closes the dialog. Defaults to `false` for alert dialogs to ensure a choice is made.
+    *   `onResponse` (Function, optional): Callback function executed when a choice
+        button is clicked. Receives the `value` of the chosen option as an
+        argument. The dialog automatically closes after a response.
+    *   `customContent` (HTMLElement, optional): Optional custom HTML element to use
+        as the dialog's content instead of the `body` string. If provided, `body`
+        string might be ignored or used as a fallback label.
+    *   `closeOnBackdropClick` (Boolean, optional): Whether clicking the backdrop
+        closes the dialog. Defaults to `false` for alert dialogs to ensure a
+        choice is made.
 
 **Returns:**
 
@@ -42,10 +51,12 @@ Adw.createAlertDialog(body, options = {}) -> { dialog: HTMLDivElement, open: fun
 
   const showAlertBtn = Adw.createButton("Show Alert", {
     onClick: () => {
-      const alert = Adw.createAlertDialog("Are you sure you want to delete this item? This action cannot be undone.", {
-        heading: "Confirm Deletion",
-        choices: [
-          { label: "Cancel", value: "cancel" },
+      const alert = Adw.createAlertDialog(
+        "Are you sure you want to delete this item? This action cannot be undone.",
+        {
+          heading: "Confirm Deletion",
+          choices: [
+            { label: "Cancel", value: "cancel" },
           { label: "Delete", value: "delete", style: "destructive" }
         ],
         onResponse: (value) => {

--- a/docs/widgets/banner.md
+++ b/docs/widgets/banner.md
@@ -1,6 +1,9 @@
 # Banner
 
-An `AdwBanner` is a prominent message area typically displayed at the top of a view or window, used for important announcements or status messages that require user attention but are not necessarily modal. Adwaita-Web provides `Adw.createBanner()` and the `<adw-banner>` Web Component.
+An `AdwBanner` is a prominent message area typically displayed at the top of a
+view or window, used for important announcements or status messages that require
+user attention but are not necessarily modal. Adwaita-Web provides
+`Adw.createBanner()` and the `<adw-banner>` Web Component.
 
 ## JavaScript Factory: `Adw.createBanner()`
 
@@ -14,12 +17,20 @@ Adw.createBanner(title, options = {}) -> HTMLElement
 
 **Parameters:**
 
-*   `title` (String): The main text to display in the banner. HTML can be used if `useMarkup` is true.
+*   `title` (String): The main text to display in the banner. HTML can be used if
+    `useMarkup` is true.
 *   `options` (Object, optional): Configuration options:
-    *   `useMarkup` (Boolean, optional): If `true`, the `title` string is treated as HTML. Defaults to `false`. **Use with caution and ensure any HTML is sanitized if from user input.**
-    *   `buttonLabel` (String, optional): If provided, a button with this label is added to the banner.
-    *   `onButtonClicked` (Function, optional): A callback function executed when the button is clicked. The banner instance is passed as an argument.
-    *   `type` (String, optional): Sets the visual style of the banner. Common types could be `'info'`, `'warning'`, `'error'`, `'success'`. This usually applies a corresponding CSS class (e.g., `adw-banner-warning`). Defaults to a neutral/info style.
+    *   `useMarkup` (Boolean, optional): If `true`, the `title` string is treated
+        as HTML. Defaults to `false`. **Use with caution and ensure any HTML is
+        sanitized if from user input.**
+    *   `buttonLabel` (String, optional): If provided, a button with this label is
+        added to the banner.
+    *   `onButtonClicked` (Function, optional): A callback function executed when
+        the button is clicked. The banner instance is passed as an argument.
+    *   `type` (String, optional): Sets the visual style of the banner. Common types
+        could be `'info'`, `'warning'`, `'error'`, `'success'`. This usually
+        applies a corresponding CSS class (e.g., `adw-banner-warning`). Defaults
+        to a neutral/info style.
     *   `id` (String, optional): A specific ID to set on the banner element.
 
 **Returns:**
@@ -59,7 +70,8 @@ A declarative way to create Adwaita banners.
 *   `title` (String, required): The main text for the banner.
 *   `use-markup` (Boolean, optional): If present, treats the `title` as HTML.
 *   `button-label` (String, optional): Label for the action button.
-*   `type` (String, optional): Visual type: `'info'`, `'warning'`, `'error'`, `'success'`.
+*   `type` (String, optional): Visual type: `'info'`, `'warning'`, `'error'`,
+    `'success'`.
 
 **Properties:**
 *   `title` (String)
@@ -69,11 +81,15 @@ A declarative way to create Adwaita banners.
 
 **Events:**
 
-*   `button-clicked`: Fired when the action button (if present) is clicked. `event.detail` might contain the banner instance.
-*   `dismissed`: (Potentially) Fired if the banner has a built-in dismiss mechanism (e.g., a close button, not standard in Libadwaita banners but common in web implementations).
+*   `button-clicked`: Fired when the action button (if present) is clicked.
+    `event.detail` might contain the banner instance.
+*   `dismissed`: (Potentially) Fired if the banner has a built-in dismiss
+    mechanism (e.g., a close button, not standard in Libadwaita banners but
+    common in web implementations).
 
 **Slots:**
-*   If the `title` attribute is not used, the default slot can be used for the banner's main content.
+*   If the `title` attribute is not used, the default slot can be used for the
+    banner's main content.
 *   A named slot like `slot="action"` could be used for custom action elements instead of just `button-label`. (This would be an enhancement over basic Libadwaita).
 
 **Example:**
@@ -81,7 +97,7 @@ A declarative way to create Adwaita banners.
 ```html
 <adw-banner title="Welcome to Adwaita-Web!"></adw-banner>
 
-<adw-banner title="<strong>Update Required!</strong> Your software is out of date."
+<adw-banner title="&lt;strong&gt;Update Required!&lt;/strong&gt; Your software is out of date."
             use-markup
             button-label="Update Now"
             type="warning">

--- a/docs/widgets/bin.md
+++ b/docs/widgets/bin.md
@@ -1,6 +1,9 @@
 # Bin
 
-An AdwBin is a simple container widget that holds a single child element. It's often used as a base class for more complex widgets that need to manage a single child, or as a straightforward way to apply Adwaita container styling or padding to a single item.
+An AdwBin is a simple container widget that holds a single child element.
+It's often used as a base class for more complex widgets that need to manage a
+single child, or as a straightforward way to apply Adwaita container styling
+or padding to a single item.
 
 ## JavaScript Factory: `Adw.createBin()`
 
@@ -62,16 +65,22 @@ A declarative way to use an Adwaita bin container.
 
 ```html
 <p>Bin with a card-like style applied to the Bin itself:</p>
-<adw-bin style="border: 1px solid var(--borders-color); border-radius: var(--border-radius-default); padding: var(--spacing-m); background-color: var(--view-bg-color); max-width: 300px;">
+<adw-bin style="border: 1px solid var(--borders-color); padding: var(--spacing-m);
+              border-radius: var(--border-radius-default); max-width: 300px;
+              background-color: var(--view-bg-color);">
   <adw-label title-level="2">Content Card</adw-label>
   <p>This content is wrapped by an AdwBin, styled to look like a simple card.</p>
   <adw-button flat>An action</adw-button>
 </adw-bin>
 
-<p style="margin-top: 1em;">Bin used to group an image and caption (though an AdwBox might be more semantically correct for multiple items):</p>
+<p style="margin-top: 1em;">
+  Bin used to group an image and caption (though an AdwBox might be more
+  semantically correct for multiple items):
+</p>
 <adw-bin>
   <div> <!-- The single child of the bin -->
-    <img src="app-demo/static/img/default_avatar.png" alt="Avatar" style="width: 80px; height: 80px; border-radius: 4px;">
+    <img src="app-demo/static/img/default_avatar.png" alt="Avatar"
+         style="width: 80px; height: 80px; border-radius: 4px;">
     <p style="font-size: var(--font-size-small); text-align: center;">Avatar Image</p>
   </div>
 </adw-bin>
@@ -81,8 +90,12 @@ A declarative way to use an Adwaita bin container.
 
 *   Primary SCSS: `scss/_bin.scss`.
 *   A Bin itself is often unstyled or has minimal styling (like `display: block`).
-*   Its primary purpose is to act as a container. Any significant visual styling (borders, padding, background) would often be applied directly to the bin element via classes or inline styles, or through styles applied to its single child.
-*   It does not impose flex or grid layout on its child by default, unless specific utility classes are added.
+*   Its primary purpose is to act as a container. Any significant visual styling
+    (borders, padding, background) would often be applied directly to the bin
+    element via classes or inline styles, or through styles applied to its
+    single child.
+*   It does not impose flex or grid layout on its child by default, unless
+    specific utility classes are added.
 
 ---
 Next: [WrapBox](./wrapbox.md)

--- a/docs/widgets/bottomsheet.md
+++ b/docs/widgets/bottomsheet.md
@@ -1,6 +1,8 @@
 # BottomSheet
 
-An AdwBottomSheet is a modal sheet that slides up from the bottom of the screen, typically used on mobile or in narrow views to present contextual actions, navigation, or simple forms.
+An AdwBottomSheet is a modal sheet that slides up from the bottom of the
+screen, typically used on mobile or in narrow views to present contextual
+actions, navigation, or simple forms.
 
 ## JavaScript Factory: `Adw.createBottomSheet()`
 
@@ -43,12 +45,15 @@ Adw.createBottomSheet(options = {}) -> { sheet: HTMLDivElement, backdrop: HTMLDi
   sheetContent.style.maxHeight = "70vh"; // Allow content to scroll if too tall
   sheetContent.style.overflowY = "auto";
 
-  const title = Adw.createLabel("Sheet Title", {title: 2}); // Assuming AdwLabel with title option
-  const action1 = Adw.createButton("Action 1", {flat: true, onClick: () => {mySheet.close(); Adw.createToast("Action 1 chosen");} });
-  const action2 = Adw.createButton("Action 2", {flat: true, onClick: () => {mySheet.close(); Adw.createToast("Action 2 chosen");} });
+  const title = Adw.createLabel("Sheet Title", {title: 2});
+  const action1Opts = {flat: true, onClick: () => {mySheet.close(); Adw.createToast("Action 1 chosen");}};
+  const action1 = Adw.createButton("Action 1", action1Opts);
+  const action2Opts = {flat: true, onClick: () => {mySheet.close(); Adw.createToast("Action 2 chosen");}};
+  const action2 = Adw.createButton("Action 2", action2Opts);
   const cancelAction = Adw.createButton("Cancel", {suggested: true, onClick: () => mySheet.close() });
 
-  const contentBox = Adw.createBox({orientation: "vertical", spacing: "s", children: [title, action1, action2, Adw.createLabel("---"), cancelAction]});
+  const contentBoxChildren = [title, action1, action2, Adw.createLabel("---"), cancelAction];
+  const contentBox = Adw.createBox({orientation: "vertical", spacing: "s", children: contentBoxChildren});
   sheetContent.appendChild(contentBox);
 
 

--- a/docs/widgets/box.md
+++ b/docs/widgets/box.md
@@ -15,12 +15,23 @@ Adw.createBox(options = {}) -> HTMLDivElement
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `orientation` (String, optional): Flex direction. Can be `"horizontal"` (default) or `"vertical"`.
-    *   `align` (String, optional): `align-items` value. Common values: `"start"`, `"center"`, `"end"`, `"stretch"`, `"baseline"`.
-    *   `justify` (String, optional): `justify-content` value. Common values: `"start"`, `"center"`, `"end"`, `"between"` (space-between), `"around"` (space-around), `"evenly"` (space-evenly).
-    *   `spacing` (String, optional): Gap spacing between children. Maps to Adwaita spacing variables (e.g., `"xs"`, `"s"`, `"m"`, `"l"`, `"xl"`) or a direct CSS value like `"10px"`. If using predefined spacing like "m", it typically maps to a CSS variable like `var(--spacing-m)`.
-    *   `fillChildren` (Boolean, optional): If `true`, children will grow to fill available space along the main axis (applies `flex-grow: 1` to children via a class). Defaults to `false`.
-    *   `children` (Array<HTMLElement>, optional): An array of HTML elements to append as children to the box. *Security: Ensure children are trusted or sanitized if user-generated.*
+    *   `orientation` (String, optional): Flex direction. Can be `"horizontal"`
+        (default) or `"vertical"`.
+    *   `align` (String, optional): `align-items` value. Common values: `"start"`,
+        `"center"`, `"end"`, `"stretch"`, `"baseline"`.
+    *   `justify` (String, optional): `justify-content` value. Common values:
+        `"start"`, `"center"`, `"end"`, `"between"` (space-between),
+        `"around"` (space-around), `"evenly"` (space-evenly).
+    *   `spacing` (String, optional): Gap spacing between children. Maps to Adwaita
+        spacing variables (e.g., `"xs"`, `"s"`, `"m"`, `"l"`, `"xl"`) or a direct
+        CSS value like `"10px"`. If using predefined spacing like "m", it
+        typically maps to a CSS variable like `var(--spacing-m)`.
+    *   `fillChildren` (Boolean, optional): If `true`, children will grow to fill
+        available space along the main axis (applies `flex-grow: 1` to children
+        via a class). Defaults to `false`.
+    *   `children` (Array<HTMLElement>, optional): An array of HTML elements to
+        append as children to the box. *Security: Ensure children are trusted or
+        sanitized if user-generated.*
 
 **Returns:**
 
@@ -102,7 +113,8 @@ A declarative way to use Adwaita box containers.
 <br/>
 
 <!-- Horizontal box where children fill available width -->
-<adw-box orientation="horizontal" spacing="xs" fill-children style="border: 1px solid var(--borders-color); padding: 5px; width: 100%;">
+<adw-box orientation="horizontal" spacing="xs" fill-children
+           style="border: 1px solid var(--borders-color); padding: 5px; width: 100%;">
   <adw-button style="min-width: 100px;">A</adw-button> <!-- flex-grow will be applied -->
   <adw-label style="text-align: center;">B (Centered)</adw-label>
   <adw-button style="min-width: 100px;">C</adw-button>

--- a/docs/widgets/breakpointbin.md
+++ b/docs/widgets/breakpointbin.md
@@ -15,13 +15,23 @@ Adw.createBreakpointBin(options = {}) -> HTMLDivElement (with methods)
 **Parameters:**
 
 *   `options` (Object, required): Configuration options:
-    *   `children` (Array<Object>, required): An array of child objects. Each object defines a child view and its condition:
+    *   `children` (Array<Object>, required): An array of child objects. Each
+        object defines a child view and its condition:
         *   `name` (String, required): A unique name for this child/breakpoint.
-        *   `element` (HTMLElement, required): The HTML element to display for this breakpoint.
-        *   `condition` (String | Number, required): The condition for displaying this child.
-            *   If a Number, it's interpreted as the minimum width in pixels (e.g., `600`).
-            *   If a String, it should be a valid media query condition, typically `min-width` (e.g., `"min-width: 768px"`). The factory primarily parses numerical min-width from this string.
-    *   `defaultChildName` (String, optional): The `name` of the child to show if no conditions match or if `ResizeObserver` is unavailable. Usually, this would be the child intended for the smallest screen size. If not specified, the child with the smallest `min-width` condition is often chosen as a fallback.
+        *   `element` (HTMLElement, required): The HTML element to display for this
+            breakpoint.
+        *   `condition` (String | Number, required): The condition for displaying
+            this child.
+            *   If a Number, it's interpreted as the minimum width in pixels
+                (e.g., `600`).
+            *   If a String, it should be a valid media query condition, typically
+                `min-width` (e.g., `"min-width: 768px"`). The factory primarily
+                parses numerical min-width from this string.
+    *   `defaultChildName` (String, optional): The `name` of the child to show if
+        no conditions match or if `ResizeObserver` is unavailable. Usually, this
+        would be the child intended for the smallest screen size. If not specified,
+        the child with the smallest `min-width` condition is often chosen as a
+        fallback.
 
 **Returns:**
 
@@ -33,7 +43,10 @@ Adw.createBreakpointBin(options = {}) -> HTMLDivElement (with methods)
 **Example:**
 
 ```html
-<div id="js-breakpointbin-container" style="border: 1px solid var(--borders-color); padding: var(--spacing-s); resize: horizontal; overflow: auto; width: 500px; min-width: 250px; max-width: 800px;">
+<div id="js-breakpointbin-container"
+     style="border: 1px solid var(--borders-color); padding: var(--spacing-s);
+            resize: horizontal; overflow: auto; width: 500px;
+            min-width: 250px; max-width: 800px;">
   <p><em>Resize this container horizontally to see different children.</em></p>
 </div>
 <script>
@@ -43,10 +56,13 @@ Adw.createBreakpointBin(options = {}) -> HTMLDivElement (with methods)
   const childSmall = Adw.createLabel("Small View (<400px)", {title: 2});
   childSmall.style.padding="10px"; childSmall.style.backgroundColor="var(--adw-red-1)";
 
-  const childMedium = Adw.createBox({ orientation: "horizontal", spacing: "m", children: [Adw.createButton("Medium A"), Adw.createButton("Medium B")]});
+  const mediumChildren = [Adw.createButton("Medium A"), Adw.createButton("Medium B")];
+  const childMedium = Adw.createBox({ orientation: "horizontal", spacing: "m", children: mediumChildren});
   childMedium.style.padding="10px"; childMedium.style.backgroundColor="var(--adw-yellow-1)";
 
-  const childLarge = Adw.createStatusPage({ title: "Large View (>=600px)", description: "Showing full details." });
+  const childLarge = Adw.createStatusPage({
+    title: "Large View (>=600px)", description: "Showing full details."
+  });
   childLarge.style.backgroundColor="var(--adw-green-1)";
 
 
@@ -93,10 +109,13 @@ A declarative way to use Adwaita breakpoint bins.
 
 ```html
 <adw-breakpoint-bin default-child-name="mobile"
-                    style="border: 1px solid var(--borders-color); padding: var(--spacing-s); resize: horizontal; overflow: auto; width: 500px; min-width: 200px; max-width: 100%;">
+      style="border: 1px solid var(--borders-color); padding: var(--spacing-s);
+             resize: horizontal; overflow: auto; width: 500px;
+             min-width: 200px; max-width: 100%;">
   <p><em>Resize this container horizontally.</em></p>
 
-  <div data-name="mobile" data-condition="0" style="background-color: var(--adw-blue-1); padding: 10px;">
+  <div data-name="mobile" data-condition="0"
+       style="background-color: var(--adw-blue-1); padding: 10px;">
     <h4>Mobile View</h4>
     <p>Content for small screens.</p>
   </div>
@@ -107,7 +126,8 @@ A declarative way to use Adwaita breakpoint bins.
     <adw-button>Tablet Action 2</adw-button>
   </div>
 
-  <div data-name="desktop" data-condition="min-width: 800px" style="background-color: var(--adw-green-1); padding: 10px;">
+  <div data-name="desktop" data-condition="min-width: 800px"
+       style="background-color: var(--adw-green-1); padding: 10px;">
     <h4>Desktop View (>=800px)</h4>
     <p>Full content with more details shown here.</p>
     <adw-entry-row title="Search Desktop Content"></adw-entry-row>

--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -16,15 +16,26 @@ Adw.createButton(text, options = {}) -> HTMLButtonElement | HTMLAnchorElement
 
 *   `text` (String): The text content of the button. Can be empty if using only an icon.
 *   `options` (Object, optional): Configuration options:
-    *   `href` (String, optional): If provided, creates an `<a>` tag styled as a button. *Security: Ensure this URL is trusted or validated to prevent XSS via `javascript:` URLs.*
-    *   `onClick` (Function, optional): Callback function for the button's click event. Not called if the button is disabled.
-    *   `suggested` (Boolean, optional): If `true`, applies the 'suggested-action' class (e.g., for primary actions). Defaults to `false`.
-    *   `destructive` (Boolean, optional): If `true`, applies the 'destructive-action' class (e.g., for delete actions). Defaults to `false`.
-    *   `flat` (Boolean, optional): If `true`, applies the 'flat' class for a less prominent button. Defaults to `false`.
-    *   `disabled` (Boolean, optional): If `true`, disables the button. Defaults to `false`.
-    *   `active` (Boolean, optional): If `true`, applies the 'active' class (e.g., for toggle buttons). Defaults to `false`.
-    *   `isCircular` (Boolean, optional): If `true`, applies the 'circular' class, typically for icon-only buttons. Defaults to `false`.
-    *   `icon` (String, optional): HTML string for an SVG icon, or a CSS class name for an icon font. *Security: If providing an HTML string, ensure it's from a trusted source or sanitized.*
+    *   `href` (String, optional): If provided, creates an `<a>` tag styled as a
+        button. *Security: Ensure this URL is trusted or validated to prevent XSS
+        via `javascript:` URLs.*
+    *   `onClick` (Function, optional): Callback function for the button's click
+        event. Not called if the button is disabled.
+    *   `suggested` (Boolean, optional): If `true`, applies the 'suggested-action'
+        class (e.g., for primary actions). Defaults to `false`.
+    *   `destructive` (Boolean, optional): If `true`, applies the
+        'destructive-action' class (e.g., for delete actions). Defaults to `false`.
+    *   `flat` (Boolean, optional): If `true`, applies the 'flat' class for a less
+        prominent button. Defaults to `false`.
+    *   `disabled` (Boolean, optional): If `true`, disables the button. Defaults to
+        `false`.
+    *   `active` (Boolean, optional): If `true`, applies the 'active' class (e.g.,
+        for toggle buttons). Defaults to `false`.
+    *   `isCircular` (Boolean, optional): If `true`, applies the 'circular' class,
+        typically for icon-only buttons. Defaults to `false`.
+    *   `icon` (String, optional): HTML string for an SVG icon, or a CSS class name
+        for an icon font. *Security: If providing an HTML string, ensure it's from
+        a trusted source or sanitized.*
 
 **Returns:**
 
@@ -46,7 +57,7 @@ Adw.createButton(text, options = {}) -> HTMLButtonElement | HTMLAnchorElement
 
   // Icon button
   const iconButton = Adw.createButton("", {
-    icon: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2Z"/></svg>', // Plus icon
+    icon: '<svg viewBox="0 0 16 16"><path d="M8 2a.5.5Z"/></svg>', // Plus icon (shortened)
     isCircular: true,
     flat: true,
     onClick: () => Adw.createToast("Icon button clicked!")
@@ -94,7 +105,7 @@ A declarative way to use Adwaita buttons.
 <adw-button destructive flat>Delete Item</adw-button>
 
 <!-- Circular icon button -->
-<adw-button circular icon='<svg viewBox="0 0 16 16" fill="currentColor"><path d="M12.5 5h-9V4h9v1zm0 3h-9V7h9v1zm-2 3h-7v-1h7v1zM3 14v-1h10v1H3zM1.5 2A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-13z"/></svg>'>
+<adw-button circular icon='<svg viewBox="0 0 16 16"><path d="M12.5 5h-9Z"/></svg>'>
 </adw-button>
 
 <!-- Link as a button -->

--- a/docs/widgets/carousel.md
+++ b/docs/widgets/carousel.md
@@ -43,7 +43,9 @@ Adw.createAdwCarousel(options = {}) -> HTMLDivElement (with methods)
   const container = document.getElementById('js-carousel-container');
 
   const slide1 = document.createElement('div');
-  slide1.style.cssText = "background-color: var(--adw-blue-1); height: 200px; display:flex; align-items:center; justify-content:center; color: var(--adw-blue-5); font-size: 2em;";
+  slide1.style.cssText = "background-color: var(--adw-blue-1); height: 200px; " +
+    "display:flex; align-items:center; justify-content:center; " +
+    "color: var(--adw-blue-5); font-size: 2em;";
   slide1.textContent = "Slide 1";
 
   const slide2 = document.createElement('img');
@@ -108,13 +110,19 @@ A declarative way to define Adwaita carousels.
 **Example:**
 
 ```html
-<adw-carousel show-nav-buttons autoplay autoplay-interval="3500" indicator-style="dots"
-              style="max-width: 600px; margin: auto; border: 1px solid var(--borders-color);"
-              id="wc-carousel">
-  <div style="background-color: var(--adw-purple-1); height: 250px; display:flex; align-items:center; justify-content:center; color: var(--adw-purple-5); font-size: 2.5em;">
+<adw-carousel show-nav-buttons autoplay autoplay-interval="3500"
+              indicator-style="dots" id="wc-carousel"
+              style="max-width: 600px; margin: auto;
+                     border: 1px solid var(--borders-color);">
+  <div style="background-color: var(--adw-purple-1); height: 250px;
+              display:flex; align-items:center; justify-content:center;
+              color: var(--adw-purple-5); font-size: 2.5em;">
     First Slide (Declarative)
   </div>
-  <img src="app-demo/static/img/default_avatar.png" alt="Image Slide" data-thumbnail="app-demo/static/img/default_avatar.png" style="width:100%; height:250px; object-fit:contain; background-color: var(--shade-color);">
+  <img src="app-demo/static/img/default_avatar.png" alt="Image Slide"
+       data-thumbnail="app-demo/static/img/default_avatar.png"
+       style="width:100%; height:250px; object-fit:contain;
+              background-color: var(--shade-color);">
   <div style="background-color: var(--adw-green-1); height: 250px; padding: 20px;">
     <h4>Rich Content Slide</h4>
     <p>This slide contains various HTML elements.</p>

--- a/docs/widgets/checkbox.md
+++ b/docs/widgets/checkbox.md
@@ -37,9 +37,7 @@ Adw.createCheckbox(options = {}) -> HTMLLabelElement (wrapper)
   const rememberMeCheck = Adw.createCheckbox({
     label: "Remember me on this computer",
     name: "remember",
-    onChanged: (event) => {
-      Adw.createToast(`Remember me: ${event.target.checked}`);
-    }
+    onChanged: (event) => Adw.createToast(`Remember me: ${event.target.checked}`)
   });
   container.appendChild(rememberMeCheck);
 

--- a/docs/widgets/clamp.md
+++ b/docs/widgets/clamp.md
@@ -26,8 +26,11 @@ Adw.createClamp(options = {}) -> HTMLDivElement
 **Example:**
 
 ```html
-<div id="js-clamp-container" style="border: 1px solid var(--borders-color); padding: var(--spacing-s); width: 100%;">
-  <p style="text-align:center;"><em>Resize browser window to see clamp effect. Container is full width.</em></p>
+<div id="js-clamp-container"
+     style="border: 1px solid var(--borders-color); padding: var(--spacing-s); width: 100%;">
+  <p style="text-align:center;">
+    <em>Resize browser window to see clamp effect. Container is full width.</em>
+  </p>
 </div>
 <script>
   const container = document.getElementById('js-clamp-container');
@@ -36,8 +39,14 @@ Adw.createClamp(options = {}) -> HTMLDivElement
   const textBlock = document.createElement('div');
   textBlock.innerHTML = `
     <h3>Clamped Document</h3>
-    <p>This paragraph is inside an AdwClamp. It will be centered and its width will not exceed the maximumSize specified (defaulting to around 80 characters). This is ideal for long-form text to maintain readability on wide screens.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <p>This paragraph is inside an AdwClamp. It will be centered and its width
+    will not exceed the maximumSize specified (defaulting to around 80
+    characters). This is ideal for long-form text to maintain readability on
+    wide screens.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat.</p>
   `;
   textBlock.style.textAlign = "left"; // Content alignment
   textBlock.style.padding = "var(--spacing-m)";
@@ -93,19 +102,30 @@ A declarative way to use Adwaita clamp containers.
 
 ```html
 <div style="background-color: var(--shade-color); padding: var(--spacing-l);">
-  <adw-clamp maximum-size="50ch" style="background-color: var(--window-bg-color); padding: var(--spacing-m); border-radius: var(--border-radius-large);">
+  <adw-clamp maximum-size="50ch"
+             style="background-color: var(--window-bg-color); padding: var(--spacing-m);
+                    border-radius: var(--border-radius-large);">
     <h2>Article Title</h2>
-    <p>This text is within an <code>adw-clamp</code> Web Component. It will be centered on the page (if the clamp itself has room to be centered or is full width) and its content flow will not exceed 50 characters wide, making it pleasant to read.</p>
-    <p>Further paragraphs will also adhere to this width constraint, providing a focused reading experience. The clamp itself can have its own background and padding.</p>
+    <p>This text is within an <code>adw-clamp</code> Web Component. It will be
+    centered on the page (if the clamp itself has room to be centered or is
+    full width) and its content flow will not exceed 50 characters wide,
+    making it pleasant to read.</p>
+    <p>Further paragraphs will also adhere to this width constraint, providing a
+    focused reading experience. The clamp itself can have its own background
+    and padding.</p>
     <adw-button>Read More</adw-button>
   </adw-clamp>
 </div>
 
-<div style="background-color: var(--body-bg-color); padding: var(--spacing-l); margin-top: var(--spacing-m);">
-  <adw-clamp maximum-size="400px" scrollable style="height: 200px; border: 1px solid var(--borders-color); background-color: var(--view-bg-color); padding: var(--spacing-s);">
+<div style="background-color: var(--body-bg-color); padding: var(--spacing-l);
+            margin-top: var(--spacing-m);">
+  <adw-clamp maximum-size="400px" scrollable
+             style="height: 200px; border: 1px solid var(--borders-color);
+                    background-color: var(--view-bg-color); padding: var(--spacing-s);">
       <h4>Scrollable Clamped Area</h4>
       <p>This content is clamped to 400px width.</p>
-      <p>If it becomes taller than the clamp's explicit height (200px here), the clamp will become scrollable.</p>
+      <p>If it becomes taller than the clamp's explicit height (200px here),
+      the clamp will become scrollable.</p>
       <p>Lorem ipsum dolor sit amet...</p>
       <p>Consectetur adipiscing elit...</p>
       <p>Sed do eiusmod tempor incididunt...</p>

--- a/docs/widgets/comborow.md
+++ b/docs/widgets/comborow.md
@@ -1,6 +1,9 @@
 # ComboRow
 
-A ComboRow is a specialized `AdwRow` that combines a label (title and optional subtitle) with a dropdown select input (a `<select>` element). It's used for selecting one option from a list within a form or settings panel, typically inside an `AdwListBox`.
+A ComboRow is a specialized `AdwRow` that combines a label (title and optional
+subtitle) with a dropdown select input (a `<select>` element). It's used for
+selecting one option from a list within a form or settings panel, typically
+inside an `AdwListBox`.
 
 ## Web Component: `<adw-combo-row>`
 
@@ -69,7 +72,8 @@ Adwaita-Web provides the `<adw-combo-row>` Web Component for creating this type 
   langCombo.value = "fr-FR";
 
   langCombo.addEventListener('change', () => {
-    Adw.createToast(`Language changed to: ${langCombo.value} (${langCombo.querySelector('select option:checked').textContent})`);
+    const selectedLabel = langCombo.querySelector('select option:checked').textContent;
+    Adw.createToast(`Language changed to: ${langCombo.value} (${selectedLabel})`);
   });
 
   const soundCombo = document.getElementById('sound-combo-row');

--- a/docs/widgets/dialog.md
+++ b/docs/widgets/dialog.md
@@ -18,10 +18,18 @@ Adw.createDialog(options = {}) -> { dialog: HTMLDivElement, open: function, clos
 
 *   `options` (Object, optional): Configuration options:
     *   `title` (String, optional): Title displayed at the top of the dialog.
-    *   `content` (HTMLElement | String, optional): The main content of the dialog. If a string is provided, it's wrapped in a `<p>` tag. *Security: If providing an HTMLElement, ensure its content is trusted/sanitized if it's user-generated HTML.*
-    *   `buttons` (Array<HTMLElement>, optional): An array of button elements (e.g., created with `Adw.createButton()`) to display in the dialog's action area.
-    *   `onClose` (Function, optional): Callback function executed when the dialog is closed (either programmatically, by Escape key, or backdrop click if enabled).
-    *   `closeOnBackdropClick` (Boolean, optional): If `true` (default), clicking the backdrop overlay will close the dialog. Set to `false` to prevent this.
+    *   `content` (HTMLElement | String, optional): The main content of the dialog.
+        If a string is provided, it's wrapped in a `<p>` tag. *Security: If
+        providing an HTMLElement, ensure its content is trusted/sanitized if it's
+        user-generated HTML.*
+    *   `buttons` (Array<HTMLElement>, optional): An array of button elements
+        (e.g., created with `Adw.createButton()`) to display in the dialog's
+        action area.
+    *   `onClose` (Function, optional): Callback function executed when the dialog
+        is closed (either programmatically, by Escape key, or backdrop click if
+        enabled).
+    *   `closeOnBackdropClick` (Boolean, optional): If `true` (default), clicking
+        the backdrop overlay will close the dialog. Set to `false` to prevent this.
 
 **Returns:**
 
@@ -39,7 +47,8 @@ Adw.createDialog(options = {}) -> { dialog: HTMLDivElement, open: function, clos
 
   const contentEl = document.createElement('div');
   const p = document.createElement('p');
-  p.textContent = "This is some custom content for the dialog. It can include various HTML elements.";
+  p.textContent = "This is some custom content for the dialog. " +
+                  "It can include various HTML elements.";
   const entry = Adw.createEntry({ placeholder: "Enter something..."});
   contentEl.append(p, entry);
 
@@ -100,9 +109,11 @@ A declarative way to define Adwaita dialogs.
 ```html
 <adw-button id="open-wc-dialog-btn">Open Web Component Dialog</adw-button>
 
-<adw-dialog id="my-wc-dialog" title="Web Component Dialog" close-on-backdrop-click="false">
+<adw-dialog id="my-wc-dialog" title="Web Component Dialog"
+            close-on-backdrop-click="false">
   <div slot="content">
-    <p>This dialog is defined declaratively using the <code>&lt;adw-dialog&gt;</code> tag.</p>
+    <p>This dialog is defined declaratively using the
+       <code>&lt;adw-dialog&gt;</code> tag.</p>
     <adw-entry placeholder="Your input here..."></adw-entry>
   </div>
   <div slot="buttons">

--- a/docs/widgets/entryrow.md
+++ b/docs/widgets/entryrow.md
@@ -16,19 +16,27 @@ Adw.createEntryRow(options = {}) -> HTMLDivElement
 
 *   `options` (Object, optional): Configuration options:
     *   `title` (String, required): The main title/label for the entry.
-    *   `subtitle` (String, optional): Additional descriptive text displayed below the title.
-    *   `entryOptions` (Object, optional): An object containing options to be passed directly to the underlying `Adw.createEntry()` factory function. Common `entryOptions` include:
+    *   `subtitle` (String, optional): Additional descriptive text displayed below
+        the title.
+    *   `entryOptions` (Object, optional): An object containing options to be
+        passed directly to the underlying `Adw.createEntry()` factory function.
+        Common `entryOptions` include:
         *   `placeholder` (String): Placeholder text for the entry.
         *   `value` (String): Initial value for the entry.
         *   `name` (String): The `name` attribute for the input element.
-        *   `type` (String): Input type (e.g., "text", "email", "search"). Defaults to "text".
+        *   `type` (String): Input type (e.g., "text", "email", "search").
+            Defaults to "text".
         *   `disabled` (Boolean): Disables only the entry field.
         *   `onInput` (Function): Input event handler for the entry.
-    *   `disabled` (Boolean, optional): If `true`, disables the entire row including the label and the entry. This is distinct from `entryOptions.disabled` which only disables the input field.
+    *   `disabled` (Boolean, optional): If `true`, disables the entire row
+        including the label and the entry. This is distinct from
+        `entryOptions.disabled` which only disables the input field.
 
 **Returns:**
 
-*   `(HTMLDivElement)`: The created `<div>` element representing the entry row. The internal `<input>` element can be accessed by querying within this div (e.g., `entryRowElement.querySelector('input.adw-entry')`).
+*   `(HTMLDivElement)`: The created `<div>` element representing the entry row.
+    The internal `<input>` element can be accessed by querying within this div
+    (e.g., `entryRowElement.querySelector('input.adw-entry')`).
 
 **Example:**
 
@@ -121,24 +129,15 @@ A declarative way to define Adwaita entry rows.
   <adw-entry-row
     title="Username"
     subtitle="Choose a unique username"
-    placeholder="e.g., ada_lovelace"
-    name="username"
-    required>
+    placeholder="e.g., ada_lovelace" name="username" required>
   </adw-entry-row>
 
-  <adw-entry-row
-    title="Website"
-    type="url"
-    placeholder="https://example.com"
-    value="https://gnome.org"
-    name="user_website">
+  <adw-entry-row title="Website" type="url" placeholder="https://example.com"
+                 value="https://gnome.org" name="user_website">
   </adw-entry-row>
 
-  <adw-entry-row
-    title="API Key"
-    subtitle="This field is disabled"
-    value=" preset-key-cannot-change"
-    disabled> <!-- Disables the whole row -->
+  <adw-entry-row title="API Key" subtitle="This field is disabled"
+                 value=" preset-key-cannot-change" disabled>
   </adw-entry-row>
 </adw-list-box>
 
@@ -146,7 +145,8 @@ A declarative way to define Adwaita entry rows.
   const usernameRow = document.querySelector('adw-entry-row[name="username"]');
   usernameRow.addEventListener('input', (event) => {
     // The event.target will be the <adw-entry-row> itself.
-    // To get the input's value, you'd use the .value property of the custom element.
+    // To get the input's value, you'd use the .value property of the
+    // custom element.
     console.log("Username:", usernameRow.value);
   });
 </script>

--- a/docs/widgets/expanderrow.md
+++ b/docs/widgets/expanderrow.md
@@ -37,7 +37,8 @@ Adw.createExpanderRow(options = {}) -> HTMLDivElement
 
   // Create content for the expander
   const detailsContent = document.createElement('div');
-  detailsContent.style.padding = "var(--spacing-s) 0 0 var(--spacing-l)"; // Indent content
+  // Indent content for visual hierarchy
+  detailsContent.style.padding = "var(--spacing-s) 0 0 var(--spacing-l)";
   detailsContent.innerHTML = `
     <p>This is the detailed content that was hidden.</p>
     <adw-entry placeholder="Enter detail..."></adw-entry>
@@ -99,15 +100,19 @@ A declarative way to define Adwaita expander rows.
 
 ```html
 <adw-list-box style="max-width: 500px;">
-  <adw-expander-row title="User Profile" subtitle="Edit your personal information">
-    <div slot="content" style="padding: var(--spacing-m); border-top: 1px solid var(--borders-color);">
+  <adw-expander-row title="User Profile"
+                      subtitle="Edit your personal information">
+    <div slot="content"
+         style="padding: var(--spacing-m); border-top: 1px solid var(--borders-color);">
       <adw-entry-row title="Name" placeholder="Your Name"></adw-entry-row>
       <adw-entry-row title="Email" placeholder="Your Email"></adw-entry-row>
     </div>
   </adw-expander-row>
 
   <adw-expander-row title="Application Logs" expanded>
-    <pre slot="content" style="padding: var(--spacing-m); background-color: var(--shade-color); max-height: 100px; overflow-y: auto;">Log entry 1...
+    <pre slot="content"
+         style="padding: var(--spacing-m); background-color: var(--shade-color);
+                max-height: 100px; overflow-y: auto;">Log entry 1...
 Log entry 2...
 Log entry 3...</pre>
   </adw-expander-row>

--- a/docs/widgets/flap.md
+++ b/docs/widgets/flap.md
@@ -33,7 +33,9 @@ Adw.createFlap(options = {}) -> { element: HTMLDivElement, toggleFlap: function,
 **Example:**
 
 ```html
-<div id="js-flap-container" style="height: 250px; border: 1px solid var(--borders-color); position: relative; overflow: hidden;">
+<div id="js-flap-container"
+     style="height: 250px; border: 1px solid var(--borders-color);
+            position: relative; overflow: hidden;">
   <!-- Button to trigger flap will be added here -->
 </div>
 <script>
@@ -43,14 +45,16 @@ Adw.createFlap(options = {}) -> { element: HTMLDivElement, toggleFlap: function,
 
 
   const flapContentEl = document.createElement('div');
-  flapContentEl.innerHTML = '<h4>Flap Content</h4><p>This is the flap area. It can contain navigation or tools.</p>';
+  flapContentEl.innerHTML = '<h4>Flap Content</h4><p>This is the flap area. ' +
+                            'It can contain navigation or tools.</p>';
   flapContentEl.style.padding = "var(--spacing-m)";
   flapContentEl.style.backgroundColor = "var(--sidebar-bg-color)"; // Example background
   flapContentEl.style.height = "100%";
 
 
   const mainContentEl = document.createElement('div');
-  mainContentEl.innerHTML = '<h3>Main Content Area</h3><p>This is where the primary content goes.</p>';
+  mainContentEl.innerHTML = '<h3>Main Content Area</h3><p>This is where the ' +
+                            'primary content goes.</p>';
   mainContentEl.style.padding = "var(--spacing-m)";
 
   const myFlap = Adw.createFlap({
@@ -107,8 +111,12 @@ A declarative way to define Adwaita flaps.
 
 ```html
 <adw-button id="wc-flap-toggle-btn">Toggle Flap</adw-button>
-<adw-flap id="my-wc-flap" folded flap-width="280px" style="height: 300px; border: 1px solid var(--borders-color); margin-top: 5px;">
-  <div slot="flap" style="background-color: var(--popover-bg-color); padding: var(--spacing-m); height: 100%;">
+<adw-flap id="my-wc-flap" folded flap-width="280px"
+          style="height: 300px; border: 1px solid var(--borders-color);
+                 margin-top: 5px;">
+  <div slot="flap"
+       style="background-color: var(--popover-bg-color);
+              padding: var(--spacing-m); height: 100%;">
     <h4>Sidebar Flap</h4>
     <ul>
       <li>Navigation Item 1</li>
@@ -118,7 +126,8 @@ A declarative way to define Adwaita flaps.
 
   <div slot="main" style="padding: var(--spacing-m);"> <!-- Or use default slot -->
     <h3>Main Application Content</h3>
-    <p>This content remains visible, and the flap slides over or reflows next to it.</p>
+    <p>This content remains visible, and the flap slides over or reflows next
+    to it.</p>
   </div>
 </adw-flap>
 

--- a/docs/widgets/headerbar.md
+++ b/docs/widgets/headerbar.md
@@ -34,13 +34,13 @@ Adw.createHeaderBar(options = {}) -> HTMLElement
   const container = document.getElementById('js-headerbar-container');
 
   const backButton = Adw.createButton("", {
-    icon: '<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/></svg>', // Left arrow
+    icon: '<svg viewBox="0 0 16 16"><path d="M12 8a.5.5Z"/></svg>', // Left arrow (shortened)
     flat: true,
     onClick: () => Adw.createToast("Back button clicked")
   });
 
   const menuButton = Adw.createButton("", {
-    icon: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>', // Menu icon
+    icon: '<svg viewBox="0 0 16 16"><path d="M2.5 12a.5.5Z"/></svg>', // Menu icon (shortened)
     flat: true,
     onClick: () => Adw.createToast("Menu button clicked")
   });
@@ -85,13 +85,16 @@ A declarative way to define Adwaita header bars.
 ```html
 <adw-header-bar>
   <div slot="start">
-    <adw-button circular flat icon='<svg viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/></svg>'></adw-button>
+    <adw-button circular flat icon='<svg viewBox="0 0 16 16"><path d="M12 8Z"/></svg>'></adw-button>
   </div>
   <adw-window-title slot="title">My App Title</adw-window-title>
-  <span slot="subtitle" style="font-size: var(--font-size-small); opacity: 0.7;">Details about view</span>
+  <span slot="subtitle"
+        style="font-size: var(--font-size-small); opacity: 0.7;">
+    Details about view
+  </span>
   <div slot="end">
     <adw-button flat>Action 1</adw-button>
-    <adw-button circular flat icon='<svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>'></adw-button>
+    <adw-button circular flat icon='<svg viewBox="0 0 16 16"><path d="M2.5 12Z"/></svg>'></adw-button>
   </div>
 </adw-header-bar>
 

--- a/docs/widgets/label.md
+++ b/docs/widgets/label.md
@@ -17,13 +17,26 @@ Adw.createLabel(text, options = {}) -> HTMLLabelElement | HTMLSpanElement
 
 *   `text` (String): The text content of the label.
 *   `options` (Object, optional): Configuration options:
-    *   `mnemonicFor` (String, optional): The ID of an activatable widget that this label is for. If provided, an `<label>` element is created with a `for` attribute, and the first character of the text that can be a mnemonic will be underlined.
-    *   `selectable` (Boolean, optional): If `true`, allows the text to be selected by the user. Defaults to `false`.
-    *   `wrap` (Boolean, optional): If `true`, the text will wrap if it exceeds the available width. Defaults to `false`. CSS `white-space: normal` is applied.
-    *   `lines` (Number, optional): The number of lines to display. If set, and text exceeds this, ellipsization might occur based on `ellipsize` mode (though primarily works with `wrap: true`).
-    *   `justify` (String, optional): Text alignment. Accepts `'left'`, `'center'`, `'right'`, `'fill'`. Defaults to `'left'`. (CSS `text-align`)
-    *   `ellipsize` (String, optional): How to ellipsize text if it overflows. Accepts `'none'`, `'start'`, `'middle'`, `'end'`. Defaults to `'none'`. (CSS `text-overflow`, often requires `overflow: hidden` and `white-space: nowrap` or line-clamping for multi-line)
-    *   `cssClass` (Array<String>, optional): Additional CSS classes to apply to the label element.
+    *   `mnemonicFor` (String, optional): The ID of an activatable widget that
+        this label is for. If provided, an `<label>` element is created with a
+        `for` attribute, and the first character of the text that can be a
+        mnemonic will be underlined.
+    *   `selectable` (Boolean, optional): If `true`, allows the text to be
+        selected by the user. Defaults to `false`.
+    *   `wrap` (Boolean, optional): If `true`, the text will wrap if it exceeds the
+        available width. Defaults to `false`. CSS `white-space: normal` is
+        applied.
+    *   `lines` (Number, optional): The number of lines to display. If set, and
+        text exceeds this, ellipsization might occur based on `ellipsize` mode
+        (though primarily works with `wrap: true`).
+    *   `justify` (String, optional): Text alignment. Accepts `'left'`, `'center'`,
+        `'right'`, `'fill'`. Defaults to `'left'`. (CSS `text-align`)
+    *   `ellipsize` (String, optional): How to ellipsize text if it overflows.
+        Accepts `'none'`, `'start'`, `'middle'`, `'end'`. Defaults to `'none'`.
+        (CSS `text-overflow`, often requires `overflow: hidden` and
+        `white-space: nowrap` or line-clamping for multi-line)
+    *   `cssClass` (Array<String>, optional): Additional CSS classes to apply to
+        the label element.
     *   `id` (String, optional): A specific ID to set on the label element.
 
 **Returns:**
@@ -42,11 +55,16 @@ Adw.createLabel(text, options = {}) -> HTMLLabelElement | HTMLSpanElement
   container.appendChild(simpleLabel);
   container.appendChild(document.createElement('br'));
 
-  const wrappedLabel = Adw.createLabel("This is a longer label that will wrap within its container.", { wrap: true });
+  const wrappedLabel = Adw.createLabel(
+    "This is a longer label that will wrap within its container.",
+    { wrap: true }
+  );
   container.appendChild(wrappedLabel);
   container.appendChild(document.createElement('br'));
 
-  const selectableLabel = Adw.createLabel("This text is selectable.", { selectable: true });
+  const selectableLabel = Adw.createLabel(
+    "This text is selectable.", { selectable: true }
+  );
   container.appendChild(selectableLabel);
   container.appendChild(document.createElement('br'));
 

--- a/docs/widgets/listbox.md
+++ b/docs/widgets/listbox.md
@@ -1,6 +1,9 @@
 # ListBox
 
-A ListBox is a container used to display a list of `AdwRow` (or row-like) elements. It groups rows together, often with a distinct visual style like a card or a bordered list. Adwaita-Web provides `Adw.createListBox()` and the `<adw-list-box>` Web Component.
+A ListBox is a container used to display a list of `AdwRow` (or row-like)
+elements. It groups rows together, often with a distinct visual style like a
+card or a bordered list. Adwaita-Web provides `Adw.createListBox()` and the
+`<adw-list-box>` Web Component.
 
 ## JavaScript Factory: `Adw.createListBox()`
 
@@ -15,9 +18,15 @@ Adw.createListBox(options = {}) -> HTMLDivElement
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `children` (Array<HTMLElement>, optional): An array of row elements (e.g., created with `Adw.createRow()`, `Adw.createActionRow()`) to populate the listbox.
-    *   `isFlat` (Boolean, optional): If `true`, removes the default box-shadow/card appearance, making it look more like a simple list. Defaults to `false`.
-    *   `selectable` (Boolean, optional): If `true`, indicates that rows within the listbox can be selected. This might add specific ARIA attributes or visual cues, but selection logic is typically handled by the rows themselves or application code. Defaults to `false`.
+    *   `children` (Array<HTMLElement>, optional): An array of row elements
+        (e.g., created with `Adw.createRow()`, `Adw.createActionRow()`) to
+        populate the listbox.
+    *   `isFlat` (Boolean, optional): If `true`, removes the default box-shadow/card
+        appearance, making it look more like a simple list. Defaults to `false`.
+    *   `selectable` (Boolean, optional): If `true`, indicates that rows within the
+        listbox can be selected. This might add specific ARIA attributes or
+        visual cues, but selection logic is typically handled by the rows
+        themselves or application code. Defaults to `false`.
 
 **Returns:**
 
@@ -31,9 +40,13 @@ Adw.createListBox(options = {}) -> HTMLDivElement
   const container = document.getElementById('js-listbox-container');
 
   // Create some rows
-  const row1 = Adw.createActionRow({ title: "General Settings", subtitle: "Network, Display, Sound" });
+  const row1 = Adw.createActionRow({
+    title: "General Settings", subtitle: "Network, Display, Sound"
+  });
   const row2 = Adw.createEntryRow({ title: "Username" });
-  const row3 = Adw.createSwitchRow({ title: "Enable Notifications", active: true }); // Assuming AdwSwitchRow exists
+  const row3 = Adw.createSwitchRow({ // Assuming AdwSwitchRow exists
+    title: "Enable Notifications", active: true
+  });
 
   // Create a ListBox with these rows
   const myListBox = Adw.createListBox({

--- a/docs/widgets/navigationsplitview.md
+++ b/docs/widgets/navigationsplitview.md
@@ -1,6 +1,10 @@
 # NavigationSplitView
 
-An AdwNavigationSplitView is a layout container that provides a master-detail view, typically with a collapsible sidebar (master) and a main content pane (detail). The content pane often hosts an `AdwNavigationView` or `AdwTabView`. It's responsive, changing behavior at defined breakpoints (e.g., sidebar overlays content on narrower screens).
+An AdwNavigationSplitView is a layout container that provides a master-detail
+view, typically with a collapsible sidebar (master) and a main content pane
+(detail). The content pane often hosts an `AdwNavigationView` or `AdwTabView`.
+It's responsive, changing behavior at defined breakpoints (e.g., sidebar
+overlays content on narrower screens).
 
 ## JavaScript Factory: `Adw.createAdwNavigationSplitView()`
 
@@ -17,10 +21,16 @@ Adw.createAdwNavigationSplitView(options = {}) -> HTMLDivElement (with methods)
 *   `options` (Object, optional): Configuration options:
     *   `sidebar` (HTMLElement, required): The content for the sidebar.
     *   `content` (HTMLElement, required): The content for the main pane.
-    *   `showSidebar` (Boolean, optional): Initial visibility of the sidebar. Defaults to `true`.
-    *   `canCollapse` (Boolean, optional): Whether the sidebar can be collapsed. Defaults to `true`. If `false`, the sidebar is always visible in docked mode (unless screen is too narrow for docked mode).
-    *   `collapseThreshold` (Number, optional): Width in pixels below which the sidebar transitions to overlay mode (if `canCollapse` is true). Defaults to `768`.
-    *   `sidebarWidth` (String, optional): Default CSS width of the sidebar when docked (e.g., "300px"). Defaults to a predefined value.
+    *   `showSidebar` (Boolean, optional): Initial visibility of the sidebar.
+        Defaults to `true`.
+    *   `canCollapse` (Boolean, optional): Whether the sidebar can be collapsed.
+        Defaults to `true`. If `false`, the sidebar is always visible in docked
+        mode (unless screen is too narrow for docked mode).
+    *   `collapseThreshold` (Number, optional): Width in pixels below which the
+        sidebar transitions to overlay mode (if `canCollapse` is true). Defaults
+        to `768`.
+    *   `sidebarWidth` (String, optional): Default CSS width of the sidebar when
+        docked (e.g., "300px"). Defaults to a predefined value.
 
 **Returns:**
 

--- a/docs/widgets/navigationview.md
+++ b/docs/widgets/navigationview.md
@@ -1,6 +1,9 @@
 # NavigationView
 
-An AdwNavigationView manages a stack of views (pages), allowing users to navigate between them using "push" (to a new view) and "pop" (back to the previous view) operations. It typically includes an `AdwHeaderBar` that updates its title and back button visibility based on the navigation stack.
+An AdwNavigationView manages a stack of views (pages), allowing users to
+navigate between them using "push" (to a new view) and "pop" (back to the
+previous view) operations. It typically includes an `AdwHeaderBar` that
+updates its title and back button visibility based on the navigation stack.
 
 ## JavaScript Factory: `Adw.createNavigationView()`
 
@@ -15,14 +18,20 @@ Adw.createNavigationView(options = {}) -> HTMLDivElement (with methods)
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `initialPages` (Array<Object>, optional): An array of page data objects to initialize the stack. The first page in the array is shown initially. Each object:
+    *   `initialPages` (Array<Object>, optional): An array of page data objects to
+        initialize the stack. The first page in the array is shown initially.
+        Each object:
         *   `name` (String, required): A unique identifier for the page.
-        *   `element` (HTMLElement, required): The HTML element representing the page content.
-        *   `header` (Object, optional): Configuration for the header bar when this page is active.
+        *   `element` (HTMLElement, required): The HTML element representing the
+            page content.
+        *   `header` (Object, optional): Configuration for the header bar when this
+            page is active.
             *   `title` (String, optional): Page title.
             *   `subtitle` (String, optional): Page subtitle.
-            *   `start` (Array<HTMLElement>, optional): Elements for the start of the header bar (prepended to back button if shown).
-            *   `end` (Array<HTMLElement>, optional): Elements for the end of the header bar.
+            *   `start` (Array<HTMLElement>, optional): Elements for the start of
+                the header bar (prepended to back button if shown).
+            *   `end` (Array<HTMLElement>, optional): Elements for the end of the
+                header bar.
 
 **Returns:**
 
@@ -34,7 +43,9 @@ Adw.createNavigationView(options = {}) -> HTMLDivElement (with methods)
 **Example:**
 
 ```html
-<div id="js-navview-container" style="height: 350px; border: 1px solid var(--borders-color); display: flex; flex-direction: column;"></div>
+<div id="js-navview-container"
+     style="height: 350px; border: 1px solid var(--borders-color);
+            display: flex; flex-direction: column;"></div>
 <script>
   const navViewContainer = document.getElementById('js-navview-container');
 
@@ -44,7 +55,8 @@ Adw.createNavigationView(options = {}) -> HTMLDivElement (with methods)
   const page1Button = Adw.createButton("Go to Page 2", {
     onClick: () => myNavView.push(page2Data) // page2Data defined below
   });
-  page1Content.append(Adw.createLabel("This is the first page.", {isBody: true}), page1Button);
+  const page1Label = Adw.createLabel("This is the first page.", {isBody: true});
+  page1Content.append(page1Label, page1Button);
 
   // --- Page 2 Content ---
   const page2Content = document.createElement('div');
@@ -52,7 +64,8 @@ Adw.createNavigationView(options = {}) -> HTMLDivElement (with methods)
   const page2Button = Adw.createButton("Go to Page 3 (Settings)", {
     onClick: () => myNavView.push(page3Data) // page3Data defined below
   });
-  page2Content.append(Adw.createLabel("This is the second page.", {isBody: true}), page2Button);
+  const page2Label = Adw.createLabel("This is the second page.", {isBody: true});
+  page2Content.append(page2Label, page2Button);
 
   // --- Page 3 Content ---
   const page3Content = Adw.createEntryRow({title: "Some Setting"}); // Example content
@@ -96,8 +109,11 @@ A declarative way to define Adwaita navigation views.
 
 **Slots:**
 
-*   Default slot: Place page elements here. Each page element should be identifiable (e.g., have a `data-page-name` or `page-name` attribute) and can define its header bar content via sub-slots.
-    *   A page element (e.g., a `<div>` or a custom `<adw-navigation-page>` component) should have a `data-page-name` (or `page-name`) attribute.
+*   Default slot: Place page elements here. Each page element should be
+    identifiable (e.g., have a `data-page-name` or `page-name` attribute) and
+    can define its header bar content via sub-slots.
+    *   A page element (e.g., a `<div>` or a custom `<adw-navigation-page>`
+        component) should have a `data-page-name` (or `page-name`) attribute.
     *   Inside a page element, you can define header parts:
         *   `<div slot="header-title">My Page Title</div>`
         *   `<div slot="header-subtitle">Subtitle</div>`
@@ -112,7 +128,11 @@ A declarative way to define Adwaita navigation views.
 
 **Methods:**
 
-*   `push(pageElementOrName)`: Pushes a new page. If `pageElementOrName` is a string, it's treated as the `data-page-name` of an existing slotted page to navigate to. If it's an HTMLElement, it's added to the view (if not already present) and pushed. The element should conform to the page structure with `data-page-name` and optional header slots.
+*   `push(pageElementOrName)`: Pushes a new page. If `pageElementOrName` is a
+    string, it's treated as the `data-page-name` of an existing slotted page to
+    navigate to. If it's an HTMLElement, it's added to the view (if not already
+    present) and pushed. The element should conform to the page structure with
+    `data-page-name` and optional header slots.
 *   `pop()`: Pops the current page.
 *   `getVisiblePageName() -> String | null`: Returns the name of the current page.
 

--- a/docs/widgets/overlaysplitview.md
+++ b/docs/widgets/overlaysplitview.md
@@ -1,6 +1,11 @@
 # OverlaySplitView
 
-An AdwOverlaySplitView is a layout container similar to `AdwNavigationSplitView`, providing a sidebar and a main content pane. However, in an `AdwOverlaySplitView`, the sidebar *always* overlays the content (or is hidden) and does not have a "docked" mode where it pushes content aside. It's suitable for contexts where the sidebar is less frequently accessed or needs to be quickly shown/hidden without disturbing the main content flow.
+An AdwOverlaySplitView is a layout container similar to `AdwNavigationSplitView`,
+providing a sidebar and a main content pane. However, in an
+`AdwOverlaySplitView`, the sidebar *always* overlays the content (or is hidden)
+and does not have a "docked" mode where it pushes content aside. It's suitable
+for contexts where the sidebar is less frequently accessed or needs to be
+quickly shown/hidden without disturbing the main content flow.
 
 ## JavaScript Factory: `Adw.createAdwOverlaySplitView()`
 
@@ -17,10 +22,17 @@ Adw.createAdwOverlaySplitView(options = {}) -> HTMLDivElement (with methods)
 *   `options` (Object, optional): Configuration options:
     *   `sidebar` (HTMLElement, required): The content for the sidebar.
     *   `content` (HTMLElement, required): The content for the main pane.
-    *   `showSidebar` (Boolean, optional): Initial visibility of the sidebar. Defaults to `false` (sidebar is typically hidden by default in overlay views).
-    *   `canCollapse` (Boolean, optional): Whether the sidebar can be hidden by user interaction (e.g., backdrop click, Escape key). Defaults to `true`. If `false`, once shown, it might only be hideable programmatically or not at all via typical dismiss actions.
-    *   `sidebarPosition` (String, optional): Position of the sidebar. Can be `"start"` (left, default) or `"end"` (right).
-    *   `sidebarWidth` (String, optional): CSS width of the sidebar when shown (e.g., "300px"). Defaults to a predefined value.
+    *   `showSidebar` (Boolean, optional): Initial visibility of the sidebar.
+        Defaults to `false` (sidebar is typically hidden by default in overlay
+        views).
+    *   `canCollapse` (Boolean, optional): Whether the sidebar can be hidden by user
+        interaction (e.g., backdrop click, Escape key). Defaults to `true`. If
+        `false`, once shown, it might only be hideable programmatically or not at
+        all via typical dismiss actions.
+    *   `sidebarPosition` (String, optional): Position of the sidebar. Can be
+        `"start"` (left, default) or `"end"` (right).
+    *   `sidebarWidth` (String, optional): CSS width of the sidebar when shown
+        (e.g., "300px"). Defaults to a predefined value.
 
 **Returns:**
 
@@ -33,7 +45,10 @@ Adw.createAdwOverlaySplitView(options = {}) -> HTMLDivElement (with methods)
 **Example:**
 
 ```html
-<div id="js-overlaysplitview-container" style="height: 300px; border: 1px solid var(--borders-color); width: 100%; max-width: 600px; margin: auto; position: relative; overflow: hidden;">
+<div id="js-overlaysplitview-container"
+     style="height: 300px; border: 1px solid var(--borders-color);
+            width: 100%; max-width: 600px; margin: auto;
+            position: relative; overflow: hidden;">
   <!-- Button to trigger sidebar will be part of main content or external -->
 </div>
 <script>
@@ -42,7 +57,8 @@ Adw.createAdwOverlaySplitView(options = {}) -> HTMLDivElement (with methods)
   // --- Sidebar Content ---
   const sidebarContent = document.createElement('div');
   sidebarContent.style.padding = "var(--spacing-m)";
-  sidebarContent.style.backgroundColor = "var(--popover-bg-color)"; // Overlay often looks like a popover
+  // Overlay often looks like a popover
+  sidebarContent.style.backgroundColor = "var(--popover-bg-color)";
   sidebarContent.style.height = "100%";
   sidebarContent.innerHTML = `
     <h4>Filters</h4>
@@ -58,7 +74,9 @@ Adw.createAdwOverlaySplitView(options = {}) -> HTMLDivElement (with methods)
   const openOverlayBtn = Adw.createButton("Show Filters", {
       onClick: () => overlaySplitView.showSidebar()
   });
-  mainContent.append(openOverlayBtn, Adw.createLabel("Main application content goes here. The sidebar will overlay this."));
+  const mainLabel = "Main application content goes here. " +
+                    "The sidebar will overlay this.";
+  mainContent.append(openOverlayBtn, Adw.createLabel(mainLabel));
 
 
   const overlaySplitView = Adw.createAdwOverlaySplitView({
@@ -112,18 +130,27 @@ A declarative way to define Adwaita overlay split views.
   id="my-wc-overlaysplit"
   sidebar-position="end"
   sidebar-width="320px"
-  style="height: 350px; border: 1px solid var(--borders-color); margin-top: 5px; position: relative; overflow: hidden;">
+  style="height: 350px; border: 1px solid var(--borders-color);
+         margin-top: 5px; position: relative; overflow: hidden;">
 
-  <div slot="sidebar" style="background-color: var(--dialog-bg-color); padding: var(--spacing-m); height: 100%;">
+  <div slot="sidebar"
+       style="background-color: var(--dialog-bg-color);
+              padding: var(--spacing-m); height: 100%;">
     <h3>Quick Settings</h3>
     <adw-switch-row title="Dark Mode"></adw-switch-row>
     <adw-switch-row title="Notifications"></adw-switch-row>
-    <adw-button style="margin-top: var(--spacing-m)" onclick="document.getElementById('my-wc-overlaysplit').hideSidebar()">Close Settings</adw-button>
+    <adw-button style="margin-top: var(--spacing-m)"
+                onclick="document.getElementById('my-wc-overlaysplit').hideSidebar()">
+      Close Settings
+    </adw-button>
   </div>
 
-  <div slot="content" style="padding: var(--spacing-l); background-color: var(--view-bg-color); height:100%;">
+  <div slot="content"
+       style="padding: var(--spacing-l);
+              background-color: var(--view-bg-color); height:100%;">
     <h2>Main Application View</h2>
-    <p>This is the primary content. The settings sidebar will appear overlaying this content from the right.</p>
+    <p>This is the primary content. The settings sidebar will appear overlaying
+    this content from the right.</p>
   </div>
 </adw-overlay-split-view>
 

--- a/docs/widgets/passwordentryrow.md
+++ b/docs/widgets/passwordentryrow.md
@@ -16,18 +16,24 @@ Adw.createPasswordEntryRow(options = {}) -> HTMLDivElement
 
 *   `options` (Object, optional): Configuration options:
     *   `title` (String, required): The main title/label for the password entry.
-    *   `subtitle` (String, optional): Additional descriptive text displayed below the title.
-    *   `entryOptions` (Object, optional): An object containing options for the password input field itself. These are similar to `Adw.createEntry()` options but will default `type` to "password".
+    *   `subtitle` (String, optional): Additional descriptive text displayed below
+        the title.
+    *   `entryOptions` (Object, optional): An object containing options for the
+        password input field itself. These are similar to `Adw.createEntry()`
+        options but will default `type` to "password".
         *   `placeholder` (String): Placeholder text.
         *   `value` (String): Initial value.
         *   `name` (String): The `name` attribute.
         *   `disabled` (Boolean): Disables only the entry field.
-        *   `showPeekButton` (Boolean, optional): If `true` (often the default for this component), includes a button to toggle password visibility.
+        *   `showPeekButton` (Boolean, optional): If `true` (often the default for
+            this component), includes a button to toggle password visibility.
     *   `disabled` (Boolean, optional): If `true`, disables the entire row.
 
 **Returns:**
 
-*   `(HTMLDivElement)`: The created `<div>` element for the row. It contains the label and the password input mechanism (input field and optional peek button).
+*   `(HTMLDivElement)`: The created `<div>` element for the row. It contains the
+    label and the password input mechanism (input field and optional peek
+    button).
 
 **Example:**
 
@@ -59,7 +65,8 @@ Adw.createPasswordEntryRow(options = {}) -> HTMLDivElement
   container.appendChild(confirmPasswordRow);
 
   // Accessing the input value (the input element is usually type="password")
-  const inputInRow = passwordRow.querySelector('input[type="password"], input[type="text"]'); // Input type might change if peek is active
+  // Input type might change if peek is active
+  const inputInRow = passwordRow.querySelector('input[type="password"], input[type="text"]');
   if (inputInRow) {
     inputInRow.addEventListener('input', (e) => {
       console.log("Password field value:", e.target.value);

--- a/docs/widgets/preferencesdialog.md
+++ b/docs/widgets/preferencesdialog.md
@@ -15,13 +15,21 @@ Adw.createPreferencesDialog(options = {}) -> { dialog: HTMLDivElement, open: fun
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `title` (String, optional): Title for the dialog window. Defaults to "Preferences".
-    *   `pages` (Array<Object>, required): An array of page objects. Each object defines a page in the preferences dialog:
+    *   `title` (String, optional): Title for the dialog window. Defaults to
+        "Preferences".
+    *   `pages` (Array<Object>, required): An array of page objects. Each object
+        defines a page in the preferences dialog:
         *   `name` (String, required): A unique internal name for the page.
-        *   `title` (String, required): The display title for the page (used in the ViewSwitcher button).
-        *   `pageElement` (HTMLElement, required): The HTML element that constitutes the content of this preference page. This element should be structured like an `AdwPreferencesPage` (see below or `adw-preferences-page` Web Component).
-    *   `initialPageName` (String, optional): The `name` of the page to show initially. Defaults to the first page in the `pages` array.
-    *   `onClose` (Function, optional): Callback function executed when the dialog is closed.
+        *   `title` (String, required): The display title for the page (used in
+            the ViewSwitcher button).
+        *   `pageElement` (HTMLElement, required): The HTML element that
+            constitutes the content of this preference page. This element should
+            be structured like an `AdwPreferencesPage` (see below or
+            `adw-preferences-page` Web Component).
+    *   `initialPageName` (String, optional): The `name` of the page to show
+        initially. Defaults to the first page in the `pages` array.
+    *   `onClose` (Function, optional): Callback function executed when the dialog
+        is closed.
 
 **Returns:**
 
@@ -49,12 +57,13 @@ A typical `pageElement` would be a `div` with class `adw-preferences-page` (or a
   appearanceTitle.classList.add('adw-preferences-group-title');
   appearanceTitle.textContent = "Appearance";
   appearanceGroup.appendChild(appearanceTitle);
-  appearanceGroup.appendChild(
-    Adw.createSwitchRow({ title: "Use Dark Theme", active: true, onChanged: (val) => Adw.toggleTheme(val ? 'dark' : 'light')}) // Assuming SwitchRow exists
-  );
-  appearanceGroup.appendChild(
-    Adw.createComboRow({ title: "Accent Color", selectOptions: [{label: "Blue", value: "blue"}, {label: "Green", value: "green"}], value: "blue" }) // Assuming ComboRow exists
-  );
+  const switchRowOpts = { title: "Use Dark Theme", active: true,
+                          onChanged: (val) => Adw.toggleTheme(val ? 'dark' : 'light')};
+  appearanceGroup.appendChild(Adw.createSwitchRow(switchRowOpts));
+  const comboOpts = { title: "Accent Color", value: "blue",
+                      selectOptions: [{label: "Blue", value: "blue"},
+                                      {label: "Green", value: "green"}]};
+  appearanceGroup.appendChild(Adw.createComboRow(comboOpts));
   generalPage.appendChild(appearanceGroup);
 
   // --- Page 2: Advanced Preferences ---

--- a/docs/widgets/radiobutton.md
+++ b/docs/widgets/radiobutton.md
@@ -43,18 +43,18 @@ Adw.createRadioButton(options = {}) -> HTMLLabelElement (wrapper)
   const selectedContactSpan = document.getElementById('selected-contact');
 
   const radioName = "contactMethod";
+  const onContactChange = (e) => {
+    if(e.target.checked) selectedContactSpan.textContent = e.target.parentElement.textContent.trim();
+  };
 
   const emailRadio = Adw.createRadioButton({
-    label: "Email", name: radioName, value: "email", checked: true,
-    onChanged: (e) => { if(e.target.checked) selectedContactSpan.textContent = "Email"; }
+    label: "Email", name: radioName, value: "email", checked: true, onChanged: onContactChange
   });
   const phoneRadio = Adw.createRadioButton({
-    label: "Phone", name: radioName, value: "phone",
-    onChanged: (e) => { if(e.target.checked) selectedContactSpan.textContent = "Phone"; }
+    label: "Phone", name: radioName, value: "phone", onChanged: onContactChange
   });
   const mailRadio = Adw.createRadioButton({
-    label: "Mail (Post)", name: radioName, value: "post",
-    onChanged: (e) => { if(e.target.checked) selectedContactSpan.textContent = "Mail"; }
+    label: "Mail (Post)", name: radioName, value: "post", onChanged: onContactChange
   });
 
   radioGroup1Container.append(emailRadio, phoneRadio, mailRadio);

--- a/docs/widgets/row.md
+++ b/docs/widgets/row.md
@@ -43,9 +43,10 @@ Adw.createRow(options = {}) -> HTMLDivElement
   // Interactive row with an icon and text
   const row2Icon = document.createElement('span'); // Using a simple span for icon placeholder
   row2Icon.className = 'icon'; // Add your icon class or SVG here
-  row2Icon.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0ZM7 4v3H4v2h3v3h2V9h3V7H9V4H7Z"/></svg>'; // Example plus icon
+  row2Icon.innerHTML = '<svg viewBox="0 0 16 16"><path d="M8 0a8Z"/></svg>'; // Shortened
   const row2Label = Adw.createLabel("Clickable Row");
-  const row2Box = Adw.createBox({children: [row2Icon, row2Label], spacing: "s", align: "center"});
+  const row2Children = [row2Icon, row2Label];
+  const row2Box = Adw.createBox({children: row2Children, spacing: "s", align: "center"});
 
   const row2 = Adw.createRow({
     children: [row2Box],
@@ -55,7 +56,8 @@ Adw.createRow(options = {}) -> HTMLDivElement
   container.appendChild(row2);
 
   // Activated (selected) row
-  const row3Content = Adw.createLabel("This row is activated/selected.");
+  const row3Label = "This row is activated/selected.";
+  const row3Content = Adw.createLabel(row3Label);
   const row3 = Adw.createRow({
     children: [row3Content],
     activated: true,

--- a/docs/widgets/spinner.md
+++ b/docs/widgets/spinner.md
@@ -50,7 +50,8 @@ Adw.createSpinner(options = {}) -> HTMLDivElement
   loadingSpinner.style.display = 'none'; // Start hidden for JS factory
   loadingSpinner.style.marginLeft = 'var(--spacing-xs)';
 
-  const loadingBox = Adw.createBox({children: [loadingButton, loadingSpinner], align: 'center'});
+  const loadingBoxChildren = [loadingButton, loadingSpinner];
+  const loadingBox = Adw.createBox({children: loadingBoxChildren, align: 'center'});
   container.appendChild(loadingBox);
 
   let isLoading = false;

--- a/docs/widgets/splitbutton.md
+++ b/docs/widgets/splitbutton.md
@@ -37,7 +37,7 @@ Adw.createSplitButton(options = {}) -> HTMLDivElement
 
   const saveSplitButton = Adw.createSplitButton({
     actionText: "Save",
-    actionIconHTML: '<svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M2 2v12h12V2H2zm1 1h10v10H3V3zm2 2v2h6V5H5zm0 3v2h6V8H5zm0 3v2h4v-2H5z"/></svg>', // Save icon
+    actionIconHTML: '<svg viewBox="0 0 16 16"><path d="M2 2v12h12V2H2z"/></svg>', // Save icon (shortened)
     suggested: true,
     onActionClick: () => {
       Adw.createToast("Default Save action!");

--- a/docs/widgets/statuspage.md
+++ b/docs/widgets/statuspage.md
@@ -33,9 +33,11 @@ Adw.createStatusPage(options = {}) -> HTMLDivElement
 
   // "No Results" Status Page
   const noResultsPage = Adw.createStatusPage({
-    iconHTML: '<svg viewBox="0 0 48 48" width="64" height="64"><path fill="currentColor" d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm0 36c-8.84 0-16-7.16-16-16S15.16 8 24 8s16 7.16 16 16-7.16 16-16 16zm-4-20h8v4h-8v-4zm0 6h8v4h-8v-4z"/></svg>', // Example icon (magnifying glass with slash)
+    // Example icon (magnifying glass with slash, shortened for brevity)
+    iconHTML: '<svg viewBox="0 0 48 48" width="64" height="64"><path d="M24 4C12.95Z"/></svg>',
     title: "No Results Found",
-    description: "Your search query did not match any documents. Try using different keywords.",
+    description: "Your search query did not match any documents. " +
+                 "Try using different keywords.",
     actions: [
       Adw.createButton("Clear Search", {
         onClick: () => Adw.createToast("Search cleared (concept).")
@@ -53,9 +55,11 @@ Adw.createStatusPage(options = {}) -> HTMLDivElement
     onClick: () => Adw.createToast("Welcome action!")
   });
   const welcomePage = Adw.createStatusPage({
-    iconHTML: '<svg viewBox="0 0 48 48" width="64" height="64"><path fill="currentColor" d="M10 36V12h4v24h-4zm8-14v14h4V22h-4zm8 8v6h4v-6h-4zM24 4a20 20 0 100 40 20 20 0 000-40z"/></svg>', // Example 'welcome' icon
+    // Example 'welcome' icon (shortened)
+    iconHTML: '<svg viewBox="0 0 48 48" width="64" height="64"><path d="M10 36V12h4Z"/></svg>',
     title: "Welcome to My Application!",
-    description: "This application helps you manage your tasks efficiently. Click below to begin.",
+    description: "This application helps you manage your tasks efficiently. " +
+                 "Click below to begin.",
     actions: [welcomeAction]
   });
   container.innerHTML = ''; // Clear previous
@@ -89,8 +93,9 @@ A declarative way to define Adwaita status pages.
 <adw-status-page
   title="Empty Mailbox"
   description="There are no messages in your inbox."
-  icon="<svg viewBox='0 0 48 48' width='64' height='64' fill='currentColor'><path d='M8 12C5.79 12 4 13.79 4 16v16c0 2.21 1.79 4 4 4h32c2.21 0 4-1.79 4-4V16c0-2.21-1.79-4-4-4H8zm0 2h32c1.1 0 2 .9 2 2v2.51l-16.43 9.39c-.33.19-.71.19-1.04 0L6 22.51V16c0-1.1.9-2 2-2zm0 20v-13.5l15.39 8.79c.53.3 1.15.45 1.78.45.62 0 1.25-.15 1.78-.45L40 20.5V32c0 1.1-.9 2-2 2H8z'/></svg>"
-  style="max-width: 400px; margin: 20px auto; padding: 20px; border: 1px solid var(--borders-color);">
+  icon="<svg viewBox='0 0 48 48' width='64'><path d='M8 12C5.79Z'/></svg>"
+  style="max-width: 400px; margin: 20px auto; padding: 20px;
+         border: 1px solid var(--borders-color);">
   <div slot="actions">
     <adw-button suggested id="compose-mail-btn">Compose New Mail</adw-button>
   </div>

--- a/docs/widgets/switchrow.md
+++ b/docs/widgets/switchrow.md
@@ -50,7 +50,8 @@ Adwaita-Web provides the `<adw-switch-row>` Web Component as the primary way to 
 <script>
   const featureXSwitch = document.getElementById('feature-x-switch');
   featureXSwitch.addEventListener('change', () => {
-    Adw.createToast(`Feature X is now ${featureXSwitch.active ? 'ON' : 'OFF'}`);
+    const state = featureXSwitch.active ? 'ON' : 'OFF';
+    Adw.createToast(`Feature X is now ${state}`);
   });
 
   const darkModeSwitch = document.getElementById('dark-mode-switch');

--- a/docs/widgets/tabview.md
+++ b/docs/widgets/tabview.md
@@ -50,9 +50,12 @@ The TabView system provides a way to manage multiple pages of content, where eac
     *   `pages` (Array<Object>, optional): Initial pages. Each object: `{ name: String, title: String, content: HTMLElement, isClosable?: boolean }`.
     *   `activePageName` (String, optional): Initially active page name.
     *   `showNewTabButton` (Boolean, optional): Passed to `AdwTabBar`.
-    *   `onNewTabRequested` (Function, optional): Passed to `AdwTabBar`. App should call `adwTabView.addPage()`.
+    *   `onNewTabRequested` (Function, optional): Passed to `AdwTabBar`. App should
+        call `adwTabView.addPage()`.
     *   `onPageChanged` (Function, optional): `onPageChanged(pageName)` callback.
-    *   `onBeforePageClose` (Function, optional): `onBeforePageClose(pageName) -> boolean`. Return `false` to prevent closing.
+    *   `onBeforePageClose` (Function, optional):
+        `onBeforePageClose(pageName) -> boolean`. Return `false` to prevent
+        closing.
     *   `onPageClosed` (Function, optional): `onPageClosed(pageName)` callback.
 *   **Returns**: The main tab view `<div>`, augmented with methods:
     *   `addPage(pageData, makeActive?)`
@@ -68,9 +71,11 @@ The TabView system provides a way to manage multiple pages of content, where eac
   const tabViewContainer = document.getElementById('js-tabview-container');
   let pageCounter = 2;
 
+  const page1Content = Adw.createLabel("Content for Page 1");
+  const page2Content = Adw.createEntry({placeholder: "Input for Page 2"});
   const initialPages = [
-    { name: "page1", title: "Page 1", content: Adw.createLabel("Content for Page 1"), isClosable: true },
-    { name: "page2", title: "Page Two", content: Adw.createEntry({placeholder: "Input for Page 2"}), isClosable: true }
+    { name: "page1", title: "Page 1", content: page1Content, isClosable: true },
+    { name: "page2", title: "Page Two", content: page2Content, isClosable: true }
   ];
 
   const myTabView = Adw.createTabView({

--- a/docs/widgets/toast.md
+++ b/docs/widgets/toast.md
@@ -1,6 +1,10 @@
 # Toast
 
-An `AdwToast` is a small, non-modal notification that appears briefly to provide feedback or information to the user. Toasts are often managed by a central overlay or toast manager. Adwaita-Web provides `Adw.createToast()` for imperative creation and an `<adw-toast>` Web Component (though toasts are often created dynamically).
+An `AdwToast` is a small, non-modal notification that appears briefly to
+provide feedback or information to the user. Toasts are often managed by a
+central overlay or toast manager. Adwaita-Web provides `Adw.createToast()` for
+imperative creation and an `<adw-toast>` Web Component (though toasts are often
+created dynamically).
 
 ## JavaScript Factory: `Adw.createToast()`
 
@@ -16,10 +20,16 @@ Adw.createToast(title, options = {}) -> HTMLElement
 
 *   `title` (String): The main text to display in the toast.
 *   `options` (Object, optional): Configuration options:
-    *   `timeout` (Number, optional): Duration in milliseconds before the toast automatically dismisses. Defaults to `3000` (3 seconds). A value of `0` or negative might mean it persists until an action or manual dismissal.
-    *   `actionName` (String, optional): If provided, an action button with this label is added to the toast.
-    *   `onAction` (Function, optional): A callback function executed when the action button is clicked. The toast instance is passed as an argument.
-    *   `priority` (String, optional): Priority of the toast. Can be `'normal'` or `'high'`. High priority toasts might be styled differently or placed above normal priority ones. Defaults to `'normal'`.
+    *   `timeout` (Number, optional): Duration in milliseconds before the toast
+        automatically dismisses. Defaults to `3000` (3 seconds). A value of `0` or
+        negative might mean it persists until an action or manual dismissal.
+    *   `actionName` (String, optional): If provided, an action button with this
+        label is added to the toast.
+    *   `onAction` (Function, optional): A callback function executed when the
+        action button is clicked. The toast instance is passed as an argument.
+    *   `priority` (String, optional): Priority of the toast. Can be `'normal'` or
+        `'high'`. High priority toasts might be styled differently or placed
+        above normal priority ones. Defaults to `'normal'`.
     *   `id` (String, optional): A specific ID to set on the toast element.
 
 **Returns:**
@@ -93,10 +103,12 @@ While toasts are often created dynamically via the factory, a web component can 
 **Example (Declarative, if part of a static view - less common for toasts):**
 
 ```html
-<!-- This toast would need to be managed (shown/hidden) by parent component logic -->
+<!-- This toast would need to be managed (shown/hidden) by parent logic -->
 <adw-toast title="Profile updated" timeout="2000" style="display: none;"></adw-toast>
 ```
-*Usage note: `<adw-toast>` elements are typically added and removed from the DOM dynamically by a toast management system rather than being statically placed in HTML and hidden/shown.*
+*Usage note: `<adw-toast>` elements are typically added and removed from the DOM
+dynamically by a toast management system rather than being statically placed in
+HTML and hidden/shown.*
 
 ## Styling
 

--- a/docs/widgets/togglebutton.md
+++ b/docs/widgets/togglebutton.md
@@ -15,11 +15,16 @@ Adw.createAdwToggleButton(text, options = {}) -> HTMLButtonElement (with methods
 **Parameters:**
 
 *   `text` (String): The text content of the button.
-*   `options` (Object, optional): Configuration options, extending `Adw.createButton` options:
+*   `options` (Object, optional): Configuration options, extending
+    `Adw.createButton` options:
     *   `active` (Boolean, optional): Initial active state. Defaults to `false`.
-    *   `onToggled` (Function, optional): Callback when the button is toggled by user interaction or programmatically if `fireCallback` is true in `setActive`. Receives `(isActive: boolean, value?: string)`.
-    *   `value` (String, optional): A value associated with the button, useful when part of a group.
-    *   Other `Adw.createButton` options like `icon`, `flat` (defaults to `true`), `suggested`, `destructive`, `disabled`, `isCircular` are also applicable.
+    *   `onToggled` (Function, optional): Callback when the button is toggled by
+        user interaction or programmatically if `fireCallback` is true in
+        `setActive`. Receives `(isActive: boolean, value?: string)`.
+    *   `value` (String, optional): A value associated with the button, useful when
+        part of a group.
+    *   Other `Adw.createButton` options like `icon`, `flat` (defaults to `true`),
+        `suggested`, `destructive`, `disabled`, `isCircular` are also applicable.
 
 **Returns:**
 
@@ -39,7 +44,8 @@ Adw.createAdwToggleButton(text, options = {}) -> HTMLButtonElement (with methods
     // icon: "format-text-bold-symbolic", // Example if using icon font
     value: "bold",
     onToggled: (isActive, value) => {
-      Adw.createToast(`Bold is now ${isActive ? 'ON' : 'OFF'} (Value: ${value})`);
+      const state = isActive ? 'ON' : 'OFF';
+      Adw.createToast(`Bold is now ${state} (Value: ${value})`);
       document.body.style.fontWeight = isActive ? 'bold' : 'normal'; // Demo effect
     }
   });
@@ -83,8 +89,12 @@ A declarative way to define Adwaita toggle buttons.
 
 **Events:**
 
-*   `toggled`: Fired when the button's active state changes due to user interaction or programmatic change that fires callbacks. `event.detail` contains `{ isActive: boolean, value?: string }`.
-*   `adw-toggle-button-clicked`: (Internal) Fired on click, primarily for `AdwToggleGroup` to manage state. `event.detail` contains `{ value?: string, currentState: boolean }`.
+*   `toggled`: Fired when the button's active state changes due to user
+    interaction or programmatic change that fires callbacks. `event.detail`
+    contains `{ isActive: boolean, value?: string }`.
+*   `adw-toggle-button-clicked`: (Internal) Fired on click, primarily for
+    `AdwToggleGroup` to manage state. `event.detail` contains
+    `{ value?: string, currentState: boolean }`.
 
 **Example:**
 

--- a/docs/widgets/togglegroup.md
+++ b/docs/widgets/togglegroup.md
@@ -15,10 +15,18 @@ Adw.createAdwToggleGroup(options = {}) -> HTMLDivElement (with methods)
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `buttons` (Array<Object | HTMLElement>, optional): An array of `AdwToggleButton` option objects (passed to `Adw.createAdwToggleButton`) or pre-created `AdwToggleButton` elements. Each button should have a unique `value`.
-    *   `linked` (Boolean, optional): If `true`, styles the buttons as a single linked group (e.g., like segments of a segmented button). Defaults to `false`.
-    *   `activeValue` (String, optional): The `value` of the button to be initially active.
-    *   `onActiveChanged` (Function, optional): Callback when the active button changes. Receives the `value` of the newly active button (or `null` if none become active, though typically one is always active in a group).
+    *   `buttons` (Array<Object | HTMLElement>, optional): An array of
+        `AdwToggleButton` option objects (passed to `Adw.createAdwToggleButton`)
+        or pre-created `AdwToggleButton` elements. Each button should have a
+        unique `value`.
+    *   `linked` (Boolean, optional): If `true`, styles the buttons as a single
+        linked group (e.g., like segments of a segmented button). Defaults to
+        `false`.
+    *   `activeValue` (String, optional): The `value` of the button to be initially
+        active.
+    *   `onActiveChanged` (Function, optional): Callback when the active button
+        changes. Receives the `value` of the newly active button (or `null` if
+        none become active, though typically one is always active in a group).
 
 **Returns:**
 

--- a/docs/widgets/toolbarview.md
+++ b/docs/widgets/toolbarview.md
@@ -1,6 +1,9 @@
 # ToolbarView
 
-An AdwToolbarView is a layout container that arranges content with optional top and bottom toolbars. The main content area is typically scrollable, and the toolbars can be revealed or hidden. This is useful for views that need persistent actions or information visible at the top or bottom.
+An AdwToolbarView is a layout container that arranges content with optional top
+and bottom toolbars. The main content area is typically scrollable, and the
+toolbars can be revealed or hidden. This is useful for views that need
+persistent actions or information visible at the top or bottom.
 
 ## JavaScript Factory: `Adw.createToolbarView()`
 
@@ -50,18 +53,20 @@ Adw.createToolbarView(options = {}) -> HTMLDivElement (with methods)
 
 
   // --- Bottom Bar ---
+  const bottomBarChildren = [
+    Adw.createButton("Cancel", { onClick: () => Adw.createToast("Cancel") }),
+    Adw.createButton("Apply", { suggested: true, onClick: () => Adw.createToast("Apply") })
+  ];
   const bottomBarContent = Adw.createBox({
     orientation: "horizontal",
     spacing: "m",
     align: "center",
     justify: "end", // Align buttons to the right
-    children: [
-      Adw.createButton("Cancel", { onClick: () => Adw.createToast("Cancel") }),
-      Adw.createButton("Apply", { suggested: true, onClick: () => Adw.createToast("Apply") })
-    ]
+    children: bottomBarChildren
   });
   bottomBarContent.style.padding = "var(--spacing-s)";
-  bottomBarContent.style.backgroundColor = "var(--headerbar-bg-color)"; // Use headerbar colors for consistency
+  // Use headerbar colors for consistency
+  bottomBarContent.style.backgroundColor = "var(--headerbar-bg-color)";
   bottomBarContent.style.borderTop = "1px solid var(--borders-color)";
 
 
@@ -127,24 +132,33 @@ A declarative way to define Adwaita toolbar views.
                     id="wc-toolbar-view">
   <adw-header-bar slot="top-bar">
     <h1 slot="title">My Document</h1>
-    <adw-button slot="end" flat icon="<svg viewBox='0 0 16 16'><path d='M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z'/></svg>"></adw-button>
+    <adw-button slot="end" flat icon="<svg viewBox='0 0 16 16'><path d='M2.5 12Z'/></svg>"></adw-button>
   </adw-header-bar>
 
   <div style="padding: var(--spacing-l); overflow-y: auto;"> <!-- Main content -->
     <p>This is the primary scrollable content area of the toolbar view.</p>
     <p>It can contain text, images, forms, or other Adwaita components.</p>
     <!-- Add more content here to demonstrate scrolling -->
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+    ut aliquip ex ea commodo consequat.</p>
+    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+    dolore eu fugiat nulla pariatur.</p>
+    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+    officia deserunt mollit anim id est laborum.</p>
+     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+     tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+    ut aliquip ex ea commodo consequat.</p>
+    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+    dolore eu fugiat nulla pariatur.</p>
+    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+    officia deserunt mollit anim id est laborum.</p>
   </div>
 
-  <adw-box slot="bottom-bar" spacing="m" align="center" style="padding: var(--spacing-s); border-top: 1px solid var(--borders-color);">
+  <adw-box slot="bottom-bar" spacing="m" align="center"
+           style="padding: var(--spacing-s); border-top: 1px solid var(--borders-color);">
     <adw-label>Status: Ready</adw-label>
     <div style="flex-grow: 1;"></div> <!-- Spacer -->
     <adw-button id="wc-tbv-action">Perform Action</adw-button>

--- a/docs/widgets/viewswitcher.md
+++ b/docs/widgets/viewswitcher.md
@@ -15,15 +15,26 @@ Adw.createViewSwitcher(options = {}) -> HTMLDivElement (the main switcher contai
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `views` (Array<Object>, required): An array of view objects. Each object should have:
+    *   `views` (Array<Object>, required): An array of view objects. Each object
+        should have:
         *   `name` (String, required): A unique identifier for the view.
-        *   `content` (HTMLElement, required): The HTML element representing the content of this view.
-        *   `id` (String, optional): An ID for the view's content panel (used for ARIA).
-        *   `buttonOptions` (Object, optional): Options passed to `Adw.createButton` for this view's switcher button. Typically includes `text` or `icon`. Example: `{ text: "View Title" }`.
-    *   `activeViewName` (String, optional): The `name` of the view to be initially active. If not provided, the first view in the `views` array becomes active.
-    *   `label` (String, optional): An ARIA label for the view switcher bar (the group of buttons).
-    *   `isInline` (Boolean, optional): If `true`, styles the switcher buttons more compactly, suitable for inline use. Defaults to `false`.
-    *   `onViewChanged` (Function, optional): Callback function executed when the active view changes. Receives `(viewName, buttonId, panelId)` as arguments.
+        *   `content` (HTMLElement, required): The HTML element representing the
+            content of this view.
+        *   `id` (String, optional): An ID for the view's content panel (used for
+            ARIA).
+        *   `buttonOptions` (Object, optional): Options passed to
+            `Adw.createButton` for this view's switcher button. Typically
+            includes `text` or `icon`. Example: `{ text: "View Title" }`.
+    *   `activeViewName` (String, optional): The `name` of the view to be initially
+        active. If not provided, the first view in the `views` array becomes
+        active.
+    *   `label` (String, optional): An ARIA label for the view switcher bar (the
+        group of buttons).
+    *   `isInline` (Boolean, optional): If `true`, styles the switcher buttons more
+        compactly, suitable for inline use. Defaults to `false`.
+    *   `onViewChanged` (Function, optional): Callback function executed when the
+        active view changes. Receives `(viewName, buttonId, panelId)` as
+        arguments.
 
 **Returns:**
 
@@ -76,16 +87,23 @@ A declarative way to define Adwaita view switchers.
 **Attributes:**
 
 *   `label` (String, optional): ARIA label for the switcher button group.
-*   `active-view` (String, optional): The `view-name` of the initially active view. Can be dynamically changed to switch views.
-*   `is-inline` (Boolean, optional): If present, applies inline styling to the switcher buttons.
+*   `active-view` (String, optional): The `view-name` of the initially active
+    view. Can be dynamically changed to switch views.
+*   `is-inline` (Boolean, optional): If present, applies inline styling to the
+    switcher buttons.
 
 **Slots:**
 
-*   Default slot: Child elements that represent the views. Each child element **must** have a `view-name` attribute. The content of the child element is the view itself. The text content of a `label` attribute on the child or a `data-view-title` attribute can be used for the switcher button text if not specified via other means.
+*   Default slot: Child elements that represent the views. Each child element
+    **must** have a `view-name` attribute. The content of the child element is
+    the view itself. The text content of a `label` attribute on the child or a
+    `data-view-title` attribute can be used for the switcher button text if not
+    specified via other means.
 
 **Events:**
 
-*   `view-changed`: Fired when the active view changes. `event.detail` contains `{ viewName: String, buttonId: String, panelId: String }`.
+*   `view-changed`: Fired when the active view changes. `event.detail` contains
+    `{ viewName: String, buttonId: String, panelId: String }`.
 
 **Methods:**
 *   `setActiveView(viewName)`: Programmatically sets the active view.

--- a/docs/widgets/window.md
+++ b/docs/widgets/window.md
@@ -70,13 +70,14 @@ A declarative way to define an Adwaita application window structure.
 <adw-application-window style="height: 450px; border: 1px solid var(--borders-color);">
   <adw-header-bar slot="header">
     <h1 slot="title">My WC Application</h1>
-    <adw-button slot="end" flat icon='<svg viewBox="0 0 16 16"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>'></adw-button>
+    <adw-button slot="end" flat icon='<svg viewBox="0 0 16 16"><path d="M2.5 12Z"/></svg>'></adw-button>
   </adw-header-bar>
 
   <!-- Default slot for main content -->
   <div style="padding: var(--spacing-l);">
     <h2>Welcome!</h2>
-    <p>This is the content area of the <code>&lt;adw-application-window&gt;</code>.</p>
+    <p>This is the content area of the
+       <code>&lt;adw-application-window&gt;</code>.</p>
     <p>It can contain any HTML or other Adwaita components.</p>
     <adw-box spacing="m">
         <adw-button suggested>Confirm</adw-button>

--- a/docs/widgets/wrapbox.md
+++ b/docs/widgets/wrapbox.md
@@ -15,13 +15,25 @@ Adw.createWrapBox(options = {}) -> HTMLDivElement
 **Parameters:**
 
 *   `options` (Object, optional): Configuration options:
-    *   `children` (Array<HTMLElement>, optional): Child elements to add to the wrap box.
-    *   `orientation` (String, optional): Main layout direction before wrapping. Can be `"horizontal"` (default) or `"vertical"`.
-    *   `spacing` (String | Number, optional): Gap between items along the main axis and cross axis if `lineSpacing` is not set. Can be a predefined Adwaita spacing unit (e.g., "s", "m") or a CSS value (e.g., "10px", 10 for 10px). Defaults to a medium spacing.
-    *   `lineSpacing` (String | Number, optional): Gap between lines of wrapped items (cross-axis spacing). If not set, `spacing` is used for both item and line gaps.
-    *   `align` (String, optional): `align-items` value (cross-axis alignment of items within a line). E.g., `"start"`, `"center"`, `"end"`, `"stretch"`. Defaults to `"start"`.
-    *   `justify` (String, optional): `justify-content` value (main-axis alignment of items within a line). E.g., `"start"`, `"center"`, `"end"`, `"between"`. Defaults to `"start"`.
-    *   *Note: `align-content` (for alignment of wrapped lines) might also be configurable or default to stretch/start.*
+    *   `children` (Array<HTMLElement>, optional): Child elements to add to the
+        wrap box.
+    *   `orientation` (String, optional): Main layout direction before wrapping.
+        Can be `"horizontal"` (default) or `"vertical"`.
+    *   `spacing` (String | Number, optional): Gap between items along the main
+        axis and cross axis if `lineSpacing` is not set. Can be a predefined
+        Adwaita spacing unit (e.g., "s", "m") or a CSS value (e.g., "10px",
+        10 for 10px). Defaults to a medium spacing.
+    *   `lineSpacing` (String | Number, optional): Gap between lines of wrapped
+        items (cross-axis spacing). If not set, `spacing` is used for both item
+        and line gaps.
+    *   `align` (String, optional): `align-items` value (cross-axis alignment of
+        items within a line). E.g., `"start"`, `"center"`, `"end"`, `"stretch"`.
+        Defaults to `"start"`.
+    *   `justify` (String, optional): `justify-content` value (main-axis
+        alignment of items within a line). E.g., `"start"`, `"center"`, `"end"`,
+        `"between"`. Defaults to `"start"`.
+    *   *Note: `align-content` (for alignment of wrapped lines) might also be
+        configurable or default to stretch/start.*
 
 **Returns:**
 

--- a/index.html
+++ b/index.html
@@ -378,15 +378,64 @@ accentColors.forEach(color => {
             const accentColors = Adw.getAccentColors(); // Expects [{id: 'blue', name: 'Blue'}, ...]
             accentColors.forEach(color => {
                 const button = Adw.createButton(color.name, {
-                    onClick: () => Adw.setAccentColor(color.id) // Pass the ID (e.g., 'green')
+                    onClick: () => {
+                        Adw.setAccentColor(color.id);
+                        // Optionally, re-style the buttons if needed after global accent change,
+                        // but ideally they just use standard button styles that react to the theme.
+                    }
                 });
-                // Basic preview - relies on CSS variables from _variables.scss being available
-                // These variable names are defined in :root in _variables.scss
-                button.style.setProperty('background-color', `var(--accent-${color.id}-light-bg)`);
-                button.style.setProperty('color', `var(--accent-${color.id}-light-fg)`);
-                button.style.setProperty('border-color', `var(--accent-${color.id}-light-standalone)`);
+                // Style the button to use its specific accent for its border,
+                // but let its main background/foreground come from standard button theming.
+                // This way, it adapts to light/dark mode better.
+                // We need to know if light or dark theme is active to pick the right standalone color.
+                const isLightTheme = document.body.classList.contains('light-theme');
+                const standaloneColorVar = isLightTheme ? `var(--accent-${color.id}-light-standalone)` : `var(--accent-${color.id}-dark-standalone)`;
+                const bgColorVar = isLightTheme ? `var(--accent-${color.id}-light-bg)` : `var(--accent-${color.id}-dark-bg)`;
+                const fgColorVar = isLightTheme ? `var(--accent-${color.id}-light-fg)` : `var(--accent-${color.id}-dark-fg)`;
+
+                // For the demo, let's make the buttons themselves use their accent color
+                // This will make them visually represent the color they set.
+                button.style.setProperty('background-color', bgColorVar);
+                button.style.setProperty('color', fgColorVar);
+                button.style.setProperty('border-color', standaloneColorVar);
+                // To ensure text is readable, especially for yellow, we might need to adjust
+                if (color.id === 'yellow') {
+                    button.style.setProperty('color', 'rgba(0,0,0,0.8)'); // Force dark text on yellow
+                }
+
+
                 accentPickerContainer.appendChild(button);
             });
+
+            // Re-style accent buttons if theme changes
+            new MutationObserver((mutationsList, observer) => {
+                for(const mutation of mutationsList) {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                        const isLightThemeCurrent = document.body.classList.contains('light-theme');
+                        accentPickerContainer.querySelectorAll('adw-button').forEach(btn => {
+                            // Find the color.id for this button. This is a bit fragile.
+                            // Assumes button text is unique or we store color.id on the button.
+                            const colorName = btn.textContent;
+                            const accentColorObj = accentColors.find(ac => ac.name === colorName);
+                            if (accentColorObj) {
+                                const colorId = accentColorObj.id;
+                                const newStandaloneColorVar = isLightThemeCurrent ? `var(--accent-${colorId}-light-standalone)` : `var(--accent-${colorId}-dark-standalone)`;
+                                const newBgColorVar = isLightThemeCurrent ? `var(--accent-${colorId}-light-bg)` : `var(--accent-${colorId}-dark-bg)`;
+                                const newFgColorVar = isLightThemeCurrent ? `var(--accent-${colorId}-light-fg)` : `var(--accent-${colorId}-dark-fg)`;
+
+                                btn.style.setProperty('background-color', newBgColorVar);
+                                btn.style.setProperty('color', newFgColorVar);
+                                btn.style.setProperty('border-color', newStandaloneColorVar);
+                                if (colorId === 'yellow') {
+                                    btn.style.setProperty('color', 'rgba(0,0,0,0.8)');
+                                }
+                            }
+                        });
+                        break; // Only need to react once per class change
+                    }
+                }
+            }).observe(document.body, { attributes: true });
+
         } else {
             console.warn("Accent color picker container not found.");
         }

--- a/scss/_action_row.scss
+++ b/scss/_action_row.scss
@@ -5,7 +5,7 @@
   align-items: center;
   padding: var(--spacing-m) var(--spacing-l);
   background-color: var(--card-bg-color); // Action Rows are often on card-like or view backgrounds
-  border-bottom: var(--border-width) solid var(--borders-color); // Use theme-aware --borders-color
+  border-bottom: var(--border-width) solid var(--list-separator-color); // Use new variable
   min-height: 48px; // Standard Adwaita row height
   gap: var(--spacing-m); // Use gap for spacing prefix, content, and suffix
 

--- a/scss/_entry.scss
+++ b/scss/_entry.scss
@@ -4,7 +4,7 @@
   padding: var(--spacing-s) var(--spacing-m);
   border-width: var(--border-width, 1px);
   border-style: solid;
-  border-color: var(--borders-color); // Use theme-aware general border color
+  border-color: var(--button-border-color); // Changed to use button-border-color for consistency
   border-radius: var(--border-radius-default);
   background-color: var(--view-bg-color); // Entries are usually on view or window backgrounds
   color: var(--view-fg-color);

--- a/scss/_entry_row.scss
+++ b/scss/_entry_row.scss
@@ -1,0 +1,90 @@
+// scss/_entry_row.scss
+@use 'variables';
+
+.adw-entry-row {
+  display: flex;
+  align-items: center; // Vertically align label and entry
+  // Padding is handled by .adw-list-box > .adw-row if this is a child.
+  // If used standalone, it would need its own padding.
+  // Assuming it's primarily a child of adw-list-box for now.
+  // border-bottom: var(--border-width) solid var(--list-separator-color); // Handled by adw-list-box > .adw-row
+
+  // min-height: 48px; // Or derive from content, Adwaita rows are typically this tall
+
+  .adw-entry-row-label {
+    color: var(--view-fg-color);
+    font-size: var(--font-size-base);
+    margin-right: var(--spacing-l); // 18px space between label and entry
+    // Adwaita entry rows often have labels that are not overly emphasized.
+    // font-weight: 500; // Optional: if labels should be bolder like ActionRow titles
+  }
+
+  .adw-entry-row-entry-container {
+    flex-grow: 1; // Entry takes remaining space
+    display: flex; // Allows for easy integration of icons/spinners inside later if needed
+
+    .adw-entry {
+      // Standard Adwaita EntryRows often have flat/borderless entries integrated into the row.
+      // The row itself provides the visual grouping.
+      border: none; // Remove border from entry when inside an entry row
+      background-color: transparent; // Entry bg should blend with row bg
+      box-shadow: none; // No inner shadow for embedded entries
+      padding-left: 0; // Remove padding if border is gone, or adjust as needed
+      padding-right: 0;
+
+      // Focus indication needs to be on the entry itself, even if borderless
+      &:focus,
+      &:focus-within {
+        // Since the border is removed, we need a different focus style.
+        // Option 1: Outline (can be tricky with adjacent elements)
+        // outline: 2px solid var(--accent-color);
+        // outline-offset: 2px;
+
+        // Option 2: A subtle background change or underline for the text area
+        // For now, let the default browser outline appear on focus if no border.
+        // Or, we can add a focus style to the parent .adw-entry-row-entry-container
+        // or the .adw-entry-row itself when the entry is focused.
+        // Libadwaita EntryRow entries don't show a separate focus ring for the entry itself,
+        // the row's selection/focus state is usually enough.
+        // If the row is not activatable, then the entry needs its own clear focus.
+        // Let's try a subtle background change on focus for the embedded entry.
+        background-color: var(--list-row-hover-bg-color); // A very subtle change
+      }
+
+      &[disabled],
+      &:disabled {
+        background-color: transparent; // Keep transparent even when disabled
+        // Opacity is handled by the .adw-entry's own disabled style or the row's disabled style
+      }
+    }
+  }
+
+  // When the row itself is disabled
+  &[disabled],
+  &:disabled {
+    .adw-entry-row-label {
+      opacity: var(--opacity-disabled);
+    }
+    // The .adw-entry inside will also apply its disabled styles.
+  }
+}
+
+// Ensure it integrates well when inside a list-box (which it usually is)
+.adw-list-box > .adw-entry-row {
+  // Inherits padding from .adw-list-box > .adw-row
+  // Inherits border-bottom from .adw-list-box > .adw-row
+}
+
+// Dark theme adjustments (mostly handled by variables)
+.dark-theme .adw-entry-row,
+body.dark-theme .adw-entry-row {
+  .adw-entry-row-label {
+    color: var(--view-fg-color);
+  }
+  .adw-entry-row-entry-container .adw-entry {
+    &:focus,
+    &:focus-within {
+      background-color: var(--list-row-hover-bg-color);
+    }
+  }
+}

--- a/scss/_listbox.scss
+++ b/scss/_listbox.scss
@@ -12,7 +12,7 @@
     display: flex;
     align-items: center;
     padding: var(--spacing-m);
-    border-bottom: var(--border-width) solid var(--card-shade-color); // Use --card-shade-color for separators
+    border-bottom: var(--border-width) solid var(--list-separator-color); // Use new variable
     transition: background-color 0.1s ease-out, color 0.1s ease-out, outline-offset 0.1s ease-out;
     cursor: default; // Default cursor, change if rows are interactive
     outline-offset: -2px; // For focus outline to be inset

--- a/scss/_spin_button.scss
+++ b/scss/_spin_button.scss
@@ -20,11 +20,12 @@
   .adw-spin-button-entry {
     // AdwEntry styles are applied by the factory, but we might override some specifics
     border: none; // Remove individual entry border, wrapper has it
-    border-radius: 0; // No radius inside the wrapper
-    // padding-right: var(--spacing-xxs); // Slightly less padding if buttons are close
+    border-radius: 0;
     box-shadow: none; // No inner shadow
-    min-height: calc(var(--button-size-base) - 2px); // Match button height, minus border
-    height: calc(var(--button-size-base) - 2px);
+    // Remove fixed height, let AdwEntry's natural padding define its height.
+    // Ensure AdwEntry component has appropriate vertical padding (e.g., var(--spacing-s))
+    // height: auto; // Default
+    // min-height: auto; // Default
 
     &:focus, &:focus-within {
       box-shadow: none; // No focus shadow on entry if wrapper handles focus
@@ -34,17 +35,18 @@
   .adw-spin-button-buttons {
     display: flex;
     flex-direction: column;
-    // height: 100%; // Let content define height, align with entry via flex align-items on parent
-    // align-self: stretch; // Make button container take full height of flex parent
+    align-self: stretch; // Make button container take full height of the parent flex container
+    box-sizing: border-box;
 
     .adw-spin-button-control.adw-button { // Target the specific buttons
       background-color: var(--button-bg-color);
       border: none;
       border-radius: 0;
-      padding: var(--spacing-xxs) var(--spacing-xs); // Very minimal padding
-      min-height: 0;
-      height: 1.5em; // Adjust height to be small, relative to font or fixed
-      line-height: 1; // For better icon centering
+      padding: var(--spacing-xxs) var(--spacing-xs); // Minimal padding
+      min-height: 0; // Allow button to shrink
+      height: 50%; // Each button takes half the container height
+      box-sizing: border-box; // Padding and border included in height
+      line-height: 1; // For better icon centering if text was used
       box-shadow: none;
       display: flex; // Ensure icon inside is centered
       align-items: center;

--- a/scss/_split_button.scss
+++ b/scss/_split_button.scss
@@ -12,7 +12,7 @@
   box-shadow: none;
 
   &:focus-within {
-    outline: 2px solid var(--accent-bg-color);
+    outline: 2px solid var(--accent-color); // Use standalone accent for outline
     outline-offset: 2px;
   }
 
@@ -21,7 +21,7 @@
     cursor: pointer;
     text-align: center;
     flex-grow: 1;
-    border-right: var(--border-width, 1px) solid var(--button-border-color);
+    // border-right: var(--border-width, 1px) solid var(--button-border-color); // Removed
     border-radius: var(--border-radius-default) 0 0 var(--border-radius-default);
     transition: background-color 0.1s ease-out;
     color: inherit;
@@ -43,6 +43,7 @@
     justify-content: center;
     padding: var(--spacing-s) var(--spacing-xs);
     cursor: pointer;
+    border-left: var(--border-width, 1px) solid var(--button-border-color); // Added separator here
     border-radius: 0 var(--border-radius-default) var(--border-radius-default) 0;
     transition: background-color 0.1s ease-out;
     color: inherit;
@@ -51,8 +52,8 @@
 
     // Ensure the icon itself is styled correctly within the dropdown part
     .adw-icon {
-      width: 1em; // Or a fixed small size e.g. 12px or 14px
-      height: 1em;
+      width: 12px; // Fixed size for dropdown arrow
+      height: 12px;
       // fill: currentColor; // AdwIcon component should handle this
     }
 
@@ -74,20 +75,21 @@
     border-color: transparent;
 
     .adw-split-button-action {
-      border-right-color: transparent;
+      // border-right-color: transparent; // Not needed as border-right was removed
       &:hover {
-        background-color: rgba(255,255,255, 0.1); // Assuming accent-fg-color is white
+        background-color: var(--accent-bg-hover-color);
       }
       &:active {
-        background-color: rgba(255,255,255, 0.2); // Assuming accent-fg-color is white
+        background-color: var(--accent-bg-active-color);
       }
     }
     .adw-split-button-dropdown {
+      border-left-color: var(--accent-bg-active-color); // Subtle separator for suggested state
       &:hover {
-        background-color: rgba(255,255,255, 0.1); // Assuming accent-fg-color is white
+        background-color: var(--accent-bg-hover-color);
       }
       &:active {
-        background-color: rgba(255,255,255, 0.2); // Assuming accent-fg-color is white
+        background-color: var(--accent-bg-active-color);
       }
       // .adw-split-button-arrow rule removed
       // Icon color will be handled by .adw-icon and currentColor if accent-fg-color is set on parent
@@ -113,7 +115,10 @@
         color: var(--accent-fg-color);
         border-color: transparent;
         .adw-split-button-action {
-            border-right-color: transparent; // Also make this transparent for disabled suggested
+            // No border here anymore
+        }
+        .adw-split-button-dropdown {
+            border-left-color: transparent; // Separator also transparent for disabled suggested
         }
     }
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -122,6 +122,7 @@
   --list-row-selected-bg-color: var(--adw-blue-1); // #99c1f1
   --list-row-selected-fg-color: var(--adw-blue-5); // #1a5fb4
   --expander-content-bg-color: rgba(0,0,0,0.03);
+  --list-separator-color: rgba(0,0,0,0.07); // Subtle separator for light theme
 
   --entry-disabled-bg-color: rgba(0,0,0,0.04);
   --entry-disabled-border-color: rgba(0,0,0,0.1);
@@ -239,6 +240,7 @@
   --list-row-selected-bg-color: var(--adw-blue-5); // #1a5fb4
   --list-row-selected-fg-color: var(--adw-blue-1); // #99c1f1
   --expander-content-bg-color: rgba(255,255,255,0.03);
+  --list-separator-color: rgba(255,255,255,0.08); // Subtle separator for dark theme
 
   --entry-disabled-bg-color: rgba(255,255,255,0.04);
   --entry-disabled-border-color: rgba(255,255,255,0.1);

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -12,6 +12,7 @@
 @use "checkbox";
 @use "dialog";
 @use "entry";
+@use "entry_row"; // Added import for entry_row
 @use "expander_row";
 @use "headerbar";
 @use "label";


### PR DESCRIPTION
- Improved visual accuracy of ListBox, ActionRow, EntryRow, SpinButton, and SplitButton components to better align with Adwaita guidelines.
- Fixed accent color application, ensuring they work correctly in both light and dark themes, and accurately represented in the demo page.
- Standardized list item separators and entry field appearances within rows.
- Corrected SpinButton layout and button height issues.
- Revamped SplitButton styling for a more polished look.
- Updated README.md to clarify the use of Web Components as primary over JS factories.
- Ensured all Markdown documentation files (README.md and docs/*) adhere to an 80-character line limit for better readability and linting compatibility.