### PR TITLE
Fix: Revamp index.html widget showcase and component behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,29 +38,108 @@
             <!-- Accent Color Picker -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Theme Controls</adw-label>
-                <adw-box orientation="horizontal" spacing="s" id="accent-color-picker-container" style="align-items: center; margin-bottom: var(--spacing-m);">
+                <adw-box orientation="horizontal" spacing="s" id="accent-color-picker-box" style="align-items: center; margin-bottom: var(--spacing-m); flex-wrap: wrap;">
                     <adw-label>Accent Color:</adw-label>
-                    {/* Buttons will be added here by JS */}
+                    {/* Declarative buttons will be placed here directly.
+                        The Adw.getAccentColors() usually returns:
+                        { id: 'default', name: 'Default' }, // often blue
+                        { id: 'blue', name: 'Blue' },
+                        { id: 'green', name: 'Green' },
+                        { id: 'yellow', name: 'Yellow' },
+                        { id: 'orange', name: 'Orange' },
+                        { id: 'red', name: 'Red' },
+                        { id: 'purple', name: 'Purple' },
+                        // Potentially pink, brown, etc. For now, sticking to common ones.
+                    */}
+                    <adw-button data-accent-color-id="default">Default</adw-button>
+                    <adw-button data-accent-color-id="blue">Blue</adw-button>
+                    <adw-button data-accent-color-id="green">Green</adw-button>
+                    <adw-button data-accent-color-id="yellow">Yellow</adw-button>
+                    <adw-button data-accent-color-id="orange">Orange</adw-button>
+                    <adw-button data-accent-color-id="red">Red</adw-button>
+                    <adw-button data-accent-color-id="purple">Purple</adw-button>
                 </adw-box>
                  <details>
