### PR TITLE
Fix: Further attempts to debug forms, uploads, and icons

### DIFF
--- a/app-demo/app.py
+++ b/app-demo/app.py
@@ -441,8 +441,17 @@ def create_app(config_overrides=None):
             _app.logger.info(f"User {current_user.username} updating profile_info, full_name, location, website_url.")
 
             file = form.profile_photo.data
+            _app.logger.info(f"Profile edit: form.profile_photo.data object: {type(file)}")
+            if file:
+                 _app.logger.info(f"Profile edit: file object received: {file}, filename: '{file.filename}'")
+            else:
+                _app.logger.info("Profile edit: No file object received in form.profile_photo.data.")
+
             if file and file.filename:
-                if allowed_file(file.filename):
+                _app.logger.info(f"Profile edit: Attempting to process file: '{file.filename}'")
+                is_allowed = allowed_file(file.filename)
+                _app.logger.info(f"Profile edit: File '{file.filename}' allowed: {is_allowed}")
+                if is_allowed:
                     try:
                         original_filename = secure_filename(file.filename)
                         ext = original_filename.rsplit('.', 1)[-1].lower()

--- a/js/components/misc.js
+++ b/js/components/misc.js
@@ -685,8 +685,9 @@ export class AdwPreferencesGroup extends HTMLElement {
 
 // --- AdwIcon ---
 const svgIconCache = new Map();
-// Path should be absolute from the web server root, as /data/ seems to be served at root.
-const ICON_BASE_PATH = '/data/icons/symbolic/';
+// Path should be absolute from the web server root.
+// Assumes icons will be moved to app-demo/static/data/icons/
+const ICON_BASE_PATH = '/static/data/icons/symbolic/';
 
 /**
  * Creates an Adwaita-style icon element by fetching and embedding an SVG.

--- a/js/components/rows.js
+++ b/js/components/rows.js
@@ -289,8 +289,14 @@ export class AdwEntryRow extends HTMLElement {
         // If _internalEntry exists, update it or the row's elements directly
         switch (name) {
             case 'value':
-                if (this._internalEntry.value !== newValue) {
-                    this._internalEntry.value = newValue === null ? '' : newValue;
+                // Ensure the internal AdwEntry's 'value' attribute is updated,
+                // which will then trigger AdwEntry's own logic to call setFormValue.
+                if (this._internalEntry.getAttribute('value') !== newValue) {
+                    if (newValue === null) {
+                        this._internalEntry.removeAttribute('value');
+                    } else {
+                        this._internalEntry.setAttribute('value', newValue);
+                    }
                 }
                 break;
             case 'placeholder':


### PR DESCRIPTION
- Modified AdwEntryRow in js/components/rows.js to set the 'value' attribute on its internal AdwEntry. This aims to ensure AdwEntry's setFormValue logic is reliably triggered for form submissions, addressing the 'title required' error for post creation.
- Added detailed diagnostic logging to the Flask 'edit_profile' route in app.py to better trace file objects and processing steps during profile photo uploads.
- Updated ICON_BASE_PATH in js/components/misc.js to '/static/data/icons/symbolic/', anticipating the user will move the 'data/icons/' directory to 'app-demo/static/data/icons/' to resolve 404 errors for icons.