### PR TITLE
Fix: More debugging for blog creation and photo uploads

### DIFF
--- a/app-demo/app.py
+++ b/app-demo/app.py
@@ -440,15 +440,21 @@ def create_app(config_overrides=None):
             current_user.website_url = form.website_url.data
             _app.logger.info(f"User {current_user.username} updating profile_info, full_name, location, website_url.")
 
-            file = form.profile_photo.data
-            _app.logger.info(f"Profile edit: form.profile_photo.data object: {type(file)}")
-            if file:
-                 _app.logger.info(f"Profile edit: file object received: {file}, filename: '{file.filename}'")
-            else:
-                _app.logger.info("Profile edit: No file object received in form.profile_photo.data.")
+            file = form.profile_photo.data # This is a FileStorage object
+            _app.logger.info(f"Profile edit: form.profile_photo.data is of type: {type(file)}")
 
-            if file and file.filename:
-                _app.logger.info(f"Profile edit: Attempting to process file: '{file.filename}'")
+            if file is not None: # Check if FileStorage object exists
+                _app.logger.info(f"Profile edit: FileStorage object received: {file}")
+                _app.logger.info(f"Profile edit: FileStorage object's filename attribute: '{file.filename}'") # This is key
+            else:
+                # This case should ideally not happen if the field is in the form,
+                // even if no file is selected, 'file' should be a FileStorage obj with empty filename.
+                # But good to log if it's truly None.
+                _app.logger.warning("Profile edit: form.profile_photo.data is None. This is unexpected.")
+
+
+            if file and file.filename: # This is the crucial check: FileStorage exists AND has a non-empty filename
+                _app.logger.info(f"Profile edit: Proceeding to process file: '{file.filename}'")
                 is_allowed = allowed_file(file.filename)
                 _app.logger.info(f"Profile edit: File '{file.filename}' allowed: {is_allowed}")
                 if is_allowed:

--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -8,15 +8,21 @@
     <form method="POST" action="{{ url_for('create_post') }}" novalidate>
         {{ form.hidden_tag() }} {# CSRF token #}
         <adw-list-box style="margin-bottom: var(--spacing-l);">
-            <adw-entry-row
-                title="{{ form.title.label.text }}"
-                name="{{ form.title.name }}"
-                id="{{ form.title.id or 'title_field' }}"
-                placeholder="Enter post title"
-                value="{{ form.title.data or '' }}"
-                {% if form.title.flags.required %}required{% endif %}
-                subtitle="{{ form.title.errors[0] if form.title.errors else '' }}">
-            </adw-entry-row>
+            {# Replace adw-entry-row with direct form field rendering for title #}
+            <div class="adw-preferences-row" style="padding: var(--spacing-s) var(--spacing-m);">
+                <div class="adw-preferences-row__title-area">
+                    {{ form.title.label(class_="adw-label") }}
+                </div>
+                <div class="adw-preferences-row__control-area" style="flex-grow: 1;">
+                    {{ form.title(class_="adw-entry", style="width: 100%;", placeholder="Enter post title", required=form.title.flags.required) }}
+                </div>
+                {% if form.title.errors %}
+                <div class="adw-preferences-row__title-area"></div> {# Spacer for alignment #}
+                <div class="adw-preferences-row__control-area errors" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xxs);">
+                    {% for error in form.title.errors %}{{ error }}<br>{% endfor %}
+                </div>
+                {% endif %}
+            </div>
 
             {# Content Field - using a generic row structure inside list-box #}
             <div class="adw-row" style="padding: var(--spacing-s) var(--spacing-m); display: flex; flex-direction: column;">


### PR DESCRIPTION
- Modified create_post.html to use a standard WTForms input for the 'title' field instead of adw-entry-row. This is to isolate whether the custom component is the cause of the 'title is required' validation error.
- Refined logging in the edit_profile route (app.py) to provide more specific details about the FileStorage object and its filename attribute during photo upload attempts.