### PR TITLE
Fix: Address further JavaScript syntax errors

### DIFF
--- a/adwaita-web/js/components/views.js
+++ b/adwaita-web/js/components/views.js
@@ -373,7 +373,7 @@ export class AdwToolbarView extends HTMLElement {
 
 /** Creates an AdwCarousel widget. */
 export function createAdwCarousel(options = {}) {
-    const opts = { showIndicators: true, showNavButtons: false, loop: true, autoplay: false, autoplayInterval: 5000, indicatorStyle: 'dots', ...options };
+    const opts = Object.assign({ showIndicators: true, showNavButtons: false, loop: true, autoplay: false, autoplayInterval: 5000, indicatorStyle: 'dots' }, options);
     const carousel = document.createElement('div'); carousel.classList.add('adw-carousel');
     carousel.setAttribute('role', 'region'); carousel.setAttribute('aria-roledescription', 'carousel');
     if (opts.loop) carousel.classList.add('looping'); if (opts.autoplay) carousel.classList.add('autoplay'); if (opts.indicatorStyle === 'thumbnails') carousel.classList.add('thumbnail-indicators');

--- a/index.html
+++ b/index.html
@@ -964,11 +964,11 @@ if (accentPickerBox) {
                 navViewPopButton?.addEventListener('click', () => navView.pop());
 
                 navView.addEventListener('pushed', (e) => {
-                    Adw.createToast(\`Pushed: \${e.detail.pageName}\`);
+                    Adw.createToast('Pushed: ' + e.detail.pageName);
                     updateNavViewPopButtonState();
                 });
                 navView.addEventListener('popped', (e) => {
-                    Adw.createToast(\`Popped: \${e.detail.pageName}\`);
+                    Adw.createToast('Popped: ' + e.detail.pageName);
                     updateNavViewPopButtonState();
                 });
                 updateNavViewPopButtonState(); // Initial state


### PR DESCRIPTION
- Replaced template literals with string concatenation in index.html for Adw.createToast calls to resolve 'invalid escape sequence' errors.
- Replaced object spread syntax with Object.assign in views.js (createAdwCarousel) to resolve 'missing ] after element list' error, improving compatibility.