### PR TITLE
Fix: Ensure info banner in index.html shows only one button

### DIFF
--- a/index.html
+++ b/index.html
@@ -825,7 +825,7 @@ if (accentPickerBox) {
         };
 
         document.getElementById('trigger-info-banner')?.addEventListener('click', () => {
-            showBanner('info', "This is an example informational banner.", true);
+            showBanner('info', "This is an example informational banner.", false); // Changed true to false
         });
 
         document.getElementById('trigger-error-banner')?.addEventListener('click', () => {


### PR DESCRIPTION
Modified the JavaScript in index.html to configure its informational banner to only display a 'Dismiss' button, removing the explicit 'Action' button from this specific demo instance to address user feedback.

Other banners (error banners, info banners in index1.html) can still show an action button plus a dismiss button as intended.