### PR TITLE
Refactor: Update app-demo to use web components for theming

### DIFF
--- a/app-demo/static/js/settings.js
+++ b/app-demo/static/js/settings.js
@@ -1,131 +1,110 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const themeSwitch = document.getElementById('theme-switch'); // This is now <adw-switch-row>
-  const accentColorCombo = document.getElementById('accent-color-combo'); // This is now <adw-combo-row>
-  const body = document.body;
-
-  const ACCENT_COLORS_LIST = [
-    { value: 'default', label: 'Default (Blue)' },
-    { value: 'green', label: 'Green' },
-    { value: 'orange', label: 'Orange' },
-    { value: 'purple', label: 'Purple' },
-    { value: 'red', label: 'Red' },
-    { value: 'yellow', label: 'Yellow' }
-  ];
+  const themeSwitch = document.getElementById('theme-switch'); // This is <adw-switch-row>
+  const accentColorCombo = document.getElementById('accent-color-combo'); // This is <adw-combo-row>
+  const body = document.body; // Still useful for server-side initial values
 
   // --- Initialization ---
   function initializeSettings() {
+    if (!window.Adw) {
+      console.error("Adwaita-Web (Adw) object not found. Make sure components.js is loaded before settings.js");
+      return;
+    }
+
     // Populate Accent Color ComboBox
     if (accentColorCombo) {
-      // Assuming <adw-combo-row> has a `selectOptions` property
-      // that takes an array of {label: string, value: string}
-      accentColorCombo.selectOptions = ACCENT_COLORS_LIST;
+      const availableAccents = Adw.getAccentColors(); // Returns [{id: 'blue', name: 'Default (Blue)'}, ...]
+      accentColorCombo.selectOptions = availableAccents.map(accent => ({
+        value: accent.id, // e.g. 'blue'
+        label: accent.name // e.g. 'Default (Blue)'
+      }));
+
+      // Load and apply saved accent color
+      // Adw.loadSavedTheme() already calls Adw.setAccentColor with localStorage or default.
+      // We just need to set the combo box's initial value.
+      const currentAccentName = localStorage.getItem('accentColorName') || body.dataset.serverAccentColor || Adw.DEFAULT_ACCENT_COLOR_NAME;
+      accentColorCombo.value = currentAccentName;
     }
 
     // Load and apply saved theme
-    const savedTheme = localStorage.getItem('theme') || (body.dataset.serverTheme || 'light'); // Default to light if no system preference
+    // Adw.loadSavedTheme() is called automatically on DOMContentLoaded from utils.js
+    // It handles localStorage, system preference, and applies the theme.
+    // We just need to set the switch's initial state.
     if (themeSwitch) {
-      // <adw-switch-row> should have an 'active' property
-      themeSwitch.active = (savedTheme === 'dark');
+      const currentTheme = localStorage.getItem('theme') || (body.classList.contains('light-theme') ? 'light' : 'dark');
+      themeSwitch.active = (currentTheme === 'dark');
     }
-    applyTheme(savedTheme);
-
-    // Load and apply saved accent color
-    const savedAccentColor = localStorage.getItem('accentColor') || (body.dataset.serverAccentColor || 'default');
-    if (accentColorCombo) {
-      // <adw-combo-row> should have a 'value' property
-      accentColorCombo.value = savedAccentColor;
-    }
-    applyAccentColor(savedAccentColor);
   }
 
-  // --- Theme Logic ---
-  function applyTheme(theme) {
-    body.classList.remove('dark-theme', 'light-theme');
-    if (theme === 'dark') {
-      body.classList.add('dark-theme');
-    } else { // light or system (defaulting to light for now)
-      body.classList.add('light-theme');
-    }
-    // Dispatch event for other components if needed
-    document.dispatchEvent(new CustomEvent('adw-theme-changed', {
-      detail: { theme, isLight: (theme === 'light') }
-    }));
-  }
-
+  // --- Event Listeners ---
   if (themeSwitch) {
-    // Assuming <adw-switch-row> fires a 'change' event,
-    // and its state is in event.target.active or this.active
     themeSwitch.addEventListener('change', function() {
-      const newTheme = this.active ? 'dark' : 'light';
-      localStorage.setItem('theme', newTheme);
-      applyTheme(newTheme);
+      // Adw.toggleTheme() handles applying the class and saving to localStorage.
+      Adw.toggleTheme();
+      const newTheme = document.body.classList.contains('light-theme') ? 'light' : 'dark';
       savePreference('/api/settings/theme', { theme: newTheme });
     });
   }
 
