### PR TITLE
Fix: Correct JavaScript syntax error in utils.js

### DIFF
--- a/adwaita-web/js/components/utils.js
+++ b/adwaita-web/js/components/utils.js
@@ -212,16 +212,6 @@ window.addEventListener("DOMContentLoaded", () => {
 
 
 const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:', 'ftp:', './', '../', '/', '#'];
-    } catch (e) {
-        console.warn("Could not save theme preference to localStorage:", e);
-    }
-}
-
-// Global event listener
-window.addEventListener("DOMContentLoaded", loadSavedTheme);
-
-
-const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:', 'ftp:', './', '../', '/', '#'];
 /**
  * Sanitizes an href value to prevent javascript: URLs and other unsafe protocols.
  * @param {string} url The URL to sanitize.


### PR DESCRIPTION
Removed a duplicated block of code in `adwaita-web/js/components/utils.js` that was causing a syntax error ("unexpected garbage after module"). This error prevented the module from loading correctly and caused subsequent failures in theme and component initialization.