### PR TITLE
Fix: Correct ReferenceError in AdwEntry _render method

### DIFF
--- a/js/components/forms.js
+++ b/js/components/forms.js
@@ -129,8 +129,8 @@ export class AdwEntry extends HTMLElement {
 
         this._inputElement.placeholder = this.getAttribute('placeholder') || '';
         const valueAttr = this.getAttribute('value');
-        // Use _initialValue for the very first render if value attribute not set, then valueAttr
-        const initialRenderValue = (valueAttr === null && oldValue === null) ? this._initialValue : (valueAttr === null ? '' : valueAttr);
+        // If value attribute is explicitly set, use it. Otherwise, use the stored _initialValue.
+        const initialRenderValue = (valueAttr !== null) ? valueAttr : this._initialValue;
 
         if (this._inputElement.value !== initialRenderValue) {
             this._inputElement.value = initialRenderValue;


### PR DESCRIPTION
The AdwEntry component's _render method incorrectly referenced an 'oldValue' variable that was not in its scope. This occurred when _render was called from paths like connectedCallback, leading to a JavaScript error on page load for forms using adw-entry-row or adw-password-entry-row (e.g., the app-demo login page).

This commit corrects the logic for determining 'initialRenderValue' within AdwEntry._render() to only use available properties like this.getAttribute('value') and this._initialValue.

This resolves the runtime error and ensures that AdwEntry components initialize correctly.