### PR TITLE
Fix: Resolve icon loading and Node.insertBefore errors

### DIFF
--- a/js/components/misc.js
+++ b/js/components/misc.js
@@ -658,8 +658,8 @@ export class AdwPreferencesGroup extends HTMLElement {
 
 // --- AdwIcon ---
 const svgIconCache = new Map();
-// Assuming index.html is served from a directory like 'app-demo/' and 'data/' is at the project root.
-const ICON_BASE_PATH = '../data/icons/symbolic/';
+// Path should be absolute from the web server root, as /data/ seems to be served at root.
+const ICON_BASE_PATH = '/data/icons/symbolic/';
 
 /**
  * Creates an Adwaita-style icon element by fetching and embedding an SVG.


### PR DESCRIPTION
- Corrected ICON_BASE_PATH in misc.js to use an absolute path for icons, resolving 404s for existing icons.
- Fixed 'Node.insertBefore' errors in AdwTabView and AdwNavigationView (views.js) by ensuring their internal '_pagesSlot' is appended to the Shadow DOM before being used as a reference node.
- Enhanced AdwNavigationView.push error logging for invalid arguments.

Note: JS files were modified in the root 'js/' directory. The build script (build-adwaita-web.sh) needs to be run (requires 'sass') to copy these updates to 'app-demo/static/js/' and compile SCSS.