### PR TITLE
Fix: Correct toast visibility, center banner text, and refine banner …

### DIFF
--- a/adwaita-web/js/components/misc.js
+++ b/adwaita-web/js/components/misc.js
@@ -567,52 +567,51 @@ export function createAdwBanner(title, options = {}) {
     banner.setAttribute('role', 'status'); // Or 'alert' if it's for important dynamic changes
     if (opts.id) banner.id = opts.id;
 
-    const contentWrapper = document.createElement('div'); // Wrapper for title and button
-    contentWrapper.classList.add('adw-banner-content-wrapper');
-
+    // Create title span
     const titleSpan = document.createElement('span');
     titleSpan.classList.add('adw-banner-title');
     if (opts.useMarkup) {
-        titleSpan.innerHTML = title; // Assumes sanitized HTML if markup is used
+        titleSpan.innerHTML = title; // Assumes sanitized HTML
     } else {
         titleSpan.textContent = title;
     }
-    contentWrapper.appendChild(titleSpan); // Add title to wrapper
+    banner.appendChild(titleSpan); // Title is a direct child of banner
 
-    if (opts.buttonLabel) {
+    // Create a group for action and dismiss buttons
+    const buttonGroup = document.createElement('div');
+    buttonGroup.classList.add('adw-banner-button-group');
+
+    let actionButton = null;
+    if (opts.buttonLabel) { // Action button
         const buttonOptions = {
-            // label: opts.buttonLabel, // Label is passed directly to createAdwButton
             onClick: (event) => {
-                // Dispatch a custom event from the banner itself
                 banner.dispatchEvent(new CustomEvent('button-clicked', { bubbles: true, composed: true, detail: { originalEvent: event } }));
             }
         };
-        if (opts.buttonStyle === 'suggested') {
-            buttonOptions.suggested = true;
-        } else if (opts.buttonStyle === 'destructive') {
-            buttonOptions.destructive = true;
-        }
-        // buttonOptions.flat = true; // Banners typically have non-flat action buttons
+        if (opts.buttonStyle === 'suggested') buttonOptions.suggested = true;
+        else if (opts.buttonStyle === 'destructive') buttonOptions.destructive = true;
 
-        const button = createAdwButton(opts.buttonLabel, buttonOptions);
-        button.classList.add('adw-banner-button');
-        contentWrapper.appendChild(button); // Add action button to wrapper
+        actionButton = createAdwButton(opts.buttonLabel, buttonOptions);
+        actionButton.classList.add('adw-banner-button');
+        buttonGroup.appendChild(actionButton);
     }
-    banner.appendChild(contentWrapper); // Add content wrapper to banner
 
-    if (opts.dismissible) {
-        const dismissButton = createAdwButton('Dismiss', { // Changed to text label "Dismiss"
-            // flat: true, // Decide on styling: flat or default button appearance
-            // No iconName or isCircular needed for a text button
-            ariaLabel: 'Dismiss banner', // Keeps the aria-label for accessibility
+    let dismissButton = null;
+    if (opts.dismissible) { // Dismiss button
+        dismissButton = createAdwButton('Dismiss', {
+            ariaLabel: 'Dismiss banner',
             onClick: () => {
                 banner.remove();
                 banner.dispatchEvent(new CustomEvent('dismissed', { bubbles: true, composed: true }));
             }
         });
-        dismissButton.classList.add('adw-banner-dismiss-button'); // Keep class for specific styling
-        dismissButton.classList.add('flat'); // Make the dismiss button flat by default
-        banner.appendChild(dismissButton);
+        dismissButton.classList.add('adw-banner-dismiss-button');
+        dismissButton.classList.add('flat'); // Keep dismiss button flat
+        buttonGroup.appendChild(dismissButton);
+    }
+
+    if (buttonGroup.hasChildNodes()) {
+        banner.appendChild(buttonGroup);
     }
 
     // Set type class for styling (e.g., adw-banner-warning)

--- a/adwaita-web/scss/_banner.scss
+++ b/adwaita-web/scss/_banner.scss
@@ -44,44 +44,45 @@
   }
 
   .adw-banner-title {
-    flex-grow: 1; // Title takes available space
+    flex-grow: 1;
     font-size: var(--font-size-base);
-    font-weight: normal; // Banners usually have normal weight text
-    // Text alignment: Libadwaita centers if enough space, else left-aligns.
-    // Default to left-align for simplicity in CSS. Centering would require more complex checks or JS.
-    text-align: left;
-    min-width: 0; // For ellipsis if title is very long
+    font-weight: normal;
+    text-align: center; // Center the title text
+    min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    // The flex layout (justify-content: space-between) on .adw-banner
+    // will give this title the available space between start and the button group.
+    // Adding a small margin to ensure it doesn't touch button group if space is very tight.
+    margin-right: var(--spacing-s); // Only if there's a button group.
+    &:only-child { // If title is the only child (no button group)
+        margin-right: 0; // No margin needed
+    }
   }
 
-  .adw-banner-button.adw-button {
-    // Styling for the AdwButton component when used inside a banner
-    flex-shrink: 0; // Button should not shrink
-    // AdwButton's own styles (default, .suggested, .flat) will apply.
-    // Ensure it aligns well with the text.
-    // Example: if button is too tall, adjust its internal padding or line-height.
+  .adw-banner-button-group {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s); // Space between buttons in the group
+    flex-shrink: 0; // Prevent button group from shrinking
   }
 
-  // Common styling for ALL adw-button elements (action or dismiss) inside any banner
-  // This ensures they have a distinct background from the banner itself.
-  .adw-button {
+  // Styling for buttons inside the .adw-banner-button-group
+  .adw-banner-button-group > .adw-button {
     background-color: var(--banner-button-bg-color);
     color: var(--banner-button-fg-color);
-    border: none; // Ensure no border for a cleaner look like in the example image
-    // Padding and other button base styles come from _button.scss
+    border: none;
 
     &:hover {
       background-color: var(--banner-button-hover-bg-color);
     }
-    &:active, &.active { // Include .active for toggle buttons if they were used here
+    &:active, &.active {
       background-color: var(--banner-button-active-bg-color);
     }
 
-    // If the button is also flat (like our dismiss button), these styles will override flat's transparent bg.
-    &.flat {
-        background-color: var(--banner-button-bg-color); // Explicitly override flat's transparent bg
+    &.flat { // Specific override for flat buttons in the group
+        background-color: var(--banner-button-bg-color);
         color: var(--banner-button-fg-color);
         &:hover {
           background-color: var(--banner-button-hover-bg-color);
@@ -98,11 +99,11 @@
     color: var(--banner-error-fg-color);
     border-bottom-color: var(--banner-error-border-color);
 
-    // Override for buttons inside an ERROR banner
-    .adw-button { // Targets both .adw-banner-button and .adw-banner-dismiss-button within an error banner
+    // Override for buttons inside an ERROR banner's button group
+    .adw-banner-button-group > .adw-button {
       background-color: var(--banner-error-button-bg-color);
       color: var(--banner-error-button-fg-color);
-      border: none; // Ensure no border here too
+      border: none;
 
       &:hover {
         background-color: var(--banner-error-button-hover-bg-color);
@@ -111,9 +112,8 @@
         background-color: var(--banner-error-button-active-bg-color);
       }
 
-      // If the button is also flat (like our dismiss button), these styles will override flat's transparent bg.
-      &.flat {
-          background-color: var(--banner-error-button-bg-color); // Explicitly override flat's transparent bg
+      &.flat { // Specific override for flat buttons in the error group
+          background-color: var(--banner-error-button-bg-color);
           color: var(--banner-error-button-fg-color);
           &:hover {
             background-color: var(--banner-error-button-hover-bg-color);
@@ -124,8 +124,8 @@
       }
     }
   }
-  // Add .adw-banner-info for specific info button styling if different from default .adw-button in banner
-  // Add .adw-banner-warning, .adw-banner-success if those types are supported and variables defined
+  // Add .adw-banner-info for specific info button styling if needed
+  // Add .adw-banner-warning, .adw-banner-success if those types are supported
 }
 
 // Variables that should be defined in _variables.scss (within theme mixins):

--- a/index.html
+++ b/index.html
@@ -832,22 +832,22 @@ if (accentPickerBox) {
             showBanner('error', "This is an example error banner! Something went wrong.");
         });
 
-
-        const mainToastOverlay = document.getElementById('main-toast-overlay'); // mainToastOverlayRef is already defined above
+        // Ensure mainToastOverlayRef is used, which is defined earlier in the script.
+        // const mainToastOverlay = document.getElementById('main-toast-overlay'); // This re-declaration was the issue.
         document.getElementById('trigger-toast')?.addEventListener('click', () => {
-            if (mainToastOverlay) {
+            if (mainToastOverlayRef) { // Use the existing mainToastOverlayRef
                 // Adw.createToast just creates the element. AdwToastOverlay's addToast will use it.
                 // The onAction is now handled internally by createAdwToast if the factory is used by overlay.
                 // Or, if addToast takes options directly:
-                mainToastOverlay.addToast({
+                mainToastOverlayRef.addToast({
                     title: "This is an example toast!",
                     buttonLabel: "Undo", // Adw.createToast uses buttonLabel, not actionName for the button text
                     onAction: () => {
-                        if(mainToastOverlay) mainToastOverlay.addToast({ title: "Undo clicked!" });
+                        if(mainToastOverlayRef) mainToastOverlayRef.addToast({ title: "Undo clicked!" });
                     }
                 });
             } else {
-                console.warn("Main toast overlay not found. Creating toast without displaying.");
+                console.warn("Main toast overlay (mainToastOverlayRef) not found. Creating toast without displaying.");
                 // Fallback to old behavior if overlay not found, though it won't show.
                  Adw.createToast("This is an example toast! (Overlay missing)", { buttonLabel: "Undo", onAction: () => Adw.createToast("Undo clicked! (Overlay missing)") });
             }


### PR DESCRIPTION
…button styles

- Fixed an issue preventing toasts from displaying in index.html due to a JavaScript variable scope error.
- Centered the title text within banners for improved visual alignment, consistent with Adwaita design language. This involved minor restructuring of banner content in JS and SCSS updates.
- Ensured buttons on error banners now correctly use specific styling, providing a distinct background relative to the error banner's main color, consistent with how info banner buttons are styled.
- Verified all changes in demo pages across light and dark themes.