### PR TITLE
Fix: Resolve NameError for session in logging

### DIFF
--- a/app-demo/app.py
+++ b/app-demo/app.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from flask import Flask, render_template, url_for, abort, request, redirect, flash, jsonify
+from flask import Flask, render_template, url_for, abort, request, redirect, flash, jsonify, session
 from flask_login import LoginManager, UserMixin, login_user, logout_user, login_required, current_user
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect, FlaskForm


### PR DESCRIPTION
Added `from flask import session` to `app-demo/app.py`. This corrects a `NameError: name 'session' is not defined` that occurred in the recently added extensive logging statements when trying to access the session object directly without importing it from Flask.