### PR TITLE
Style: Improve Adwaita resemblance for ActionRow and EntryRow

### DIFF
--- a/scss/_action_row.scss
+++ b/scss/_action_row.scss
@@ -53,7 +53,7 @@
   .adw-action-row-title { // This is "label.title"
     font-size: var(--font-size-base);
     color: var(--primary-fg-color); // Use primary text color for titles
-    font-weight: 500; // Slightly bolder for emphasis
+    font-weight: normal; // Standard Adwaita row titles are normal weight
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -61,13 +61,11 @@
 
   .adw-action-row-subtitle { // This is "label.subtitle"
     font-size: var(--font-size-small);
-    color: var(--secondary-fg-color); // Subtitles are secondary
-    // opacity: 0.7; // Using secondary-fg-color might be enough, or keep opacity for further dimming.
-                     // Libadwaita often just uses the secondary color without extra opacity.
+    color: var(--secondary-fg-color); // Subtitles are secondary. This var likely includes opacity.
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    margin-top: var(--spacing-xxs);
+    margin-top: var(--spacing-xxs); // Small gap between title and subtitle
   }
 
   .adw-action-row-suffix {

--- a/scss/_entry.scss
+++ b/scss/_entry.scss
@@ -1,29 +1,68 @@
 @use "variables";
 
 .adw-entry {
-  padding: var(--spacing-xs) var(--spacing-s); // 6px 9px
-  border-width: var(--border-width, 1px);
+  // Define default values for overridable properties using new local CSS variables
+  --_entry-padding-vertical: var(--entry-padding-vertical, var(--spacing-xs));
+  --_entry-padding-horizontal: var(--entry-padding-horizontal, var(--spacing-s));
+  --_entry-border-width: var(--entry-border-width, var(--border-width, 1px));
+  --_entry-border-color: var(--entry-border-color, var(--borders-color)); // Default to general borders-color
+  --_entry-background-color: var(--entry-background-color, var(--view-bg-color));
+  --_entry-box-shadow: var(--entry-box-shadow, inset 0 1px 1px var(--entry-inset-shadow-light));
+  --_entry-focus-border-color: var(--entry-focus-border-color, var(--accent-color));
+  --_entry-focus-box-shadow: var(--entry-focus-box-shadow, 0 0 0 1px var(--accent-color));
+
+
+  padding: var(--_entry-padding-vertical) var(--_entry-padding-horizontal);
+  border-width: var(--_entry-border-width);
   border-style: solid;
-  border-color: var(--entry-border-color);
+  border-color: var(--_entry-border-color);
   border-radius: var(--border-radius-medium); // 4px
-  background-color: var(--view-bg-color);
+  background-color: var(--_entry-background-color);
   color: var(--view-fg-color);
   font-size: var(--font-size-base);
-  transition: border-color 0.1s ease-out, box-shadow 0.1s ease-out; // shorter transition
-  box-shadow: inset 0 1px 1px var(--entry-inset-shadow-light);
+  transition: border-color 0.1s ease-out, box-shadow 0.1s ease-out;
+  box-shadow: var(--_entry-box-shadow);
 
   body.dark-theme & {
-    box-shadow: inset 0 1px 1px var(--entry-inset-shadow-dark);
+    --_entry-box-shadow: var(--entry-box-shadow, inset 0 1px 1px var(--entry-inset-shadow-dark));
+    // Re-apply because the default above is light-theme specific due to var(--entry-inset-shadow-light)
+    box-shadow: var(--_entry-box-shadow);
   }
 
   &:focus,
   &:focus-within {
     outline: none;
-    border-color: var(--accent-color);
-    // The 2px effective focus ring: 1px border (already set by border-color) + 1px outer shadow
-    box-shadow: inset 0 1px 1px var(--entry-inset-shadow-light), 0 0 0 1px var(--accent-color);
+    border-color: var(--_entry-focus-border-color);
+    box-shadow: var(--_entry-focus-box-shadow);
+    // Special handling for combined inset shadow + focus shadow for standalone entries
+    // If --_entry-focus-box-shadow is the accent ring, and --_entry-box-shadow is the inset, they combine.
+    // This logic might need refinement if --entry-focus-box-shadow completely replaces the inset.
+    // For EntryRow, --_entry-box-shadow will be 'none', and focus border width changes.
+    // Let's assume for standalone, the focus shadow is *in addition* to the inset shadow if not overridden.
+    // The definition of --_entry-focus-box-shadow needs to be robust.
+    // The original was: inset 0 1px 1px var(--entry-inset-shadow-light), 0 0 0 1px var(--accent-color);
+    // So, let's make --_entry-focus-box-shadow default to that.
+    // And --_entry-box-shadow is just the inset part.
+    // Defaulting --_entry-focus-box-shadow to:
+    //   `var(--entry-focus-box-shadow, #{var(--_entry-box-shadow)}, 0 0 0 1px var(--accent-color))`
+    // This requires SASS interpolation if var(--_entry-box-shadow) should be part of the default.
+    // Simpler: Define --_entry-focus-box-shadow in _variables or let it be set completely.
+    // For now, the definition in _entry_row.scss will fully override these for the flat look.
+    // The default focus shadow for standalone entry will be:
+    // inset (from --_entry-box-shadow) + accent ring (from --_entry-focus-box-shadow if it's just the ring)
+    // Re-evaluating:
+    // Standalone focus: border turns accent, outer ring appears. Inset shadow remains.
+    // So, border-color: var(--_entry-focus-border-color) is correct.
+    // box-shadow should be: var(--_entry-box-shadow), var(--_entry-focus-box-shadow-ring); (if ring is separate)
+    // Original: box-shadow: inset ..., 0 0 0 1px var(--accent-color);
+    // Let's refine the default focus shadow variable to be just the ring part.
+    --_entry-focus-box-shadow-ring: var(--entry-focus-box-shadow-ring, 0 0 0 1px var(--accent-color));
+    box-shadow: var(--_entry-box-shadow), var(--_entry-focus-box-shadow-ring);
+
     body.dark-theme & {
-      box-shadow: inset 0 1px 1px var(--entry-inset-shadow-dark), 0 0 0 1px var(--accent-color);
+       // Ensure dark theme inset shadow is used along with the focus ring
+      --_entry-box-shadow: var(--entry-box-shadow, inset 0 1px 1px var(--entry-inset-shadow-dark));
+      box-shadow: var(--_entry-box-shadow), var(--_entry-focus-box-shadow-ring);
     }
   }
 

--- a/scss/_entry_row.scss
+++ b/scss/_entry_row.scss
@@ -59,11 +59,12 @@
     &:focus,
     &.focus, // If AdwEntry component uses .focus class
     &:focus-within { // If AdwEntry has internal input
-      // Standard Adwaita focus for entries: accent colored bottom border
-      --entry-border-color: var(--accent-color);
-      --entry-border-width: 0 0 2px 0; // Bottom border only
-      --entry-background-color: var(--view-bg-color); // Slight background change on focus
-      // No box-shadow for focus needed if border is used
+      // Standard Adwaita focus for entries in rows: accent colored bottom border
+      --entry-border-color: var(--accent-color); // This will be used by --_entry-focus-border-color in _entry.scss
+      --entry-border-width: 0 0 2px 0; // Bottom border only for the main border
+      --entry-background-color: var(--view-bg-color); // Slight background change on focus (or keep transparent if preferred)
+      --entry-box-shadow: none; // Ensure no other shadows are present
+      --entry-focus-box-shadow-ring: none; // Explicitly disable the outer focus ring for integrated entries
     }
 
     &[disabled],


### PR DESCRIPTION
- Modified ActionRow SCSS:
  - Set title font-weight to normal.
  - Ensured subtitle uses secondary foreground color consistently.
- Refactored Entry SCSS:
  - Use internal overridable CSS variables for styling properties.
- Modified EntryRow SCSS:
  - Override default Entry styles for a flat, integrated look.
  - Ensure bottom accent border on focus for integrated entries.

Note: SCSS compilation using build-adwaita-web.sh requires 'sass' command to be available.