### PR TITLE
Fix: Update banner dismiss button and add type-specific styling

### DIFF
--- a/adwaita-web/js/components/misc.js
+++ b/adwaita-web/js/components/misc.js
@@ -601,18 +601,17 @@ export function createAdwBanner(title, options = {}) {
     banner.appendChild(contentWrapper); // Add content wrapper to banner
 
     if (opts.dismissible) {
-        const dismissButton = createAdwButton('', {
-            iconName: 'ui/window-close-symbolic', // Corrected icon name
-            flat: true,
-            isCircular: true,
-            ariaLabel: 'Dismiss banner', // Explicitly provide an aria-label
+        const dismissButton = createAdwButton('Dismiss', { // Changed to text label "Dismiss"
+            // flat: true, // Decide on styling: flat or default button appearance
+            // No iconName or isCircular needed for a text button
+            ariaLabel: 'Dismiss banner', // Keeps the aria-label for accessibility
             onClick: () => {
                 banner.remove();
-                // Optionally, dispatch a 'dismissed' event
                 banner.dispatchEvent(new CustomEvent('dismissed', { bubbles: true, composed: true }));
             }
         });
-        dismissButton.classList.add('adw-banner-dismiss-button');
+        dismissButton.classList.add('adw-banner-dismiss-button'); // Keep class for specific styling
+        dismissButton.classList.add('flat'); // Make the dismiss button flat by default
         banner.appendChild(dismissButton);
     }
 

--- a/adwaita-web/scss/_banner.scss
+++ b/adwaita-web/scss/_banner.scss
@@ -5,11 +5,11 @@
   // Banners are typically placed at the top of a view or window.
   // They are not part of a listbox structure usually.
   padding: var(--spacing-s) var(--spacing-m); // Slightly less vertical padding than rows
-  background-color: var(--banner-bg-color, var(--secondary-bg-color)); // A distinct but not overly loud background
-  color: var(--banner-fg-color, var(--primary-fg-color));
+  background-color: var(--banner-bg-color); // Use theme-defined default
+  color: var(--banner-fg-color); // Use theme-defined default
   // No border-radius by default, as it usually spans full width.
   // border-radius: var(--border-radius-default);
-  border-bottom: var(--border-width) solid var(--borders-color); // Common to have a bottom separator
+  border-bottom: var(--border-width) solid var(--banner-border-color); // Use theme-defined default
   // margin-bottom: var(--spacing-m); // Margin is context-dependent, parent should handle normally
   box-sizing: border-box; // Ensure padding doesn't affect width calculation for fixed positioning
 
@@ -65,39 +65,57 @@
   }
 
   // Specific styling for the dismiss button in a banner
-  .adw-banner-dismiss-button.adw-button.circular.flat {
-    // Inherits .circular and .flat styles from _button.scss
-    // Adjust color if needed to ensure good contrast against banner background,
-    // though default flat button color (currentcolor) should work if banner-fg-color is set right.
-    // color: var(--banner-secondary-fg-color, var(--secondary-fg-color)); // Example if a dimmer color is desired
-
-    // Ensure it's aligned nicely with the title, especially if title wraps to multiple lines.
-    // Default align-items: center on .adw-banner should handle vertical alignment.
-
-    // Adjust size/padding if the default circular button padding isn't perfect for banners.
-    // For example, if it needs to be slightly smaller or have less padding:
-    // padding: var(--spacing-xs); // e.g., 6px if default var(--spacing-s) is too large
-    // .adw-icon {
-    //   font-size: 0.9em; // If the icon itself needs to be slightly smaller
-    // }
-
-    // Ensure it's visually distinct from the main action button, if present.
-    // The flat circular style already does this well.
+  .adw-banner-dismiss-button.adw-button.flat {
+    // This is now a text button, styled as flat.
+    // Ensure good contrast and alignment.
+    // Flex properties on .adw-banner should handle alignment.
+    // Default flat button styling from _button.scss will apply.
+    // We can add specific overrides here if needed, e.g., for margin or color.
+    // margin-left: var(--spacing-s); // Add some space if gap on parent isn't enough
+    // color: var(--banner-secondary-fg-color, var(--secondary-fg-color)); // If a different color is needed for dismiss
   }
+
+  // Styling for the main action button, if present and needing distinction
+  .adw-banner-button.adw-button {
+      // This is the optional action button, not the dismiss button.
+      // AdwButton's own styles apply. If it needs specific banner context styling:
+      // Example: make it less prominent than a normal button if the banner is informational
+      // &.flat {
+      //   background-color: transparent; // Ensure truly flat if it's a flat action button
+      // }
+  }
+
 
   // If a banner needs to be themed for specific contexts (e.g. error, warning)
   // this can be done by adding classes to the AdwBanner element itself.
-  // Example:
-  // &.error {
-  //   background-color: var(--error-bg-color);
-  //   color: var(--error-fg-color);
-  //   border-color: var(--error-border-color);
-  //   .adw-banner-title { color: var(--error-fg-color); }
-  //   .adw-banner-button { /* Adjust button for error context if needed */ }
-  // }
-  // However, the core AdwBanner is neutral.
+  // Default/Info banner uses the main --banner-bg-color, --banner-fg-color, --banner-border-color
+  // The AdwBanner JS adds .adw-banner-info if type is 'info' or it's the default.
+  // So, explicit .adw-banner-info class styling might not be needed if defaults are set correctly.
+
+  &.adw-banner-error {
+    background-color: var(--banner-error-bg-color);
+    color: var(--banner-error-fg-color);
+    border-bottom-color: var(--banner-error-border-color);
+
+    // Ensure buttons within error banners have appropriate contrast or style
+    .adw-banner-button, // Main action button
+    .adw-banner-dismiss-button { // Dismiss button
+      // For flat buttons on a dark error background, text might need to be light.
+      // AdwButton's .flat style typically uses `color: var(--accent-color)` or `currentColor`.
+      // If `currentColor` (banner-error-fg-color) is light, this should be fine.
+      // If specific adjustments are needed:
+      // color: var(--banner-error-fg-color); // Ensure button text matches banner's fg
+      // &:hover { background-color: rgba(255,255,255,0.1); } // Example hover for light text on dark bg
+    }
+  }
+  // Add .adw-banner-warning, .adw-banner-success if those types are supported and variables defined
 }
 
-// Variables that should be defined (e.g., in _variables.scss):
-// --banner-bg-color: (e.g. var(--secondary-bg-color) or a custom banner color)
-// --banner-fg-color: (e.g. var(--primary-fg-color))
+// Variables that should be defined in _variables.scss (within theme mixins):
+// --banner-bg-color (for default/info)
+// --banner-fg-color (for default/info)
+// --banner-border-color (for default/info)
+// --banner-error-bg-color
+// --banner-error-fg-color
+// --banner-error-border-color
+// etc. for other types

--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -355,6 +355,15 @@
   --switch-slider-off-bg-color: rgba(0,0,0,0.08);   // alpha(currentColor, 0.08)
   --switch-knob-disabled-bg-color: var(--adw-light-2);
   --switch-slider-disabled-off-bg-color: rgba(0,0,0,0.06);
+
+  // Banner specific
+  --banner-bg-color: var(--adw-light-3); // Default/Info
+  --banner-fg-color: rgba(0,0,0,0.8);
+  --banner-border-color: var(--adw-light-4); // A slightly darker border for info banners
+
+  --banner-error-bg-color: var(--adw-red-1); // Lighter red for bg in light theme
+  --banner-error-fg-color: var(--adw-light-1); // White text on red
+  --banner-error-border-color: var(--adw-red-2);
 }
 
 @mixin dark-theme {
@@ -486,6 +495,15 @@
   --switch-slider-off-bg-color: rgba(255,255,255,0.12); // alpha(currentColor, 0.12)
   --switch-knob-disabled-bg-color: var(--adw-dark-1);
   --switch-slider-disabled-off-bg-color: rgba(255,255,255,0.08);
+
+  // Banner specific
+  --banner-bg-color: var(--adw-dark-3); // Default/Info
+  --banner-fg-color: #ffffff;
+  --banner-border-color: var(--adw-dark-4);
+
+  --banner-error-bg-color: var(--adw-red-4); // Darker red for bg in dark theme
+  --banner-error-fg-color: var(--adw-light-1); // White text
+  --banner-error-border-color: var(--adw-red-5);
 }
 
 // General Helper Variables (not theme-specific)

--- a/index.html
+++ b/index.html
@@ -389,7 +389,8 @@ if (accentPickerBox) {
 
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">Banner & Toast</adw-label>
                 <adw-box orientation="horizontal" spacing="s" id="banner-toast-trigger-container">
-                    <adw-button id="trigger-banner">Show Banner</adw-button>
+                    <adw-button id="trigger-info-banner">Show Info Banner</adw-button>
+                    <adw-button id="trigger-error-banner">Show Error Banner</adw-button>
                     <adw-button id="trigger-toast">Show Toast</adw-button>
                 </adw-box>
                 <div id="banner-container-main" style="margin-top: var(--spacing-s);"></div>
@@ -787,28 +788,52 @@ if (accentPickerBox) {
         document.getElementById('trigger-preferences-dialog')?.addEventListener('click', () => prefsDialog?.open());
 
         // --- Banner & Toast Triggers (from misc section) ---
-        const bannerContainerMain = document.getElementById('banner-container-main');
-        document.getElementById('trigger-banner')?.addEventListener('click', () => {
-            if (bannerContainerMain) {
-                // Clear previous banners in this container
-                while(bannerContainerMain.firstChild) bannerContainerMain.removeChild(bannerContainerMain.firstChild);
+        const bannerContainerMain = document.getElementById('banner-container-main'); // This container is not strictly needed for fixed banners
 
-                const banner = Adw.createBanner("This is an example banner from index.html.", {
-                    type: 'info',
-                    // buttonLabel: "Action", // Optional: for button in banner
-                    dismissible: true
-                });
-                // banner.addEventListener('button-clicked', () => mainToastOverlayRef.addToast({title: "Banner action!"}));
-                banner.addEventListener('dismissed', () => mainToastOverlayRef.addToast({title: "index.html banner dismissed."}));
+        const showBanner = (type, message, hasAction = false) => {
+            // Banners are fixed, so they don't need to be in bannerContainerMain.
+            // For demo purposes, we might still clear it if we were putting multiple banners there,
+            // but since only one fixed banner is shown at a time (by replacing), this is less critical.
+            // However, to avoid old banner DOM elements lingering if not dismissed:
+            const existingBanner = document.querySelector('body > .adw-banner'); // Find any existing banner directly in body
+            if (existingBanner) existingBanner.remove();
 
-                bannerContainerMain.appendChild(banner);
-                // Ensure it becomes visible, createBanner creates it hidden by default unless 'revealed' is passed.
-                // Forcing visibility after append for consistent behavior.
-                requestAnimationFrame(() => { banner.classList.add('visible'); });
+
+            const bannerOptions = {
+                type: type,
+                dismissible: true
+            };
+            if (hasAction) {
+                bannerOptions.buttonLabel = "Action";
             }
+
+            const banner = Adw.createBanner(message, bannerOptions);
+
+            if (hasAction) {
+                banner.addEventListener('button-clicked', () => {
+                    if(mainToastOverlayRef) mainToastOverlayRef.addToast({title: `Banner action from ${type} banner!`});
+                });
+            }
+            banner.addEventListener('dismissed', () => {
+                if(mainToastOverlayRef) mainToastOverlayRef.addToast({title: `index.html ${type} banner dismissed.`});
+            });
+
+            // Append banner to body for global fixed positioning to work best
+            document.body.appendChild(banner);
+            // Ensure it becomes visible
+            requestAnimationFrame(() => { banner.classList.add('visible'); });
+        };
+
+        document.getElementById('trigger-info-banner')?.addEventListener('click', () => {
+            showBanner('info', "This is an example informational banner.", true);
         });
 
-        const mainToastOverlay = document.getElementById('main-toast-overlay');
+        document.getElementById('trigger-error-banner')?.addEventListener('click', () => {
+            showBanner('error', "This is an example error banner! Something went wrong.");
+        });
+
+
+        const mainToastOverlay = document.getElementById('main-toast-overlay'); // mainToastOverlayRef is already defined above
         document.getElementById('trigger-toast')?.addEventListener('click', () => {
             if (mainToastOverlay) {
                 // Adw.createToast just creates the element. AdwToastOverlay's addToast will use it.

--- a/index1.html
+++ b/index1.html
@@ -264,8 +264,9 @@
 
                 <div class="widget-showcase">
                     <adw-label title-level="2">AdwBanner</adw-label>
-                    <adw-button id="show-banner-btn">Show Banner</adw-button>
-                    <div id="banner-container" style="margin-top: var(--spacing-s);"></div>
+                    <adw-button id="show-info-banner-btn">Show Info Banner</adw-button>
+                    <adw-button id="show-error-banner-btn">Show Error Banner</adw-button>
+                    <div id="banner-container" style="margin-top: var(--spacing-s);"></div> {/* This container is no longer strictly necessary for fixed banners */}
                 </div>
 
                 <div class="widget-showcase">
@@ -459,27 +460,38 @@
             });
         });
 
-        const bannerContainer = document.getElementById('banner-container');
-        document.getElementById('show-banner-btn')?.addEventListener('click', () => {
-            if (bannerContainer) {
-                bannerContainer.innerHTML = ''; // Clear previous
-                // Note: Adw.createBanner returns the element, AdwBanner is the WC class.
-                // We need to append the created banner.
-                const banner = Adw.createBanner("This is a sample banner.", {
-                    type: 'info',
-                    buttonLabel: "More Info",
-                    dismissible: true
-                });
-                banner.addEventListener('button-clicked', () => {
-                     if (toastOverlay) toastOverlay.addToast({ title: "Banner button clicked!"});
-                });
-                 banner.addEventListener('dismissed', () => {
-                     if (toastOverlay) toastOverlay.addToast({ title: "Banner dismissed!"});
-                });
-                bannerContainer.appendChild(banner);
-                // To make it visible (if createAdwBanner doesn't make it visible by default)
-                requestAnimationFrame(() => banner.classList.add('visible'));
+        // Banner logic for showcase page
+        // const bannerContainer = document.getElementById('banner-container'); // Not strictly needed for fixed banners
+        const showBannerInShowcase = (type, message, hasAction = false) => {
+            // Remove any existing banner from body to avoid overlap
+            const existingBanner = document.querySelector('body > .adw-banner');
+            if (existingBanner) existingBanner.remove();
+
+            const bannerOptions = { type: type, dismissible: true };
+            if (hasAction) {
+                bannerOptions.buttonLabel = "More Info"; // Standard action button label for this page
             }
+            const banner = Adw.createBanner(message, bannerOptions);
+
+            if (hasAction) {
+                banner.addEventListener('button-clicked', () => {
+                    if (toastOverlay) toastOverlay.addToast({ title: `Showcase Banner action (${type}) clicked!`});
+                });
+            }
+            banner.addEventListener('dismissed', () => {
+                if (toastOverlay) toastOverlay.addToast({ title: `Showcase Banner (${type}) dismissed!`});
+            });
+
+            document.body.appendChild(banner); // Append to body for fixed positioning
+            requestAnimationFrame(() => banner.classList.add('visible'));
+        };
+
+        document.getElementById('show-info-banner-btn')?.addEventListener('click', () => {
+            showBannerInShowcase('info', "This is a sample informational banner with an action.", true);
+        });
+
+        document.getElementById('show-error-banner-btn')?.addEventListener('click', () => {
+            showBannerInShowcase('error', "This is a critical error banner! Please take action.");
         });
 
         // Bottom Sheet


### PR DESCRIPTION
- Changed banner dismiss button from an 'x' icon to a flat text button labeled "Dismiss" for clarity and closer Adwaita alignment.
- Implemented type-specific background and text colors for banners:
  - Info banners: Grey background.
  - Error banners: Red background.
- Colors are sourced from the GNOME palette variables in `_variables.scss` and adapt to light/dark themes.
- Updated demo pages (index.html, index1.html) to showcase these banner improvements.