### PR TITLE
feat: Align adwaita-web components closer to libadwaita

### DIFF
--- a/adwaita-web/js/components/rows.js
+++ b/adwaita-web/js/components/rows.js
@@ -226,7 +226,14 @@ export class AdwActionRow extends HTMLElement {
         const titleLabel = createAdwLabel(titleText, {htmlTag: 'span'}); titleLabel.classList.add('adw-action-row-title');
         const titleSlot = document.createElement('slot'); titleSlot.name = 'title-override'; titleLabel.appendChild(titleSlot);
         contentDiv.appendChild(titleLabel);
-        if (subtitleText) { const subtitleLabel = createAdwLabel(subtitleText, {htmlTag: 'span'}); subtitleLabel.classList.add('adw-action-row-subtitle'); contentDiv.appendChild(subtitleLabel); }
+        if (subtitleText) {
+            const subtitleLabel = createAdwLabel(subtitleText, {htmlTag: 'span'});
+            subtitleLabel.classList.add('adw-action-row-subtitle');
+            contentDiv.appendChild(subtitleLabel);
+            row.classList.add('has-subtitle');
+        } else {
+            row.classList.remove('has-subtitle');
+        }
         row.appendChild(contentDiv);
 
         const suffixContainer = document.createElement('div'); suffixContainer.classList.add('adw-action-row-suffix');
@@ -364,6 +371,15 @@ export class AdwEntryRow extends HTMLElement {
 
             this._internalEntry = new AdwEntry();
             this._internalEntry.classList.add("adw-entry-row-entry");
+            // Apply the row-input variant style
+            if (this._internalEntry.shadowRoot && this._internalEntry.shadowRoot.querySelector('.adw-entry')) {
+              // If AdwEntry is a web component and its internal input is what needs styling directly
+              // This depends on AdwEntry's internal structure.
+              // For now, assume AdwEntry itself can take the .row-input class or its styles apply to its host.
+            }
+            // Add .row-input to the AdwEntry host element itself if its styles are scoped to :host or .adw-entry
+            this._internalEntry.classList.add("row-input");
+
 
             this._internalEntry.addEventListener('input', (e) => {
                 const currentAttrValue = this.getAttribute('value');
@@ -587,6 +603,7 @@ export class AdwPasswordEntryRow extends HTMLElement {
             this._internalEntry = new AdwEntry();
             this._internalEntry.setAttribute('type', 'password'); // Default type
             this._internalEntry.classList.add("adw-entry-row-entry");
+            this._internalEntry.classList.add("row-input"); // Apply the row-input variant style
 
             this._internalEntry.addEventListener('input', (e) => {
                 const currentAttrValue = this.getAttribute('value');
@@ -945,7 +962,8 @@ export class AdwSpinRow extends HTMLElement {
         const titleText = this.getAttribute('title') || ''; const titleLabel = createAdwLabel(titleText, { htmlTag: "span" }); titleLabel.classList.add("adw-spin-row-title"); textContentDiv.appendChild(titleLabel);
         const subtitleText = this.getAttribute('subtitle'); if (subtitleText) { const subtitleLabel = createAdwLabel(subtitleText, { htmlTag: "span" }); subtitleLabel.classList.add("adw-spin-row-subtitle"); textContentDiv.appendChild(subtitleLabel); }
         row.appendChild(textContentDiv);
-        this._internalSpinButton = new AdwSpinButton(); this._internalSpinButton.classList.add("adw-spin-row-spin-button");
+        this._internalSpinButton = new AdwSpinButton();
+        this._internalSpinButton.classList.add("adw-spin-row-spin-button", "row-input"); // Add .row-input
         if (this.hasAttribute('value')) this._internalSpinButton.value = parseFloat(this.getAttribute('value'));
         if (this.hasAttribute('min')) this._internalSpinButton.setAttribute('min', this.getAttribute('min'));
         if (this.hasAttribute('max')) this._internalSpinButton.setAttribute('max', this.getAttribute('max'));

--- a/adwaita-web/scss/_action_row.scss
+++ b/adwaita-web/scss/_action_row.scss
@@ -7,12 +7,29 @@
   // The AdwActionRow web component's shadow DOM root has .adw-action-row,
   // so we apply row-base styles here.
   @include mixins.row-base; // Applies common row styles like min-height, padding, border-bottom
-  padding-top: var(--spacing-s);    // Override default vertical padding from row-base for ActionRow (9px)
-  padding-bottom: var(--spacing-s); // Override default vertical padding from row-base for ActionRow (9px)
+  // Override default vertical padding from row-base for ActionRow
+  // Aim for ~54px height for single-line, ~70px for two-line (title + subtitle)
+  // These values assume typical font sizes and line heights.
+  // Libadwaita uses 12px top/bottom for single line content area usually.
+  padding-top: 12px;
+  padding-bottom: 12px;
   // background-color: var(--card-bg-color); // This was in old version. Rows usually take listbox bg.
                                          // If used standalone on a card, card provides bg.
                                          // If within a listbox on a card, listbox provides bg.
   gap: var(--spacing-m); // Use gap for spacing prefix, content, and suffix
+
+  &.has-subtitle {
+    // Adjust padding for rows with subtitles to achieve ~70px height
+    // This often means slightly more padding if the text content height itself isn't enough.
+    // Given title + subtitle, their combined height + margin-top on subtitle will be significant.
+    // The 12px top/bottom might already be fine, or might need slight adjustment
+    // depending on actual rendered height of title+subtitle block.
+    // Let's start with the same and adjust if testing shows need.
+    // padding-top: 12px;
+    // padding-bottom: 12px;
+    // If row-base min-height is, e.g. 48px, this padding makes it at least 72px.
+    // Consider if min-height from row-base should be overridden or removed for ActionRow.
+  }
 
   // If the row itself is clickable/activatable
   &.activatable {

--- a/adwaita-web/scss/_banner.scss
+++ b/adwaita-web/scss/_banner.scss
@@ -55,6 +55,27 @@
     // Example: if button is too tall, adjust its internal padding or line-height.
   }
 
+  // Specific styling for the dismiss button in a banner
+  .adw-banner-dismiss-button.adw-button.circular.flat {
+    // Inherits .circular and .flat styles from _button.scss
+    // Adjust color if needed to ensure good contrast against banner background,
+    // though default flat button color (currentcolor) should work if banner-fg-color is set right.
+    // color: var(--banner-secondary-fg-color, var(--secondary-fg-color)); // Example if a dimmer color is desired
+
+    // Ensure it's aligned nicely with the title, especially if title wraps to multiple lines.
+    // Default align-items: center on .adw-banner should handle vertical alignment.
+
+    // Adjust size/padding if the default circular button padding isn't perfect for banners.
+    // For example, if it needs to be slightly smaller or have less padding:
+    // padding: var(--spacing-xs); // e.g., 6px if default var(--spacing-s) is too large
+    // .adw-icon {
+    //   font-size: 0.9em; // If the icon itself needs to be slightly smaller
+    // }
+
+    // Ensure it's visually distinct from the main action button, if present.
+    // The flat circular style already does this well.
+  }
+
   // If a banner needs to be themed for specific contexts (e.g. error, warning)
   // this can be done by adding classes to the AdwBanner element itself.
   // Example:

--- a/adwaita-web/scss/_entry.scss
+++ b/adwaita-web/scss/_entry.scss
@@ -58,6 +58,27 @@
   // e.g., in a search bar with an attached button. This would be handled by a wrapper or specific context.
 }
 
+// Variant for entries used within rows (e.g., AdwEntryRow)
+.adw-entry.row-input {
+  border-width: 0 0 1px 0; // Only bottom border
+  border-radius: 0; // No border radius for a clean line
+  background-color: transparent;
+  box-shadow: none; // Remove inset shadow
+  padding-left: 0; // Row itself will provide horizontal padding
+  padding-right: 0;
+  // padding-top and padding-bottom might need slight adjustment if default from .adw-entry is too much/little for row context
+
+  &:focus,
+  &:focus-within {
+    border-color: var(--_entry-focus-border-color); // Keep accent focus border
+    box-shadow: none; // No outer focus ring for row-input, just the accent border
+  }
+
+  // If the row itself has a background, this transparent entry will blend.
+  // If the row is on a card, the card provides the background.
+}
+
+
 // Variables needed in _variables.scss (ensure they exist, from original file analysis they mostly do):
 // var(--entry-inset-shadow-light) -> e.g., rgba(0,0,0,0.03)
 // var(--entry-inset-shadow-dark) -> e.g., rgba(0,0,0,0.1) or similar for dark

--- a/adwaita-web/scss/_navigation_view.scss
+++ b/adwaita-web/scss/_navigation_view.scss
@@ -29,7 +29,8 @@
     box-sizing: border-box;
     // background-color: var(--window-bg-color); // Pages have their own bg or inherit
     overflow-y: auto; // Allow individual pages to scroll
-    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    transition: transform var(--animation-duration-short, 250ms) var(--animation-ease-in-out, ease-in-out),
+                opacity var(--animation-duration-short, 250ms) var(--animation-ease-in-out, ease-in-out);
     // visibility: hidden; // Controlled by display initially
 
     // &.adw-navigation-page-active {

--- a/adwaita-web/scss/_row_types.scss
+++ b/adwaita-web/scss/_row_types.scss
@@ -79,11 +79,21 @@
   align-items: center;
   width: 100%;
   gap: var(--spacing-m);
+  justify-content: space-between; // Ensure proper spacing distribution
 
-  .adw-entry-row-title {
-    // No specific styles needed if it's just an AdwLabel, it will inherit.
-    // font-weight: normal; // If needed to override default label boldness
+  .adw-entry-row-text-content { // Assuming JS structure wraps title/subtitle in this
+    flex-grow: 0;
+    flex-shrink: 1;
+    // Add other properties from AdwComboRow's text-content if necessary:
+    // display: flex;
+    // flex-direction: column;
+    // justify-content: center;
+    // overflow: hidden;
   }
+
+  // .adw-entry-row-title {
+  //   // Styles for actual title label if needed beyond what AdwLabel provides
+  // }
 
   .adw-entry-row-entry {
     flex-grow: 1;
@@ -181,9 +191,11 @@ body.dark-theme .adw-expander-row-content.expanded {
   align-items: center;
   width: 100%;
   gap: var(--spacing-m);
+  justify-content: space-between; // Ensure spacing if select doesn't grow significantly
 
   .adw-combo-row-text-content { // Similar to ActionRow's text content
-    flex-grow: 1;
+    flex-grow: 0; // Title part should not grow
+    flex-shrink: 1; // Can shrink if needed
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -196,40 +208,48 @@ body.dark-theme .adw-expander-row-content.expanded {
   }
 
   .adw-combo-row-select {
-    // Basic styling, can be enhanced
-    padding: var(--spacing-xs) var(--spacing-s);
-    border: var(--border-width, 1px) solid var(--button-border-color);
-    border-radius: var(--border-radius-default);
-    background-color: var(--button-bg-color);
-    color: var(--button-fg-color);
-    min-width: 150px; // Ensure select has some width
-    // For true Adwaita look, this <select> would need significant custom styling
-    // to hide the native dropdown and mimic a GtkDropDown appearance (button-like with an arrow).
-    // The current styling provides basic theming for the native select.
+    // Reset default browser appearance if possible (tricky with select)
+    // -webkit-appearance: none; /* Not using this for now to keep native dropdown arrow */
+    // -moz-appearance: none;
+    // appearance: none;
+
+    background-color: transparent;
+    border: none; // Remove default border
+    border-bottom: 1px solid var(--borders-color); // Subtle bottom border, like .row-input for AdwEntry
+    border-radius: 0; // No border radius for a clean line
+    padding: var(--spacing-xxs) 0; // Minimal vertical padding to align text, horizontal spacing via row gap.
+                                   // Adjust if text is not vertically centered.
+    font-size: inherit; // Inherit font size from row
+    color: inherit; // Inherit text color
+    flex-grow: 1; // Take available space
+    min-width: 100px; // Prevent it from becoming too small
+    // Native select appearance is hard to override perfectly.
+    // For a true Adwaita GtkDropDown look, a custom component emulating <select> would be needed.
+    // This aims for a cleaner integration of the native <select>.
+
+    // Custom dropdown arrow if hiding native one (requires appearance: none)
+    // background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22currentColor%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M4.94%205.72a.75.75%200%200%201%201.06-.04l1.97%201.928%201.97-1.928a.75.75%200%201%201%201.02%201.1l-2.5%202.449a.75.75%200%200%201-1.02%200L4.98%206.78a.75.75%200%200%201-.04-1.06Z%22%2F%3E%3C%2Fsvg%3E");
+    // background-repeat: no-repeat;
+    // background-position: right var(--spacing-xs) center;
+    // padding-right: var(--spacing-l); // Make space for custom arrow if used
 
     &:hover {
-      background-color: var(--button-hover-bg-color);
+      // No background change on hover for this style, border might change if desired
+      // border-bottom-color: var(--borders-hover-color, var(--borders-color));
     }
-    &:focus-visible {
-      outline: 2px solid var(--accent-bg-color);
-      outline-offset: 1px;
+    &:focus { // Using :focus for select, focus-visible might not always trigger as expected on <select>
+      outline: none;
+      border-bottom-color: var(--accent-color); // Accent color for focused bottom border
     }
     &:disabled {
-        opacity: var(--opacity-disabled, 0.5);
+        border-bottom-color: var(--borders-color); // Keep border for consistency
+        border-bottom-style: dashed; // Indicate disabled state with dashed line
+        opacity: var(--opacity-disabled, 0.5); // Standard disabled opacity
+        color: var(--disabled-fg-color); // Use disabled foreground color
+        background-color: transparent; // Ensure background remains transparent
         cursor: not-allowed;
-        background-color: var(--button-disabled-bg-light); // Use disabled button bg
-        color: var(--button-disabled-fg-light); // Use disabled button fg
-        border-color: transparent; // Or a disabled border color
-        body.dark-theme & {
-            background-color: var(--button-disabled-bg-dark);
-            color: var(--button-disabled-fg-dark);
-        }
     }
   }
 }
 
-// Dark theme for ComboRow select specific properties are handled by the variables now.
-// .dark-theme .adw-combo-row .adw-combo-row-select,
-// body.dark-theme .adw-combo-row .adw-combo-row-select {
-//    // Variables like --button-border-color, --button-bg-color should correctly switch
-// }
+// Dark theme variables should handle color changes automatically.

--- a/adwaita-web/scss/_spin_button.scss
+++ b/adwaita-web/scss/_spin_button.scss
@@ -106,3 +106,45 @@ body.dark-theme .adw-spin-button {
     border-color: var(--accent-bg-color);
   }
 }
+
+// Variant for spin buttons used within rows (e.g., AdwSpinRow)
+.adw-spin-button.row-input {
+  border-width: 0 0 1px 0; // Only bottom border
+  border-radius: 0; // No border radius for a clean line
+  background-color: transparent; // Main background transparent
+
+  .adw-spin-button-entry {
+    background-color: transparent; // Entry part also transparent
+    padding-left: 0; // AdwEntryRow will handle overall padding
+  }
+
+  .adw-spin-button-buttons {
+    .adw-spin-button-control.adw-button {
+      background-color: transparent; // Buttons also transparent initially
+      color: var(--secondary-fg-color); // Use a less prominent color for icons
+
+      &:hover {
+        background-color: var(--button-flat-hover-bg-color); // Subtle hover
+        color: var(--primary-fg-color);
+      }
+      &:active {
+        background-color: var(--button-flat-active-bg-color);
+      }
+    }
+    .adw-spin-button-up {
+      border-bottom-color: var(--borders-color); // Match row border style
+    }
+  }
+
+  &:focus-within { // Focus indication on the wrapper
+    outline: none; // Remove outer outline
+    border-bottom-color: var(--accent-color); // Accent color for focused bottom border
+  }
+
+  &.disabled {
+    border-bottom-style: dashed;
+    .adw-spin-button-entry, .adw-spin-button-buttons .adw-button {
+        background-color: transparent !important; // Ensure transparent even when disabled
+    }
+  }
+}

--- a/adwaita-web/scss/_spin_row.scss
+++ b/adwaita-web/scss/_spin_row.scss
@@ -7,9 +7,11 @@
   // display: flex; (from .adw-row)
   // align-items: center; (from .adw-row)
   gap: var(--spacing-m); // Standard gap for row items
+  justify-content: space-between; // Ensure spacing if spinbutton doesn't grow significantly
 
   .adw-spin-row-text-content {
-    flex-grow: 1; // Allow text content to take available space
+    flex-grow: 0; // Title part should not grow
+    flex-shrink: 1; // Can shrink if needed
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -34,7 +36,9 @@
 
   .adw-spin-row-spin-button {
     // This class is on the adw-spin-button component itself (the wrapper div)
-    flex-shrink: 0; // Don't allow the spin button to shrink
+    flex-grow: 1;   // Allow spin button to take available space
+    flex-shrink: 1; // Can also shrink
+    min-width: 120px; // Give it a reasonable minimum width
   }
 }
 

--- a/adwaita-web/scss/_toast.scss
+++ b/adwaita-web/scss/_toast.scss
@@ -82,9 +82,23 @@
     margin-left: var(--spacing-s);
     color: var(--toast-secondary-fg-color, rgba(255,255,255,0.7));
 
-    .adw-icon, .icon svg {
-        font-size: var(--icon-size-inline, 1em);
+    // Target the icon container (span.icon or adw-icon)
+    .adw-icon, .icon {
+        display: inline-flex; // Ensure proper alignment and sizing
+        align-items: center;
+        justify-content: center;
+        // Use a specific size for the icon container, matching typical Adwaita small icon buttons
+        width: var(--icon-size-small, 16px); // e.g., 16px
+        height: var(--icon-size-small, 16px);
     }
+
+    // Target the SVG element itself within the icon container
+    .adw-icon svg, .icon svg {
+        width: 100%; // Fill the container
+        height: 100%; // Fill the container
+        // fill: currentColor; // Already set in SVG string, but good to ensure
+    }
+
     &:hover {
         color: var(--toast-foreground-color, rgba(255,255,255,1));
         background-color: rgba(255,255,255,0.1);


### PR DESCRIPTION
This commit implements several visual and structural enhancements to the adwaita-web UI components to better match the look and feel of libadwaita.

Key changes include:

Banners & Toasts:
- Added SCSS selector for banner dismiss buttons for easier customization.
- Refined toast close button icon styling for improved visibility and consistent sizing. Functionality for these buttons was already present.

Views:
- Standardized AdwNavigationView page transition CSS to use variables, aiming for consistency with libadwaita animation timings.

ActionRow & Input Rows:
- Adjusted AdwActionRow padding and JS to add a `has-subtitle` class, helping to achieve more standard libadwaita row heights.
- Introduced a `.row-input` SCSS styling variant for AdwEntry, AdwSpinButton, and styled <select> elements in AdwComboRow for a more integrated, less "web-form" like appearance (e.g., bottom-border only, transparent background).
- Updated JS for AdwEntryRow, AdwPasswordEntryRow, AdwComboRow, and AdwSpinRow to use the `.row-input` variant.
- Corrected flexbox layouts for these rows to ensure titles and input controls are sized and spaced more appropriately.

These changes address feedback on banners lacking dismiss buttons (library supports them, usage is key), toasts missing close icons (library adds them, styling refined), views not looking quite right (transitions adjusted), and action/entry rows appearing too much like web forms.