### PR TITLE
Fix: Correctly render content textarea and add favicon link

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -60,6 +60,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}My Libadwaita Blog{% endblock %}</title>
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <script>
       // Anti-flicker script
       (function() {

--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -66,16 +66,20 @@
                     class="{{ 'has-error' if form.title.errors else '' }}">
                 </adw-entry-row>
 
+                {# Replaced adw-action-row with a more direct rendering for TextAreaField #}
+                {# The adw-action-row's title attribute will serve as the label for the content field #}
                 <adw-action-row title="{{ form.content.label.text }}" subtitle="Enter your post content below.">
-                    <div slot="suffix" style="width:100%;">
-                        {{ form.content(id=form.content.id or 'content_field', class='adw-entry', style='width: 100%; min-height: 200px; resize: vertical; box-sizing: border-box;', rows='10') }}
-                        {% if form.content.errors %}
-                            <div class="errors" style="color: var(--error-color); font-size: var(--font-size-small); margin-top: var(--spacing-xs);">
-                                {% for error in form.content.errors %}{{ error }}<br>{% endfor %}
-                            </div>
-                        {% endif %}
-                    </div>
+                    {# The textarea is placed directly. Removed 'adw-entry' class. #}
+                    {# The 'activatable' attribute might be useful if the whole row should focus the textarea, but let's start simple #}
+                    {{ form.content(id=form.content.id or 'content_field', style='width: 100%; min-height: 200px; resize: vertical; box-sizing: border-box; border: 1px solid var(--border-color); border-radius: var(--radius-s); padding: var(--spacing-xs); background-color: var(--entry-background-color); color: var(--text-color);', rows='10') }}
                 </adw-action-row>
+                 {% if form.content.errors %}
+                    <adw-action-row class="error-row">
+                        <div class="errors" style="color: var(--error-color); font-size: var(--font-size-small); padding-left: var(--spacing-m);">
+                            {% for error in form.content.errors %}{{ error }}<br>{% endfor %}
+                        </div>
+                    </adw-action-row>
+                {% endif %}
             </adw-list-box>
         </adw-preferences-group>
 


### PR DESCRIPTION
- Modified `app-demo/templates/create_post.html` to ensure the `content` field (TextAreaField) renders as a multi-line input. Removed `adw-entry` class and adjusted styling for better Adwaita theme integration.
- Added a standard favicon link to `app-demo/templates/base.html` to resolve the 404 error for `favicon.ico`.
- Confirmed the submit button is present in the create post form.