### PR TITLE
Fix JavaScript syntax error and Tiptap loading issues

### DIFF
--- a/adwaita-web/js/components/views.js
+++ b/adwaita-web/js/components/views.js
@@ -373,7 +373,7 @@ export class AdwToolbarView extends HTMLElement {
 
 /** Creates an AdwCarousel widget. */
 export function createAdwCarousel(options = {}) {
-    const opts = {}; /* DEBUG: Simplified to isolate parser error */
+    const opts = { slides: [], ...options }; /* DEBUG: Simplified to isolate parser error */
     const carousel = document.createElement('div'); carousel.classList.add('adw-carousel');
     carousel.setAttribute('role', 'region'); carousel.setAttribute('aria-roledescription', 'carousel');
     if (opts.loop) carousel.classList.add('looping'); if (opts.autoplay) carousel.classList.add('autoplay'); if (opts.indicatorStyle === 'thumbnails') carousel.classList.add('thumbnail-indicators');

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -99,9 +99,9 @@
         // This will make Tiptap's modules available globally for inline scripts in create_post/edit_post
         // In a bundled environment, you'd import them directly in your JS files.
         try {
-            const TiptapCore = await import('https://unpkg.com/@tiptap/core?module');
-            const TiptapStarterKit = await import('https://unpkg.com/@tiptap/starter-kit?module');
-            const TiptapPlaceholder = await import('https://unpkg.com/@tiptap/extension-placeholder?module');
+            const TiptapCore = await import('https://cdn.jsdelivr.net/npm/@tiptap/core/+esm');
+            const TiptapStarterKit = await import('https://cdn.jsdelivr.net/npm/@tiptap/starter-kit/+esm');
+            const TiptapPlaceholder = await import('https://cdn.jsdelivr.net/npm/@tiptap/extension-placeholder/+esm');
             window.Tiptap = {
                 Core: TiptapCore,
                 StarterKit: TiptapStarterKit.default, // StarterKit is often a default export


### PR DESCRIPTION
- Fixed a SyntaxError in adwaita-web/js/components/views.js related to opts.slides in createAdwCarousel.
- Changed Tiptap module imports in app-demo/templates/base.html to use cdn.jsdelivr.net instead of unpkg.com to resolve CORS and MIME type errors.