### PR TITLE
Fix: Address accessibility warnings and missing icon in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@ if (accentPickerBox) {
                     <adw-icon icon-name="status/dialog-error-symbolic" style="color: var(--error-color); font-size: 32px;"></adw-icon>
                     <adw-icon icon-name="ui/pan-up-symbolic"></adw-icon>
                     <adw-icon icon-name="devices/camera-photo-symbolic"></adw-icon>
-                    <adw-icon icon-name="a-missing-icon-name"></adw-icon> {/* Error case */}
+                    {/* <adw-icon icon-name="a-missing-icon-name"></adw-icon> Error case removed */}
                 </adw-box>
                  <details>
                     <summary>Show Icon Examples</summary>
@@ -950,6 +950,7 @@ if (accentPickerBox) {
                 document.getElementById('nav-view-push-page3')?.addEventListener('click', () => {
                     const endButton = document.createElement('adw-button');
                     endButton.iconName = "actions/document-save-symbolic";
+                    endButton.setAttribute('aria-label', 'Save'); // Added aria-label
                     endButton.addEventListener('click', () => Adw.createToast("Save clicked on Page 3 header"));
 
                     const page3Data = createNavPage(


### PR DESCRIPTION
- Added aria-label to a dynamically created icon-only button in the NavigationView demo.
- Removed an <adw-icon> tag that intentionally referenced a missing icon to resolve a 404 error.

Further accessibility warnings observed in the initial logs (related to spin buttons, split buttons, and deprecated icon attributes) are likely due to the demo page (index.html) loading a `build/js/components.js` that is not up-to-date with the sources in `adwaita-web/js/components/`. The reviewed source files for AdwSpinButton and AdwSplitButton appear to correctly set aria-labels for their internal icon buttons. The source of deprecated icon attribute usage was not found in the current HTML or JS component sources.