### PR TITLE
Fix: Correct Jinja2 syntax error in create_post.html

### DIFF
--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -85,7 +85,7 @@
                     <div slot="suffix" style="width:100%; padding-top: var(--spacing-xs);"> {# Added padding-top for spacing #}
                         {{ form.content(
                             id=form.content.id or 'content_field',
-                            class='adw-textarea-standalone', {# Custom class for styling #}
+                            class='adw-textarea-standalone',
                             style='width: 100%; min-height: 200px; resize: vertical; box-sizing: border-box;',
                             rows='10'
                         ) }}


### PR DESCRIPTION
Removed a Jinja2 comment from within the arguments of the `form.content()` call in `app-demo/templates/create_post.html`. This comment was causing a `jinja2.exceptions.TemplateSyntaxError`.