### PR TITLE
Refine: Style banner buttons with distinct backgrounds

### DIFF
--- a/adwaita-web/scss/_banner.scss
+++ b/adwaita-web/scss/_banner.scss
@@ -64,50 +64,67 @@
     // Example: if button is too tall, adjust its internal padding or line-height.
   }
 
-  // Specific styling for the dismiss button in a banner
-  .adw-banner-dismiss-button.adw-button.flat {
-    // This is now a text button, styled as flat.
-    // Ensure good contrast and alignment.
-    // Flex properties on .adw-banner should handle alignment.
-    // Default flat button styling from _button.scss will apply.
-    // We can add specific overrides here if needed, e.g., for margin or color.
-    // margin-left: var(--spacing-s); // Add some space if gap on parent isn't enough
-    // color: var(--banner-secondary-fg-color, var(--secondary-fg-color)); // If a different color is needed for dismiss
+  // Common styling for ALL adw-button elements (action or dismiss) inside any banner
+  // This ensures they have a distinct background from the banner itself.
+  .adw-button {
+    background-color: var(--banner-button-bg-color);
+    color: var(--banner-button-fg-color);
+    border: none; // Ensure no border for a cleaner look like in the example image
+    // Padding and other button base styles come from _button.scss
+
+    &:hover {
+      background-color: var(--banner-button-hover-bg-color);
+    }
+    &:active, &.active { // Include .active for toggle buttons if they were used here
+      background-color: var(--banner-button-active-bg-color);
+    }
+
+    // If the button is also flat (like our dismiss button), these styles will override flat's transparent bg.
+    &.flat {
+        background-color: var(--banner-button-bg-color); // Explicitly override flat's transparent bg
+        color: var(--banner-button-fg-color);
+        &:hover {
+          background-color: var(--banner-button-hover-bg-color);
+        }
+        &:active, &.active {
+          background-color: var(--banner-button-active-bg-color);
+        }
+    }
   }
 
-  // Styling for the main action button, if present and needing distinction
-  .adw-banner-button.adw-button {
-      // This is the optional action button, not the dismiss button.
-      // AdwButton's own styles apply. If it needs specific banner context styling:
-      // Example: make it less prominent than a normal button if the banner is informational
-      // &.flat {
-      //   background-color: transparent; // Ensure truly flat if it's a flat action button
-      // }
-  }
-
-
-  // If a banner needs to be themed for specific contexts (e.g. error, warning)
-  // this can be done by adding classes to the AdwBanner element itself.
-  // Default/Info banner uses the main --banner-bg-color, --banner-fg-color, --banner-border-color
-  // The AdwBanner JS adds .adw-banner-info if type is 'info' or it's the default.
-  // So, explicit .adw-banner-info class styling might not be needed if defaults are set correctly.
-
+  // Type-specific overrides
   &.adw-banner-error {
     background-color: var(--banner-error-bg-color);
     color: var(--banner-error-fg-color);
     border-bottom-color: var(--banner-error-border-color);
 
-    // Ensure buttons within error banners have appropriate contrast or style
-    .adw-banner-button, // Main action button
-    .adw-banner-dismiss-button { // Dismiss button
-      // For flat buttons on a dark error background, text might need to be light.
-      // AdwButton's .flat style typically uses `color: var(--accent-color)` or `currentColor`.
-      // If `currentColor` (banner-error-fg-color) is light, this should be fine.
-      // If specific adjustments are needed:
-      // color: var(--banner-error-fg-color); // Ensure button text matches banner's fg
-      // &:hover { background-color: rgba(255,255,255,0.1); } // Example hover for light text on dark bg
+    // Override for buttons inside an ERROR banner
+    .adw-button { // Targets both .adw-banner-button and .adw-banner-dismiss-button within an error banner
+      background-color: var(--banner-error-button-bg-color);
+      color: var(--banner-error-button-fg-color);
+      border: none; // Ensure no border here too
+
+      &:hover {
+        background-color: var(--banner-error-button-hover-bg-color);
+      }
+      &:active, &.active {
+        background-color: var(--banner-error-button-active-bg-color);
+      }
+
+      // If the button is also flat (like our dismiss button), these styles will override flat's transparent bg.
+      &.flat {
+          background-color: var(--banner-error-button-bg-color); // Explicitly override flat's transparent bg
+          color: var(--banner-error-button-fg-color);
+          &:hover {
+            background-color: var(--banner-error-button-hover-bg-color);
+          }
+          &:active, &.active {
+            background-color: var(--banner-error-button-active-bg-color);
+          }
+      }
     }
   }
+  // Add .adw-banner-info for specific info button styling if different from default .adw-button in banner
   // Add .adw-banner-warning, .adw-banner-success if those types are supported and variables defined
 }
 

--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -364,6 +364,17 @@
   --banner-error-bg-color: var(--adw-red-1); // Lighter red for bg in light theme
   --banner-error-fg-color: var(--adw-light-1); // White text on red
   --banner-error-border-color: var(--adw-red-2);
+
+  // Banner button specific (light theme)
+  --banner-button-fg-color: var(--banner-fg-color); // Inherit text color from banner
+  --banner-button-bg-color: rgba(0,0,0,0.05); // Subtle darker overlay
+  --banner-button-hover-bg-color: rgba(0,0,0,0.08);
+  --banner-button-active-bg-color: rgba(0,0,0,0.12);
+
+  --banner-error-button-fg-color: var(--banner-error-fg-color); // Inherit text color
+  --banner-error-button-bg-color: rgba(0,0,0,0.08); // Subtle darker overlay on error bg
+  --banner-error-button-hover-bg-color: rgba(0,0,0,0.12);
+  --banner-error-button-active-bg-color: rgba(0,0,0,0.16);
 }
 
 @mixin dark-theme {
@@ -504,6 +515,17 @@
   --banner-error-bg-color: var(--adw-red-4); // Darker red for bg in dark theme
   --banner-error-fg-color: var(--adw-light-1); // White text
   --banner-error-border-color: var(--adw-red-5);
+
+  // Banner button specific (dark theme)
+  --banner-button-fg-color: var(--banner-fg-color); // Inherit text color from banner
+  --banner-button-bg-color: rgba(255,255,255,0.07); // Subtle lighter overlay
+  --banner-button-hover-bg-color: rgba(255,255,255,0.10);
+  --banner-button-active-bg-color: rgba(255,255,255,0.13);
+
+  --banner-error-button-fg-color: var(--banner-error-fg-color); // Inherit text color
+  --banner-error-button-bg-color: rgba(255,255,255,0.08); // Subtle lighter overlay on error bg
+  --banner-error-button-hover-bg-color: rgba(255,255,255,0.12);
+  --banner-error-button-active-bg-color: rgba(255,255,255,0.16);
 }
 
 // General Helper Variables (not theme-specific)


### PR DESCRIPTION
- Added CSS variables for banner button background colors (normal, hover, active) to provide subtle differentiation from the banner's main background.
- Updated SCSS for banners to apply these new variables, ensuring buttons appear as distinct clickable areas, aligning with Adwaita visual language as shown in examples (e.g., banner-dark.png).
- This applies to both action buttons and the 'Dismiss' button within info and error banners, across light and dark themes.