### PR TITLE
Fix: Hide original AdwAlertDialog choice buttons from main flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,11 @@
         .widget-showcase { margin-bottom: var(--spacing-l); }
         .widget-showcase > adw-label[title-level="1"] { margin-bottom: var(--spacing-m); }
         .button-group adw-button { margin-right: var(--spacing-s); margin-bottom: var(--spacing-s); }
+
+        /* Hide original light DOM choice buttons for AdwAlertDialog as they are processed internally */
+        adw-alert-dialog > adw-button[slot="choice"] {
+            display: none !important;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Added a CSS rule to index.html:
`adw-alert-dialog > adw-button[slot="choice"] { display: none !important; }`

This prevents the original light DOM <adw-button slot="choice"> elements, which are used as definitions by AdwAlertDialog, from being rendered in the main document layout when the dialog is active.

AdwAlertDialog internally creates its own buttons based on these definitions for display within the actual dialog modal. This change addresses the issue where the definitional buttons were incorrectly appearing outside the dialog.