-  // --- Accent Color Logic ---
-  function applyAccentColor(accent) {
-    // Remove old accent classes
-    ACCENT_COLORS_LIST.forEach(color => {
-      body.classList.remove(`accent-${color.value}`);
-    });
-
-    // Add 'accent-default' for default or rely on CSS to not have an accent class for default.
-    // The _theme.scss uses body.accent-blue for default blue.
-    if (accent && accent !== 'default') {
-      body.classList.add(`accent-${accent}`);
-    } else {
-      body.classList.add('accent-default'); // This class should map to blue or rely on :root default
-    }
-    // Dispatch event for other components if needed
-    document.dispatchEvent(new CustomEvent('adw-accent-changed', { detail: { accent } }));
-  }
-
   if (accentColorCombo) {
-    // Assuming <adw-combo-row> fires a 'change' event,
-    // and its value is in event.target.value or this.value
     accentColorCombo.addEventListener('change', function() {
-      const newAccentColor = this.value;
-      localStorage.setItem('accentColor', newAccentColor);
-      applyAccentColor(newAccentColor);
-      savePreference('/api/settings/accent_color', { accent_color: newAccentColor });
+      const newAccentColorName = this.value; // e.g. 'green'
+      // Adw.setAccentColor() handles applying the CSS variables and saving to localStorage.
+      Adw.setAccentColor(newAccentColorName);
+      savePreference('/api/settings/accent_color', { accent_color: newAccentColorName });
     });
   }
 
-  // --- API Helper ---
+  // --- API Helper (for server-side persistence) ---
   async function savePreference(url, data) {
     try {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+      if (!csrfToken) {
+        console.error('CSRF token not found. Cannot save preference.');
+        // Adw.createAdwToast('Error: CSRF token missing.', { type: 'error' });
+        return;
+      }
+
       const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          // Ensure CSRF token is available and correctly sourced
-          'X-CSRFToken': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+          'X-CSRFToken': csrfToken
         },
         body: JSON.stringify(data),
       });
+
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({ message: response.statusText }));
-        console.error('Failed to save preference:', errorData.message);
-        // Optionally, revert UI change or show error toast
-        // Example: createAdwToast(`Failed to save: ${errorData.message}`, { type: 'error' });
+        const errorData = await response.json().catch(() => ({ message: `Request failed with status: ${response.status}` }));
+        console.error('Failed to save preference to server:', errorData.message || response.statusText);
+        // Example: Adw.createAdwToast(`Failed to save: ${errorData.message || response.statusText}`, { type: 'error' });
       } else {
         const result = await response.json();
-        console.log('Preference saved:', result.message, data);
-        // Example: createAdwToast('Settings saved!', { type: 'success' });
+        console.log('Preference saved to server:', result.message, data);
+        // Example: Adw.createAdwToast('Settings saved to server!', { type: 'success' });
       }
     } catch (error) {
-      console.error('Error saving preference:', error);
-      // Example: createAdwToast(`Error: ${error.message}`, { type: 'error' });
+      console.error('Error saving preference to server:', error);
+      // Example: Adw.createAdwToast(`Client-side error: ${error.message}`, { type: 'error' });
     }
   }
 
-  // Wait for custom elements to be defined and upgraded.
-  // Using requestAnimationFrame to delay initialization slightly after DOMContentLoaded
-  // to give custom elements a better chance to upgrade, though ideally,
-  // one would use customElements.whenDefined('adw-switch-row').then(...)
-  // for each component if this becomes an issue.
-  requestAnimationFrame(() => {
-    initializeSettings();
-  });
+  // Initialize settings after custom elements are likely defined and Adw object is available.
+  // Adw.loadSavedTheme is already attached to DOMContentLoaded in utils.js,
+  // so theme and accent are applied by the time this runs.
+  // This mainly ensures UI elements (switch, combo) reflect the loaded state.
+  if (window.customElements && typeof customElements.whenDefined === 'function') {
+    Promise.all([
+      customElements.whenDefined('adw-switch-row'),
+      customElements.whenDefined('adw-combo-row')
+    ]).then(() => {
+      initializeSettings();
+    }).catch(error => {
+      console.error("Error waiting for Adwaita components to be defined:", error);
+      // Fallback to initialize after a short delay if whenDefined fails or is not supported.
+      requestAnimationFrame(initializeSettings);
+    });
+  } else {
+    // Fallback for older browsers or environments where whenDefined might not be robust.
+    requestAnimationFrame(initializeSettings);
+  }
 });


### PR DESCRIPTION
Updates app-demo/static/js/settings.js to correctly interact with adw-switch-row and adw-combo-row web components for theme and accent color selection.

Leverages Adw.toggleTheme(), Adw.setAccentColor(), and Adw.getAccentColors() from the Adwaita-Web library for managing theme state and applying accent colors via CSS custom properties.

Ensured that scss/_variables.scss contains complete definitions for all accent colors (blue, green, yellow, orange, purple, red, teal, pink, brown) for both light and dark themes, including hover and active states, to address issues with accent color visibility across themes.

Server-side persistence logic in settings.js is maintained.