### PR TITLE
fix: Correct Jinja2 orphaned endif tag in post forms

### DIFF
--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -117,7 +117,6 @@
             {# {% if form.categories.errors %}
             <adw-list-box> <adw-action-row subtitle="{{ form.categories.errors|join(' ') }}" class="error-row"></adw-action-row> </adw-list-box>
             {% endif %} #}
-            {% endif %}
         </adw-preferences-group>
 
         <adw-preferences-group title="Tags">

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -75,7 +75,6 @@
             {# {% if form.categories.errors %}
             <adw-list-box> <adw-action-row subtitle="{{ form.categories.errors|join(' ') }}" class="error-row"></adw-action-row> </adw-list-box>
             {% endif %} #}
-            {% endif %}
         </adw-preferences-group>
 
         <adw-preferences-group title="Tags">


### PR DESCRIPTION
This commit fixes a `TemplateSyntaxError` in `create_post.html` and `edit_post.html` caused by an orphaned `{% endif %}` tag after refactoring the category error display.

This change is amended to the previous UI overhaul commit.