### PR TITLE
Diag: Simplify opts initialization in createAdwCarousel

### DIFF
--- a/adwaita-web/js/components/views.js
+++ b/adwaita-web/js/components/views.js
@@ -373,7 +373,7 @@ export class AdwToolbarView extends HTMLElement {
 
 /** Creates an AdwCarousel widget. */
 export function createAdwCarousel(options = {}) {
-    const opts = Object.assign({ showIndicators: true, showNavButtons: false, loop: true, autoplay: false, autoplayInterval: 5000, indicatorStyle: 'dots' }, options);
+    const opts = {}; /* DEBUG: Simplified to isolate parser error */
     const carousel = document.createElement('div'); carousel.classList.add('adw-carousel');
     carousel.setAttribute('role', 'region'); carousel.setAttribute('aria-roledescription', 'carousel');
     if (opts.loop) carousel.classList.add('looping'); if (opts.autoplay) carousel.classList.add('autoplay'); if (opts.indicatorStyle === 'thumbnails') carousel.classList.add('thumbnail-indicators');


### PR DESCRIPTION
Temporarily simplified `opts` initialization in `views.js` to `const opts = {};` for diagnosing a persistent parser error (`missing ] after element list` at line 546). This is to check if the error location or message changes.