-                    <summary>Show Accent Picker Code (JS)</summary>
-                    <pre><code>
-// In main script:
-const accentPickerContainer = document.getElementById('accent-color-picker-container');
-const accentColors = Adw.getAccentColors(); // Returns [{id: 'blue', name: 'Blue'}, ...]
-accentColors.forEach(color => {
-    const button = Adw.createButton(color.name, {
-        onClick: () => Adw.setAccentColor(color.id)
+                    <summary>Show Accent Picker Code</summary>
+                    <pre><code>&lt;!-- HTML Structure --&gt;
+&lt;adw-box orientation="horizontal" spacing="s" id="accent-color-picker-box" style="align-items: center; flex-wrap: wrap;"&gt;
+    &lt;adw-label&gt;Accent Color:&lt;/adw-label&gt;
+    &lt;adw-button data-accent-color-id="default"&gt;Default&lt;/adw-button&gt;
+    &lt;adw-button data-accent-color-id="blue"&gt;Blue&lt;/adw-button&gt;
+    &lt;adw-button data-accent-color-id="green"&gt;Green&lt;/adw-button&gt;
+    &lt;adw-button data-accent-color-id="yellow"&gt;Yellow&lt;/adw-button&gt;
+    &lt;adw-button data-accent-color-id="orange"&gt;Orange&lt;/adw-button&gt;
+    &lt;adw-button data-accent-color-id="red"&gt;Red&lt;/adw-button&gt;
+    &lt;adw-button data-accent-color-id="purple"&gt;Purple&lt;/adw-button&gt;
+&lt;/adw-box&gt;
+
+&lt;script&gt;
+// In main script (DOMContentLoaded):
+// Logic to handle accent button clicks and styling
+const accentPickerBox = document.getElementById('accent-color-picker-box');
+if (accentPickerBox) {
+    const accentButtons = accentPickerBox.querySelectorAll('adw-button[data-accent-color-id]');
+
+    accentButtons.forEach(button => {
+        const colorId = button.dataset.accentColorId;
+        button.addEventListener('click', () => {
+            Adw.setAccentColor(colorId);
+            // The global theme/accent change should trigger the style update via MutationObserver
+        });
     });
-    // Basic preview (relies on CSS variables being available)
-    button.style.setProperty('--button-bg-color', \`var(--accent-\${color.id}-light-bg)\`);
-    button.style.setProperty('--button-fg-color', \`var(--accent-\${color.id}-light-fg)\`);
-    accentPickerContainer.appendChild(button);
-});
+
+    function styleAccentButtons() {
+        const isLightTheme = document.body.classList.contains('light-theme') ||
+                             (!document.body.classList.contains('dark-theme') &&
+                              window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches);
+
+        accentButtons.forEach(btn => {
+            const colorId = btn.dataset.accentColorId;
+            // Resolve 'default' to the actual default color ID if necessary, e.g., 'blue'
+            const effectiveColorId = (colorId === 'default') ? (Adw.DEFAULT_ACCENT_COLOR || 'blue') : colorId;
+
+            const bgColorVar = isLightTheme ? \`var(--accent-\${effectiveColorId}-light-bg)\` : \`var(--accent-\${effectiveColorId}-dark-bg)\`;
+            const fgColorVar = isLightTheme ? \`var(--accent-\${effectiveColorId}-light-fg)\` : \`var(--accent-\${effectiveColorId}-dark-fg)\`;
+            const borderColorVar = isLightTheme ? \`var(--accent-\${effectiveColorId}-light-standalone)\` : \`var(--accent-\${effectiveColorId}-dark-standalone)\`;
+
+            btn.style.backgroundColor = bgColorVar;
+            btn.style.color = fgColorVar;
+            btn.style.borderColor = borderColorVar;
+            btn.style.borderWidth = '1px';
+            btn.style.borderStyle = 'solid';
+
+            if (effectiveColorId === 'yellow') {
+                btn.style.color = isLightTheme ? 'rgba(0,0,0,0.85)' : 'rgba(0,0,0,0.9)';
+            }
+            // Add other specific color adjustments if needed (e.g., for pink on light/dark)
+        });
+    }
+
+    // Initial styling
+    styleAccentButtons();
+
+    // Re-style accent buttons if theme changes (body class attribute)
+    const themeObserverForAccentButtons = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                // Check if it's a theme-related class change
+                if (mutation.target === document.body && (document.body.classList.contains('light-theme') || document.body.classList.contains('dark-theme'))) {
+                    styleAccentButtons();
+                }
+                // Also update if body accent class changes, e.g. body.accent-blue, etc.
+                // This ensures buttons reflect the *currently selected* accent if Adw.setAccentColor doesn't trigger the theme observer quickly enough
+                // or if we want to highlight the active accent button.
+                // For now, the primary concern is light/dark adaptation.
+                break;
+            }
+        }
+    });
+    themeObserverForAccentButtons.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+}
+&lt;/script&gt;
                     </code></pre>
                 </details>
             </section>
-
             <!-- Buttons Section -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Buttons</adw-label>
@@ -322,6 +401,37 @@ accentColors.forEach(color => {
                         <adw-label title-level="3">Main Content (Flap Demo)</adw-label>
                     </adw-box>
                 </adw-flap>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">WrapBox</adw-label>
+                <adw-wrap-box spacing="s" line-spacing="m" align="center" style="padding:var(--spacing-s); border:1px dashed var(--border-color); min-height: 100px;">
+                    <adw-button>Button 1</adw-button>
+                    <adw-button suggested>Button 2 (Suggested)</adw-button>
+                    <adw-button destructive>Button 3 (Destructive)</adw-button>
+                    <adw-label>Label 4</adw-label>
+                    <adw-entry placeholder="Entry 5"></adw-entry>
+                    <adw-button>Button 6</adw-button>
+                    <adw-button>Button 7</adw-button>
+                </adw-wrap-box>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">BreakpointBin</adw-label>
+                <adw-label is-body style="margin-bottom: var(--spacing-xs);">Resize the browser window to see different children shown by BreakpointBin. Children are defined with `data-condition` (min-width).</adw-label>
+                <adw-breakpoint-bin default-child-name="small" style="padding:var(--spacing-s); border:1px dashed var(--border-color); min-height: 100px; resize: horizontal; overflow: auto; max-width: 100%;">
+                    <adw-box data-condition="0" data-name="small" style="background-color: var(--theme-color-red-2); padding: var(--spacing-m);">
+                        <adw-label title-level="4">Small View (0px+)</adw-label>
+                        <adw-label is-body>This is shown when the BreakpointBin is narrow.</adw-label>
+                    </adw-box>
+                    <adw-box data-condition="400" data-name="medium" style="background-color: var(--theme-color-green-2); padding: var(--spacing-m);">
+                        <adw-label title-level="4">Medium View (400px+)</adw-label>
+                        <adw-label is-body>This appears when the BreakpointBin is a bit wider.</adw-label>
+                        <adw-button>A Button</adw-button>
+                    </adw-box>
+                    <adw-box data-condition="700" data-name="large" style="background-color: var(--theme-color-blue-2); padding: var(--spacing-m);">
+                        <adw-label title-level="4">Large View (700px+)</adw-label>
+                        <adw-label is-body>This is for wider BreakpointBin containers.</adw-label>
+                        <adw-entry placeholder="Enter something..."></adw-entry>
+                    </adw-box>
+                </adw-breakpoint-bin>
+
                  <details>
                     <summary>Show Layout Examples</summary>
                     <pre><code>&lt;adw-box orientation="horizontal" spacing="m"&gt;...&lt;/adw-box&gt;
@@ -329,14 +439,128 @@ accentColors.forEach(color => {
 &lt;adw-flap&gt;
   &lt;div slot="flap-content"&gt;...&lt;/div&gt;
   &lt;div slot="main-content"&gt;...&lt;/div&gt;
-&lt;/adw-flap&gt;</code></pre>
+&lt;/adw-flap&gt;
+&lt;adw-wrap-box spacing="s" line-spacing="m" align="start"&gt;
+  &lt;adw-button&gt;Item 1&lt;/adw-button&gt;
+  &lt;adw-button&gt;Item 2&lt;/adw-button&gt;
+&lt;/adw-wrap-box&gt;
+&lt;adw-breakpoint-bin default-child-name="small"&gt;
+  &lt;adw-label data-condition="0" data-name="small"&gt;Smallest&lt;/adw-label&gt;
+  &lt;adw-label data-condition="600" data-name="medium"&gt;Medium&lt;/adw-label&gt;
+  &lt;adw-label data-condition="900" data-name="large"&gt;Largest&lt;/adw-label&gt;
+&lt;/adw-breakpoint-bin&gt;</code></pre>
                 </details>
             </section>
 
             <!-- View Components -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Views</adw-label>
-                <adw-label title-level="3">ViewSwitcher &amp; TabView (Conceptual)</adw-label>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">ViewSwitcher</adw-label>
+                <adw-label is-body style="margin-bottom: var(--spacing-xs);">A basic ViewSwitcher. Content below is plain HTML, controlled by the switcher.</adw-label>
+                <adw-view-switcher id="basic-view-switcher" active-view="view1" style="margin-bottom: var(--spacing-s);">
+                    <div view-name="view1" view-title="View One"></div>
+                    <div view-name="view2" view-title="View Two (Icon)" data-view-icon="actions/go-next-symbolic"></div>
+                    <div view-name="view3" view-title="View Three"></div>
+                </adw-view-switcher>
+                <div id="basic-view-switcher-content" class="view-content-area" style="padding: var(--spacing-m); border: 1px solid var(--border-color); min-height: 50px;">
+                    <!-- JS will populate this based on view-switcher -->
+                </div>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">Inline ViewSwitcher</adw-label>
+                <adw-view-switcher id="inline-view-switcher" active-view="info" is-inline>
+                     <div view-name="info" view-title="Info" data-view-icon="status/dialog-information-symbolic"></div>
+                     <div view-name="warning" view-title="Warning" data-view-icon="status/dialog-warning-symbolic"></div>
+                     <div view-name="error" view-title="Error" data-view-icon="status/dialog-error-symbolic"></div>
+                </adw-view-switcher>
+                <div id="inline-view-switcher-content" class="view-content-area" style="padding: var(--spacing-m); border: 1px solid var(--border-color); min-height: 50px; margin-top: var(--spacing-s);">
+                    <!-- JS will populate this -->
+                </div>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">ToolbarView</adw-label>
+                <adw-toolbar-view id="my-toolbar-view" style="border: 1px solid var(--border-color); min-height: 250px;">
+                    <adw-header-bar slot="top-bar">
+                        <adw-window-title slot="title" title="ToolbarView Top"></adw-window-title>
+                        <adw-button slot="start" icon-name="actions/go-up-symbolic" id="tbv-hide-top" title="Hide Top Bar"></adw-button>
+                    </adw-header-bar>
+                    <adw-box orientation="vertical" spacing="m" style="padding: var(--spacing-l); align-items: center;">
+                        <adw-label title-level="4">Main Content Area</adw-label>
+                        <adw-label is-body>This is the main content of the ToolbarView.</adw-label>
+                        <adw-spinner active></adw-spinner>
+                    </adw-box>
+                    <adw-header-bar slot="bottom-bar">
+                        <adw-window-title slot="title" title="ToolbarView Bottom"></adw-window-title>
+                        <adw-button slot="end" icon-name="actions/go-down-symbolic" id="tbv-hide-bottom" title="Hide Bottom Bar"></adw-button>
+                    </adw-header-bar>
+                </adw-toolbar-view>
+                <adw-box orientation="horizontal" spacing="s" style="margin-top: var(--spacing-s);">
+                    <adw-button id="tbv-show-top">Show Top Bar</adw-button>
+                    <adw-button id="tbv-show-bottom">Show Bottom Bar</adw-button>
+                </adw-box>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">Carousel</adw-label>
+                <adw-carousel id="my-carousel" show-nav-buttons autoplay loop style="min-height: 200px; width: 100%; max-width: 500px; margin-bottom: var(--spacing-s); border: 1px solid var(--border-color);">
+                    <adw-box style="background-color: var(--theme-color-blue-1); width: 100%; height: 100%; display:flex; align-items:center; justify-content:center;">
+                        <adw-label title-level="1">Slide 1</adw-label>
+                    </adw-box>
+                    <adw-status-page title="Slide 2" icon-name="emoji/face-smile-symbolic" style="width: 100%; height: 100%;">
+                        <adw-label slot="description">This is a status page as a slide.</adw-label>
+                    </adw-status-page>
+                    <div style="background-color: var(--theme-color-green-1); width: 100%; height: 100%; display:flex; align-items:center; justify-content:center;">
+                        <adw-label title-level="1" style="color: var(--theme-color-green-5);">Slide 3 (Plain Div)</adw-label>
+                    </div>
+                </adw-carousel>
+                <adw-box orientation="horizontal" spacing="s">
+                     <adw-button id="carousel-prev">Prev</adw-button>
+                     <adw-button id="carousel-next">Next</adw-button>
+                     <adw-spin-button id="carousel-goto-slide" min="0" max="2" value="0"></adw-spin-button>
+                     <adw-button id="carousel-goto-btn">Go to Slide</adw-button>
+                </adw-box>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">NavigationSplitView</adw-label>
+                <adw-label is-body style="margin-bottom: var(--spacing-xs);">Master-detail view. Resize window to see collapse behavior. Sidebar is on the start.</adw-label>
+                <adw-navigation-split-view id="my-nav-split-view" style="border: 1px solid var(--border-color); min-height: 300px; margin-bottom:var(--spacing-s);" show-sidebar>
+                    <adw-list-box slot="sidebar" style="min-width: 200px; background-color: var(--sidebar-bg-color);" id="nav-split-sidebar-list">
+                        <adw-action-row title="Item 1" activatable data-item-id="item1"></adw-action-row>
+                        <adw-action-row title="Item 2" activatable data-item-id="item2"></adw-action-row>
+                        <adw-action-row title="Item 3 (No Content)" activatable data-item-id="item3"></adw-action-row>
+                    </adw-list-box>
+                    <adw-box slot="content" id="nav-split-content-area" orientation="vertical" spacing="m" style="padding: var(--spacing-l); align-items:center; justify-content:center;">
+                        <adw-status-page title="Select an Item" icon-name="actions/edit-select-all-symbolic">
+                            <adw-label slot="description">Content will appear here.</adw-label>
+                        </adw-status-page>
+                    </adw-box>
+                </adw-navigation-split-view>
+                <adw-button id="toggle-nav-split-sidebar">Toggle Sidebar</adw-button>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">OverlaySplitView</adw-label>
+                <adw-label is-body style="margin-bottom: var(--spacing-xs);">Sidebar overlays content. Can be positioned at start or end.</adw-label>
+                <adw-overlay-split-view id="my-overlay-split-view" sidebar-position="end" style="border: 1px solid var(--border-color); min-height: 300px; margin-bottom:var(--spacing-s);">
+                    <adw-list-box slot="sidebar" style="min-width: 220px; background-color: var(--secondary-sidebar-bg-color);" id="overlay-split-sidebar-list">
+                        <adw-action-row title="Option A" activatable data-option-id="optionA"></adw-action-row>
+                        <adw-action-row title="Option B" activatable data-option-id="optionB"></adw-action-row>
+                    </adw-list-box>
+                    <adw-box slot="content" id="overlay-split-content-area" orientation="vertical" spacing="m" style="padding: var(--spacing-l); align-items:center; justify-content:center;">
+                        <adw-status-page title="Main Content" icon-name="emoji/face-plain-symbolic">
+                            <adw-label slot="description">Sidebar is on the end for this demo.</adw-label>
+                        </adw-status-page>
+                    </adw-box>
+                </adw-overlay-split-view>
+                <adw-button id="toggle-overlay-split-sidebar">Toggle Overlay Sidebar</adw-button>
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">NavigationView</adw-label>
+                <adw-label is-body style="margin-bottom: var(--spacing-xs);">Manages a stack of views. HeaderBar is part of it.</adw-label>
+                <adw-navigation-view id="my-navigation-view" style="border: 1px solid var(--border-color); min-height: 350px; margin-bottom:var(--spacing-s);">
+                    <!-- Initial page defined in JS -->
+                </adw-navigation-view>
+                <adw-box orientation="horizontal" spacing="s">
+                    <adw-button id="nav-view-push-page2">Push Page 2</adw-button>
+                    <adw-button id="nav-view-push-page3">Push Page 3 (Custom Header)</adw-button>
+                    <adw-button id="nav-view-pop" disabled>Pop Page (JS enables)</adw-button>
+                </adw-box>
+
+
+                <adw-label title-level="3" style="margin-top:var(--spacing-m);">TabView</adw-label>
                  <adw-tab-view id="main-tab-view" style="border: 1px solid var(--border-color); min-height: 200px;">
                     <adw-tab-page name="tab1" title="First Tab" icon-name="categories/applications-graphics-symbolic">
                         <adw-box style="padding:var(--spacing-l);">Content of Tab 1</adw-box>
@@ -350,7 +574,13 @@ accentColors.forEach(color => {
                 </adw-tab-view>
                 <details>
                     <summary>Show View Examples</summary>
-                    <pre><code>&lt;adw-tab-view&gt;
+                    <pre><code>&lt;adw-view-switcher active-view="v1"&gt;
+  &lt;div view-name="v1" view-title="View 1"&gt;&lt;/div&gt;
+  &lt;div view-name="v2" view-title="View 2"&gt;&lt;/div&gt;
+&lt;/adw-view-switcher&gt;
+&lt;!-- JS then updates content based on 'view-changed' event --&gt;
+
+&lt;adw-tab-view&gt;
   &lt;adw-tab-page name="t1" title="Tab 1" icon-name="actions/document-new-symbolic"&gt;...&lt;/adw-tab-page&gt;
   &lt;adw-tab-page name="t2" title="Tab 2" active&gt;...&lt;/adw-tab-page&gt;
 &lt;/adw-tab-view&gt;</code></pre>
@@ -372,72 +602,65 @@ accentColors.forEach(color => {
         document.getElementById('theme-toggle-button')?.addEventListener('click', Adw.toggleTheme);
         // Add other header bar listeners if needed
 
-        // --- Accent Color Picker ---
-        const accentPickerContainer = document.getElementById('accent-color-picker-container');
-        if (accentPickerContainer) {
-            const accentColors = Adw.getAccentColors(); // Expects [{id: 'blue', name: 'Blue'}, ...]
-            accentColors.forEach(color => {
-                const button = Adw.createButton(color.name, {
-                    onClick: () => {
-                        Adw.setAccentColor(color.id);
-                        // Optionally, re-style the buttons if needed after global accent change,
-                        // but ideally they just use standard button styles that react to the theme.
-                    }
+        // --- Accent Color Picker (Declarative HTML) ---
+        const accentPickerBox = document.getElementById('accent-color-picker-box');
+        if (accentPickerBox) {
+            const accentButtons = accentPickerBox.querySelectorAll('adw-button[data-accent-color-id]');
+
+            accentButtons.forEach(button => {
+                const colorId = button.dataset.accentColorId;
+                button.addEventListener('click', () => {
+                    Adw.setAccentColor(colorId);
                 });
-                // Style the button to use its specific accent for its border,
-                // but let its main background/foreground come from standard button theming.
-                // This way, it adapts to light/dark mode better.
-                // We need to know if light or dark theme is active to pick the right standalone color.
-                const isLightTheme = document.body.classList.contains('light-theme');
-                const standaloneColorVar = isLightTheme ? `var(--accent-${color.id}-light-standalone)` : `var(--accent-${color.id}-dark-standalone)`;
-                const bgColorVar = isLightTheme ? `var(--accent-${color.id}-light-bg)` : `var(--accent-${color.id}-dark-bg)`;
-                const fgColorVar = isLightTheme ? `var(--accent-${color.id}-light-fg)` : `var(--accent-${color.id}-dark-fg)`;
-
-                // For the demo, let's make the buttons themselves use their accent color
-                // This will make them visually represent the color they set.
-                button.style.setProperty('background-color', bgColorVar);
-                button.style.setProperty('color', fgColorVar);
-                button.style.setProperty('border-color', standaloneColorVar);
-                // To ensure text is readable, especially for yellow, we might need to adjust
-                if (color.id === 'yellow') {
-                    button.style.setProperty('color', 'rgba(0,0,0,0.8)'); // Force dark text on yellow
-                }
-
-
-                accentPickerContainer.appendChild(button);
             });
 
-            // Re-style accent buttons if theme changes
-            new MutationObserver((mutationsList, observer) => {
-                for(const mutation of mutationsList) {
-                    if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                        const isLightThemeCurrent = document.body.classList.contains('light-theme');
-                        accentPickerContainer.querySelectorAll('adw-button').forEach(btn => {
-                            // Find the color.id for this button. This is a bit fragile.
-                            // Assumes button text is unique or we store color.id on the button.
-                            const colorName = btn.textContent;
-                            const accentColorObj = accentColors.find(ac => ac.name === colorName);
-                            if (accentColorObj) {
-                                const colorId = accentColorObj.id;
-                                const newStandaloneColorVar = isLightThemeCurrent ? `var(--accent-${colorId}-light-standalone)` : `var(--accent-${colorId}-dark-standalone)`;
-                                const newBgColorVar = isLightThemeCurrent ? `var(--accent-${colorId}-light-bg)` : `var(--accent-${colorId}-dark-bg)`;
-                                const newFgColorVar = isLightThemeCurrent ? `var(--accent-${colorId}-light-fg)` : `var(--accent-${colorId}-dark-fg)`;
+            function styleAccentButtons() {
+                const isLightTheme = document.body.classList.contains('light-theme') ||
+                                     (!document.body.classList.contains('dark-theme') &&
+                                      window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches);
 
-                                btn.style.setProperty('background-color', newBgColorVar);
-                                btn.style.setProperty('color', newFgColorVar);
-                                btn.style.setProperty('border-color', newStandaloneColorVar);
-                                if (colorId === 'yellow') {
-                                    btn.style.setProperty('color', 'rgba(0,0,0,0.8)');
-                                }
-                            }
-                        });
-                        break; // Only need to react once per class change
+                accentButtons.forEach(btn => {
+                    const colorId = btn.dataset.accentColorId;
+                    const effectiveColorId = (colorId === 'default') ? (Adw.DEFAULT_ACCENT_COLOR || 'blue') : colorId;
+
+                    const bgColorVar = isLightTheme ? `var(--accent-${effectiveColorId}-light-bg)` : `var(--accent-${effectiveColorId}-dark-bg)`;
+                    const fgColorVar = isLightTheme ? `var(--accent-${effectiveColorId}-light-fg)` : `var(--accent-${effectiveColorId}-dark-fg)`;
+                    const borderColorVar = isLightTheme ? `var(--accent-${effectiveColorId}-light-standalone)` : `var(--accent-${effectiveColorId}-dark-standalone)`;
+
+                    btn.style.backgroundColor = bgColorVar;
+                    btn.style.color = fgColorVar;
+                    btn.style.borderColor = borderColorVar;
+                    btn.style.borderWidth = '1px';
+                    btn.style.borderStyle = 'solid';
+
+                    if (effectiveColorId === 'yellow') {
+                        btn.style.color = isLightTheme ? 'rgba(0,0,0,0.85)' : 'rgba(0,0,0,0.9)';
+                    }
+                });
+            }
+
+            // Initial styling
+            if (window.Adw && Adw.DEFAULT_ACCENT_COLOR) { // Ensure Adw is loaded for DEFAULT_ACCENT_COLOR
+                 styleAccentButtons();
+            } else {
+                // If Adw or DEFAULT_ACCENT_COLOR is not yet available, wait a moment.
+                // This can happen if this script runs before adw-initializer.js fully sets up Adw.
+                setTimeout(styleAccentButtons, 50);
+            }
+
+
+            // Re-style accent buttons if theme or accent changes (body class attribute)
+            const themeObserverForAccentButtons = new MutationObserver((mutationsList) => {
+                for (const mutation of mutationsList) {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'class' && mutation.target === document.body) {
+                        styleAccentButtons();
+                        break;
                     }
                 }
-            }).observe(document.body, { attributes: true });
-
+            });
+            themeObserverForAccentButtons.observe(document.body, { attributes: true, attributeFilter: ['class'] });
         } else {
-            console.warn("Accent color picker container not found.");
+            console.warn("Accent color picker box ('accent-color-picker-box') not found.");
         }
 
         // --- General Button Toasts (for quick feedback) ---
@@ -520,8 +743,213 @@ accentColors.forEach(color => {
 
         // --- TabView ---
         const mainTabView = document.getElementById('main-tab-view');
-        mainTabView?.addEventListener('tab-selected', (e) => Adw.createToast(`Tab selected: ${e.detail.title}`));
-        mainTabView?.addEventListener('tab-closed', (e) => Adw.createToast(`Tab closed: ${e.detail.title}`));
+        mainTabView?.addEventListener('page-changed', (e) => Adw.createToast(`Tab selected: ${e.detail.pageName}`)); // Changed from tab-selected
+        mainTabView?.addEventListener('page-closed', (e) => Adw.createToast(`Tab closed: ${e.detail.pageName}`)); // Changed from tab-closed
+
+        // --- ViewSwitcher Examples ---
+        const basicViewSwitcher = document.getElementById('basic-view-switcher');
+        const basicViewSwitcherContent = document.getElementById('basic-view-switcher-content');
+        if (basicViewSwitcher && basicViewSwitcherContent) {
+            const updateBasicViewContent = (viewName) => {
+                basicViewSwitcherContent.innerHTML = ''; // Clear previous
+                const newContent = document.createElement('adw-label');
+                newContent.isBody = true;
+                newContent.textContent = `Content for ${viewName}`;
+                basicViewSwitcherContent.appendChild(newContent);
+            };
+            basicViewSwitcher.addEventListener('view-changed', (e) => {
+                updateBasicViewContent(e.detail.viewName);
+                Adw.createToast(`Basic ViewSwitcher changed to: ${e.detail.viewName}`);
+            });
+            // Initial content
+            if (basicViewSwitcher.getAttribute('active-view')) {
+                updateBasicViewContent(basicViewSwitcher.getAttribute('active-view'));
+            }
+        }
+
+        const inlineViewSwitcher = document.getElementById('inline-view-switcher');
+        const inlineViewSwitcherContent = document.getElementById('inline-view-switcher-content');
+        if (inlineViewSwitcher && inlineViewSwitcherContent) {
+            const updateInlineViewContent = (viewName) => {
+                inlineViewSwitcherContent.innerHTML = ''; // Clear previous
+                const newContent = document.createElement('adw-status-page');
+                newContent.title = viewName.charAt(0).toUpperCase() + viewName.slice(1);
+                let iconName = 'status/dialog-information-symbolic';
+                if (viewName === 'warning') iconName = 'status/dialog-warning-symbolic';
+                if (viewName === 'error') iconName = 'status/dialog-error-symbolic';
+                newContent.iconName = iconName;
+                const desc = document.createElement('adw-label');
+                desc.slot = 'description';
+                desc.isBody = true;
+                desc.textContent = `This is the '${viewName}' view selected from the inline switcher.`;
+                newContent.appendChild(desc);
+                inlineViewSwitcherContent.appendChild(newContent);
+            };
+            inlineViewSwitcher.addEventListener('view-changed', (e) => {
+                updateInlineViewContent(e.detail.viewName);
+                Adw.createToast(`Inline ViewSwitcher changed to: ${e.detail.viewName}`);
+            });
+            // Initial content
+            if (inlineViewSwitcher.getAttribute('active-view')) {
+                updateInlineViewContent(inlineViewSwitcher.getAttribute('active-view'));
+            }
+        }
+
+        // --- ToolbarView Example ---
+        const myToolbarView = document.getElementById('my-toolbar-view');
+        if (myToolbarView) {
+            document.getElementById('tbv-hide-top')?.addEventListener('click', () => myToolbarView.hideTopBar());
+            document.getElementById('tbv-show-top')?.addEventListener('click', () => myToolbarView.showTopBar());
+            document.getElementById('tbv-hide-bottom')?.addEventListener('click', () => myToolbarView.hideBottomBar());
+            document.getElementById('tbv-show-bottom')?.addEventListener('click', () => myToolbarView.showBottomBar());
+        }
+
+        // --- Carousel Example ---
+        const myCarousel = document.getElementById('my-carousel');
+        if (myCarousel) {
+            document.getElementById('carousel-prev')?.addEventListener('click', () => myCarousel.prev());
+            document.getElementById('carousel-next')?.addEventListener('click', () => myCarousel.next());
+            document.getElementById('carousel-goto-btn')?.addEventListener('click', () => {
+                const slideNum = parseInt(document.getElementById('carousel-goto-slide').value, 10);
+                myCarousel.goTo(slideNum);
+            });
+            myCarousel.addEventListener('slide-changed', (e) => {
+                Adw.createToast(`Carousel slide changed to: ${e.detail.currentIndex}`, {timeout: 1000});
+                const gotoSpinButton = document.getElementById('carousel-goto-slide');
+                if(gotoSpinButton) gotoSpinButton.value = e.detail.currentIndex;
+            });
+        }
+
+        // --- NavigationSplitView Example ---
+        const navSplitView = document.getElementById('my-nav-split-view');
+        if (navSplitView) {
+            document.getElementById('toggle-nav-split-sidebar')?.addEventListener('click', () => navSplitView.toggleSidebar());
+            const navSplitContentArea = document.getElementById('nav-split-content-area');
+            document.querySelectorAll('#nav-split-sidebar-list adw-action-row').forEach(row => {
+                row.addEventListener('click', (e) => {
+                    const itemId = e.currentTarget.dataset.itemId;
+                    if (navSplitContentArea) {
+                        navSplitContentArea.innerHTML = ''; // Clear
+                        if (itemId === 'item1' || itemId === 'item2') {
+                            const itemLabel = document.createElement('adw-label');
+                            itemLabel.titleLevel = "1";
+                            itemLabel.textContent = `Content for ${itemId}`;
+                            const itemDesc = document.createElement('adw-label');
+                            itemDesc.isBody = true;
+                            itemDesc.textContent = `Details about ${itemId} would go here.`;
+                            navSplitContentArea.append(itemLabel, itemDesc);
+                        } else {
+                            const statusPage = document.createElement('adw-status-page');
+                            statusPage.title = "No Content";
+                            statusPage.iconName = "status/folder-visiting-symbolic";
+                            const desc = document.createElement('adw-label');
+                            desc.slot="description";
+                            desc.textContent = `There's no specific content for ${itemId}.`;
+                            statusPage.appendChild(desc);
+                            navSplitContentArea.appendChild(statusPage);
+                        }
+                    }
+                    if (navSplitView.isOverlayMode() && navSplitView.isSidebarVisible()) {
+                        navSplitView.hideSidebar();
+                    }
+                    Adw.createToast(`${itemId} selected in NavSplitView`);
+                });
+            });
+            navSplitView.addEventListener('sidebar-toggled', (e) => {
+                Adw.createToast(`NavSplitView sidebar is now ${e.detail.isVisible ? 'visible' : 'hidden'}. Overlay: ${e.detail.isOverlay}`, {timeout:1500});
+            });
+        }
+
+        // --- OverlaySplitView Example ---
+        const overlaySplitView = document.getElementById('my-overlay-split-view');
+        if (overlaySplitView) {
+            document.getElementById('toggle-overlay-split-sidebar')?.addEventListener('click', () => overlaySplitView.toggleSidebar());
+            const overlaySplitContentArea = document.getElementById('overlay-split-content-area'); // Not used for changing content in this demo
+            document.querySelectorAll('#overlay-split-sidebar-list adw-action-row').forEach(row => {
+                row.addEventListener('click', (e) => {
+                    const optionId = e.currentTarget.dataset.optionId;
+                    Adw.createToast(`${optionId} selected in OverlaySplitView sidebar`);
+                    // In a real app, you might change content or navigate.
+                    // For demo, just close sidebar if it's overlaying (which it always is in this component)
+                    if (overlaySplitView.isSidebarVisible()) {
+                        overlaySplitView.hideSidebar();
+                    }
+                });
+            });
+            overlaySplitView.addEventListener('sidebar-toggled', (e) => {
+                 Adw.createToast(`OverlaySplitView sidebar is now ${e.detail.isVisible ? 'visible' : 'hidden'}`, {timeout:1500});
+            });
+        }
+
+        // --- NavigationView Example ---
+        const navView = document.getElementById('my-navigation-view');
+        const navViewPopButton = document.getElementById('nav-view-pop');
+
+        function updateNavViewPopButtonState() {
+            if (navView && navViewPopButton) {
+                // The AdwNavigationView's pageStack is internal to the factory.
+                // We can infer stack depth by checking if getVisiblePageName returns the first page name,
+                // or by keeping our own counter, or by checking if a back button is present in its header.
+                // For simplicity, let's assume page names are unique and 'page1' is root.
+                const currentVisiblePage = navView.getVisiblePageName();
+                navViewPopButton.disabled = !currentVisiblePage || currentVisiblePage === 'page1';
+            }
+        }
+
+        if (navView) {
+            const createNavPage = (name, title, contentHTML, headerOptions = {}) => {
+                const pageElement = document.createElement('div'); // This is the element to be given to navView.push
+                pageElement.dataset.pageName = name; // Used by AdwNavigationView to identify the page
+                pageElement.style.cssText = "display: flex; flex-direction: column; align-items: center; justify-content: center; padding: var(--spacing-xl); height: 100%; box-sizing: border-box;";
+                pageElement.innerHTML = contentHTML;
+
+                // For AdwNavigationView, header options are part of the object passed to push()
+                return {
+                    name: name,
+                    element: pageElement,
+                    header: { title: title, ...headerOptions } // subtitle, start/end widgets
+                };
+            };
+
+            const page1Data = createNavPage('page1', 'Initial Page', '<adw-label title-level="1">Welcome to Page 1</adw-label><adw-label is-body>This is the first page in the NavigationView.</adw-label>');
+            navView.push(page1Data); // Push initial page
+
+            document.getElementById('nav-view-push-page2')?.addEventListener('click', () => {
+                const page2Data = createNavPage('page2', 'Page Two', '<adw-label title-level="1">Details - Page 2</adw-label><adw-button id=\'nav-view-goto-page1\'>Go to Page 1 (will pop)</adw-button>');
+                navView.push(page2Data);
+                // Add listener for the button inside page 2 after it's potentially pushed
+                setTimeout(() => { // Ensure element is in DOM if navView.push is async in rendering
+                    const btn = page2Data.element.querySelector('#nav-view-goto-page1');
+                    btn?.addEventListener('click', () => navView.pop());
+                }, 0);
+            });
+
+            document.getElementById('nav-view-push-page3')?.addEventListener('click', () => {
+                const endButton = document.createElement('adw-button');
+                endButton.iconName = "actions/document-save-symbolic";
+                endButton.addEventListener('click', () => Adw.createToast("Save clicked on Page 3 header"));
+
+                const page3Data = createNavPage(
+                    'page3',
+                    'Page Three',
+                    '<adw-label title-level="1">Advanced Page 3</adw-label><adw-label is-body>This page has a custom header item.</adw-label>',
+                    { subtitle: "With a subtitle", end: [endButton] }
+                );
+                navView.push(page3Data);
+            });
+
+            navViewPopButton?.addEventListener('click', () => navView.pop());
+
+            navView.addEventListener('pushed', (e) => {
+                Adw.createToast(`Pushed: ${e.detail.pageName}`);
+                updateNavViewPopButtonState();
+            });
+            navView.addEventListener('popped', (e) => {
+                Adw.createToast(`Popped: ${e.detail.pageName}`);
+                updateNavViewPopButtonState();
+            });
+            updateNavViewPopButtonState(); // Initial state
+        }
 
 
         console.log("Adwaita Web Showcase Initialized!");

