### PR TITLE
Fix: Correct Jinja2 syntax in temp debug block

### DIFF
--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -79,7 +79,7 @@
             {{ form.content(
                 id=form.content.id or 'content_field',
                 class='adw-textarea-standalone',
-                style='width: 100%; min-height: 100px; resize: vertical; box-sizing: border-box;', {# Reduced min-height for test #}
+                style='width: 100%; min-height: 100px; resize: vertical; box-sizing: border-box;',
                 rows='5'
             ) }}
             {% if form.content.errors %}


### PR DESCRIPTION
Removes a misplaced Jinja2 comment within the `form.content()` call in the temporary debugging div in `create_post.html`. This was causing a TemplateSyntaxError.