### PR TITLE
Refactor: Change comment style for missing icon test case in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@ if (accentPickerBox) {
                     <adw-icon icon-name="status/dialog-error-symbolic" style="color: var(--error-color); font-size: 32px;"></adw-icon>
                     <adw-icon icon-name="ui/pan-up-symbolic"></adw-icon>
                     <adw-icon icon-name="devices/camera-photo-symbolic"></adw-icon>
-                    {/* <adw-icon icon-name="a-missing-icon-name"></adw-icon> Error case removed */}
+                    <!-- <adw-icon icon-name="a-missing-icon-name"></adw-icon> Error case removed -->
                 </adw-box>
                  <details>
                     <summary>Show Icon Examples</summary>


### PR DESCRIPTION
Changed the comment for the <adw-icon icon-name="a-missing-icon-name"> test case from JSX-style ({/*...*}) to standard HTML-style (<!--...-->).

This ensures the line is definitively treated as a comment in a standard HTML parsing context, further safeguarding against it being accidentally active if the build process or environment has changed from previous assumptions.

A grep search confirmed no other direct string references to "a-missing-icon-name" in the JavaScript codebase.