--- a/js/components/layouts.js
+++ b/js/components/layouts.js
@@ -113,12 +113,12 @@ export function createAdwFlap(options = {}) {
     flapElement.style.setProperty('--adw-flap-transition-speed', opts.transitionSpeed);
 
     const flapContentWrapper = document.createElement('div');
-    flapContentWrapper.classList.add('adw-flap-content-wrapper');
+    flapContentWrapper.classList.add('adw-flap-flap-content'); // Corrected class name
     if(opts.flapContent instanceof Node) flapContentWrapper.appendChild(opts.flapContent);
     flapElement.appendChild(flapContentWrapper);
 
     const mainContentWrapper = document.createElement('div');
-    mainContentWrapper.classList.add('adw-flap-main-content-wrapper');
+    mainContentWrapper.classList.add('adw-flap-main-content'); // Corrected class name
     if(opts.mainContent instanceof Node) mainContentWrapper.appendChild(opts.mainContent);
     flapElement.appendChild(mainContentWrapper);
 
@@ -172,24 +172,18 @@ export class AdwFlap extends HTMLElement {
         }
     }
     _render() {
-        const flapContentSlot = this.querySelector('[slot="flap"]');
-        const mainContentSlot = this.querySelector('[slot="main"]');
+        // These are the actual <slot> elements that will be placed in the Shadow DOM
+        // by the factory, allowing light DOM content to project into them.
+        const flapContentSlotElement = document.createElement('slot');
+        flapContentSlotElement.name = 'flap-content';
 
-        // Use document fragments to hold cloned content before passing to factory
-        const flapContentFragment = document.createDocumentFragment();
-        if (flapContentSlot) flapContentFragment.appendChild(flapContentSlot.cloneNode(true));
-        else { const div = document.createElement('div'); div.innerHTML = '<slot name="flap"></slot>'; flapContentFragment.appendChild(div.firstChild); }
-
-
-        const mainContentFragment = document.createDocumentFragment();
-        if (mainContentSlot) mainContentFragment.appendChild(mainContentSlot.cloneNode(true));
-        else { const div = document.createElement('div'); div.innerHTML = '<slot name="main"></slot>'; mainContentFragment.appendChild(div.firstChild); }
-
+        const mainContentSlotElement = document.createElement('slot');
+        mainContentSlotElement.name = 'main-content';
 
         const options = {
             isFolded: this.hasAttribute('folded'),
-            flapContent: flapContentFragment,
-            mainContent: mainContentFragment
+            flapContent: flapContentSlotElement, // Pass the <slot> element itself
+            mainContent: mainContentSlotElement  // Pass the <slot> element itself
         };
         if (this.hasAttribute('flap-width')) options.flapWidth = this.getAttribute('flap-width');
         if (this.hasAttribute('transition-speed')) options.transitionSpeed = this.getAttribute('transition-speed');


### PR DESCRIPTION
- Refactored Accent Color picker in index.html to use declarative adw-buttons and updated JS for styling.
- Fixed AdwFlap component: Corrected CSS class name mismatch and slot handling in JS to ensure proper operation and content projection.
- Fixed AdwViewSwitcher: Modified JS factory to create the correct DOM structure (.adw-view-switcher-bar) expected by SCSS, enabling proper styling (including inline mode).
- Added missing widget showcases to index.html for:
  - AdwWrapBox
  - AdwBreakpointBin
  - AdwViewSwitcher (dedicated examples)
  - AdwToolbarView
  - AdwCarousel
  - AdwNavigationSplitView
  - AdwOverlaySplitView
  - AdwNavigationView
- Added/updated JS in index.html for interactive demos of these new showcases.
- Ensured new showcases use declarative web components as per requirements.
- Updated example code snippets in <details> sections for several components.
- Minor updates to TabView event listeners in index.html demo script to use 'page-changed' and 'page-closed' events.