### PR TITLE
Fix: Correct Python comment syntax and continue form debugging

### DIFF
--- a/app-demo/app.py
+++ b/app-demo/app.py
@@ -448,7 +448,7 @@ def create_app(config_overrides=None):
                 _app.logger.info(f"Profile edit: FileStorage object's filename attribute: '{file.filename}'") # This is key
             else:
                 # This case should ideally not happen if the field is in the form,
-                // even if no file is selected, 'file' should be a FileStorage obj with empty filename.
+                # even if no file is selected, 'file' should be a FileStorage obj with empty filename.
                 # But good to log if it's truly None.
                 _app.logger.warning("Profile edit: form.profile_photo.data is None. This is unexpected.")
 


### PR DESCRIPTION
- Corrected comment syntax in app.py (// to #) that was causing a SyntaxError.
- Modified create_post.html to use a standard WTForms input for the 'title' field instead of adw-entry-row. This is to isolate whether the custom component is the cause of the 'title is required' validation error.
- Refined logging in the edit_profile route (app.py) to provide more specific details about the FileStorage object and its filename attribute during photo upload attempts.