### PR TITLE
Fix: Correct CSS path for Adwaita Web components

### DIFF
--- a/js/components.js
+++ b/js/components.js
@@ -20,7 +20,7 @@ import * as listbox from './components/listbox.js'; // Import AdwListBox
 
 const Adw = {
     config: {
-        cssPath: 'app-demo/static/css/adwaita-web.css' // Default path, can be overridden by user
+        cssPath: '/static/css/adwaita-web.css' // Default path, can be overridden by user
     },
     // Utilities
     adwGenerateId: utils.adwGenerateId,


### PR DESCRIPTION
Changed Adw.config.cssPath in js/components.js from 'app-demo/static/css/adwaita-web.css' to '/static/css/adwaita-web.css'.

This resolves an issue where web components were attempting to load their shadow DOM stylesheets from an incorrect URL
(e.g., http://localhost:5000/app-demo/static/css/adwaita-web.css), resulting in 404 errors and unstyled components.

The correct URL path for static assets served by Flask from the app-demo/static directory is /static/....

The fallback path in individual component constructors was already correct ('/static/css/adwaita-web.css'). The build script also correctly places the CSS file in 'app-demo/static/css/adwaita-web.css'.

This change ensures that the main page and all web components now consistently use the correct path to load the stylesheet.