### PR TITLE
Refactor layout components to be more CSS-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,14 @@ A flexbox container.
 
 -   **HTML Example:**
     ```html
-    <adw-box orientation="horizontal" spacing="s" align="center">
+    <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s align-center">
       <adw-button>OK</adw-button>
       <adw-button>Cancel</adw-button>
     </adw-box>
     ```
-    Attributes: `orientation` ('vertical'/'horizontal'), `spacing`, `align`, `justify`, `fill-children`.
+    Classes: `adw-box-vertical` or `adw-box-horizontal`, `adw-box-spacing-[xs|s|m|l|xl]`, `align-[start|center|end|stretch]`, `justify-[start|center|end|between|around|evenly]`, `adw-box-fill-children`.
 -   **JS Factory:** `Adw.createBox(options = {})`
-    - `options`: `orientation`, `align`, `justify`, `spacing`, `fillChildren`, `children`.
+    - `options`: `orientation`, `align`, `justify`, `spacing`, `fillChildren`, `children` (these options will now map to classes).
 
 ### List Boxes (`<adw-list-box>` / `Adw.createListBox()`) & Rows
 

--- a/adwaita-web/scss/_clamp.scss
+++ b/adwaita-web/scss/_clamp.scss
@@ -2,30 +2,33 @@
 @use 'variables';
 
 .adw-clamp {
-  // display: flex; // Set by JS factory/WC
-  // justify-content: center; // Set by JS factory/WC
+  display: flex;
+  justify-content: center;
   width: 100%; // Clamp itself should take available width to center its child.
+
+  &.scrollable {
+    // When the clamp itself is scrollable, its child wrapper usually is not the one scrolling,
+    // but rather the clamp might have a fixed height and its content (the child wrapper) overflows.
+    // This setup seems more like the child-wrapper might scroll if clamp has fixed height.
+    // For typical clamp usage (restricting width, not usually for scrolling the clamp itself):
+    // overflow: visible; // Default, let content flow.
+
+    // If the intent of AdwClamp.scrollable is that the *content inside the clamp* scrolls
+    // once it hits its max-width and if the content is taller than available height:
+    // This would typically be handled by the parent container of AdwClamp or by sizing AdwClamp itself.
+    // Let's assume .scrollable on .adw-clamp means the content *within* the child wrapper can scroll
+    // if the clamp is given a constrained height.
+    // However, the JS sets overflow on the .adw-clamp element.
+    overflow-y: auto;
+    overflow-x: hidden; // Usually clamps are for width, horizontal scroll is rare.
+    // height: 100%; // Often needed for scrollable clamps to fill parent allocated space.
+  }
 
   .adw-clamp-child-wrapper {
     width: 100%; // Takes full width up to its own max-width.
                  // If clamp is scrollable, this ensures it uses the scrollable area.
-    // max-width is set by JS.
-    // margin-left: auto; // Set by JS if using margin auto centering
-    // margin-right: auto; // Set by JS if using margin auto centering
+    // max-width is set by JS via inline style on this element.
   }
-
-  // &.scrollable { // Class added by JS
-  //   overflow-x: hidden; // Set by JS
-  //   overflow-y: auto;   // Set by JS
-  //   // Ensure it has a height to make scrolling meaningful, e.g.,
-  //   // height: 100%;
-  //   // or parent needs to constrain its height.
-  // }
 }
 
-// No specific dark theme styles usually needed for AdwClamp itself,
-// as it's a transparent container. Child content handles its own theme.
-// .dark-theme .adw-clamp,
-// body.dark-theme .adw-clamp {
-//   // ...
-// }
+// No specific dark theme styles needed for AdwClamp itself.

--- a/adwaita-web/scss/_wrap_box.scss
+++ b/adwaita-web/scss/_wrap_box.scss
@@ -2,38 +2,48 @@
 @use 'variables';
 
 .adw-wrap-box {
-  // display: flex; // Set by JS factory/WC directly for now
-  // flex-wrap: wrap; // Set by JS factory/WC directly
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row; // Default orientation
+  gap: var(--spacing-m); // Default spacing
 
-  // Default spacing if not overridden by JS (though JS sets gap directly)
-  // gap: var(--spacing-m);
+  // Orientation
+  &.wrap-box-horizontal {
+    flex-direction: row;
+  }
+  &.wrap-box-vertical {
+    flex-direction: column;
+  }
 
-  // If specific utility classes were to be used instead of direct style manipulation by JS:
-  // &.horizontal { flex-direction: row; }
-  // &.vertical { flex-direction: column; }
+  // Spacing (gap)
+  // These will set both row-gap and column-gap to the same value.
+  // If distinct line-spacing vs item-spacing is critical and common,
+  // more complex classes or local CSS variables might be needed.
+  &.wrap-box-spacing-xs { gap: var(--spacing-xs); }
+  &.wrap-box-spacing-s { gap: var(--spacing-s); }
+  &.wrap-box-spacing-m { gap: var(--spacing-m); }
+  &.wrap-box-spacing-l { gap: var(--spacing-l); }
+  &.wrap-box-spacing-xl { gap: var(--spacing-xl); }
 
-  // &.spacing-xs { gap: var(--spacing-xs); }
-  // &.spacing-s { gap: var(--spacing-s); }
-  // &.spacing-m { gap: var(--spacing-m); }
-  // &.spacing-l { gap: var(--spacing-l); }
-  // &.spacing-xl { gap: var(--spacing-xl); }
+  // Alignment (align-items)
+  &.wrap-align-start { align-items: flex-start; }
+  &.wrap-align-center { align-items: center; }
+  &.wrap-align-end { align-items: flex-end; }
+  &.wrap-align-stretch { align-items: stretch; }
+  &.wrap-align-baseline { align-items: baseline; }
 
-  // &.align-start { align-items: flex-start; }
-  // &.align-center { align-items: center; }
-  // &.align-end { align-items: flex-end; }
-  // &.align-stretch { align-items: stretch; }
 
-  // &.justify-start { justify-content: flex-start; }
-  // &.justify-center { justify-content: center; }
-  // &.justify-end { justify-content: flex-end; }
-  // &.justify-between { justify-content: space-between; }
-  // &.justify-around { justify-content: space-around; }
-  // &.justify-evenly { justify-content: space-evenly; }
+  // Justification (justify-content)
+  // Note: justify-content applies to the main axis. For wrapping content,
+  // align-content might also be relevant if there are multiple lines.
+  // For simplicity, sticking to justify-content based on AdwBox.
+  &.wrap-justify-start { justify-content: flex-start; }
+  &.wrap-justify-center { justify-content: center; }
+  &.wrap-justify-end { justify-content: flex-end; }
+  &.wrap-justify-between { justify-content: space-between; }
+  &.wrap-justify-around { justify-content: space-around; }
+  &.wrap-justify-evenly { justify-content: space-evenly; }
 }
 
-// No dark theme specific styles usually needed if it's a simple wrapper
-// and children handle their own theming.
-// .dark-theme .adw-wrap-box,
-// body.dark-theme .adw-wrap-box {
-//   // ...
-// }
+// No specific dark theme styles needed for AdwWrapBox itself,
+// as it's a layout container. Children handle their own theming.

--- a/app-demo/templates/about.html
+++ b/app-demo/templates/about.html
@@ -2,7 +2,7 @@
 {% block title %}About Us - {{ super() }}{% endblock %}
 {% block content %}
 <adw-clamp style="max-width: 800px; margin: 20px auto; padding: var(--spacing-l);">
-    <adw-box orientation="vertical" spacing="l">
+    <adw-box class="adw-box adw-box-vertical adw-box-spacing-l">
         <h1 class="adw-title-1" style="text-align: center;">About This Application</h1>
 
         <adw-preferences-group>

--- a/app-demo/templates/contact.html
+++ b/app-demo/templates/contact.html
@@ -2,7 +2,7 @@
 {% block title %}Contact Us - {{ super() }}{% endblock %}
 {% block content %}
 <adw-clamp style="max-width: 700px; margin: 20px auto; padding: var(--spacing-l);">
-    <adw-box orientation="vertical" spacing="l">
+    <adw-box class="adw-box adw-box-vertical adw-box-spacing-l">
         <h1 class="adw-title-1" style="text-align: center;">Contact Us</h1>
 
         <adw-preferences-group title="Get in Touch">

--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -13,7 +13,7 @@
         <adw-list-box class="blog-posts-list"> {# Using adw-list-box for semantic grouping of post cards #}
             {% for post in posts %}
             {# Each post is an adw-box, styled as a card. This could also be a complex adw-expander-row or similar. #}
-            <adw-box orientation="vertical" class="blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
+            <adw-box class="adw-box adw-box-vertical blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
                 <h3 style="margin-top:0; margin-bottom: var(--spacing-xs);"><a href="{{ url_for('view_post', post_id=post.id) }}" class="post-title" style="text-decoration: none; color: var(--link-color);">{{ post.title }}</a></h3>
                 <p class="post-meta" style="font-size: var(--font-size-small); color: var(--secondary-text-color); margin-bottom: var(--spacing-s);">
                     By: <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username if post.author else 'Unknown Author' }}</a>

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -47,7 +47,7 @@
         {% if post.author %}
         <div class="author-bio-section" style="margin-top: var(--spacing-xl); margin-bottom: var(--spacing-xl); padding: var(--spacing-l); border: 1px solid var(--border-color); border-radius: var(--border-radius-lg); background-color: var(--window-bg-color); box-shadow: var(--box-shadow-sm);">
             <h3 style="margin-top:0; margin-bottom:var(--spacing-m);">About {{ post.author.full_name or post.author.username }}</h3>
-            <adw-box orientation="horizontal" spacing="m" style="align-items: flex-start;">
+            <adw-box class="adw-box adw-box-horizontal adw-box-spacing-m" style="align-items: flex-start;">
                 <adw-avatar size="64"
                             image-src="{{ url_for('static', filename=post.author.profile_photo_url) if post.author.profile_photo_url else url_for('static', filename='img/default_avatar.png') }}"
                             text="{{ post.author.username[0]|upper if post.author.username else 'A' }}">
@@ -68,7 +68,7 @@
 
         <div class="share-buttons-section" style="margin-top: var(--spacing-xl); margin-bottom: var(--spacing-xl);">
             <h4 style="margin-bottom: var(--spacing-s);">Share this post:</h4>
-            <adw-box orientation="horizontal" spacing="s" style="flex-wrap: wrap; gap: var(--spacing-s);">
+            <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s" style="flex-wrap: wrap; gap: var(--spacing-s);">
                 <adw-button
                     href="https://twitter.com/intent/tweet?url={{ request.url_root[:-1] }}{{ url_for('view_post', post_id=post.id) }}&text={{ post.title|urlencode }}"
                     target="_blank" rel="noopener noreferrer"
@@ -129,7 +129,7 @@
         {% if comments %}
             <adw-list-box>
                 {% for comment in comments %}
-                <adw-box orientation="vertical" class="comment-card" style="padding: var(--spacing-m); border-bottom: 1px solid var(--border-color);">
+                <adw-box class="adw-box adw-box-vertical comment-card" style="padding: var(--spacing-m); border-bottom: 1px solid var(--border-color);">
                     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--spacing-xs);">
                         <div style="display:flex; align-items:center; gap:var(--spacing-s);">
                             <adw-avatar text="{{ comment.author.username[0] if comment.author.username else '?' }}" image-src="{{ url_for('static', filename=comment.author.profile_photo_url) if comment.author.profile_photo_url else url_for('static', filename='img/default_avatar.png') }}" size="32"></adw-avatar>
@@ -182,9 +182,9 @@
     {% endif %}
 
 
-    <div class="adw-box justify-content-center" style="margin-top: var(--spacing-xl); margin-bottom: var(--spacing-xl);">
+    <adw-box class="adw-box justify-content-center" style="margin-top: var(--spacing-xl); margin-bottom: var(--spacing-xl);">
          <adw-button href="{{ url_for('index') }}">Back to Posts</adw-button>
-    </div>
+    </adw-box>
 </adw-clamp>
 
 <script>

--- a/app-demo/templates/posts_by_category.html
+++ b/app-demo/templates/posts_by_category.html
@@ -15,7 +15,7 @@
     {% if posts %}
         <adw-list-box class="blog-posts-list">
             {% for post in posts %}
-            <adw-box orientation="vertical" class="blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
+            <adw-box class="adw-box adw-box-vertical blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
                 <h3 style="margin-top:0; margin-bottom: var(--spacing-xs);"><a href="{{ url_for('view_post', post_id=post.id) }}" class="post-title" style="text-decoration: none; color: var(--link-color);">{{ post.title }}</a></h3>
                 <p class="post-meta" style="font-size: var(--font-size-small); color: var(--secondary-text-color); margin-bottom: var(--spacing-s);">
                     By: <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username if post.author else 'Unknown Author' }}</a>

--- a/app-demo/templates/posts_by_tag.html
+++ b/app-demo/templates/posts_by_tag.html
@@ -15,7 +15,7 @@
     {% if posts %}
         <adw-list-box class="blog-posts-list">
             {% for post in posts %}
-            <adw-box orientation="vertical" class="blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
+            <adw-box class="adw-box adw-box-vertical blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
                 <h3 style="margin-top:0; margin-bottom: var(--spacing-xs);"><a href="{{ url_for('view_post', post_id=post.id) }}" class="post-title" style="text-decoration: none; color: var(--link-color);">{{ post.title }}</a></h3>
                 <p class="post-meta" style="font-size: var(--font-size-small); color: var(--secondary-text-color); margin-bottom: var(--spacing-s);">
                     By: <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username if post.author else 'Unknown Author' }}</a>
@@ -86,8 +86,8 @@
         {% endif %}
     </nav>
     {% endif %}
-    <div class="adw-box justify-content-center" style="margin-top: var(--spacing-xl);">
+    <adw-box class="adw-box justify-content-center" style="margin-top: var(--spacing-xl);">
          <adw-button href="{{ url_for('index') }}">Back to All Posts</adw-button>
-    </div>
+    </adw-box>
 </adw-clamp>
 {% endblock %}

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -4,16 +4,16 @@
 
 {% block content %}
 <adw-clamp style="max-width: 800px; margin: var(--spacing-xl) auto;">
-    <adw-box orientation="vertical" spacing="l">
+    <adw-box class="adw-box adw-box-vertical adw-box-spacing-l">
 
         {# User Header Info #}
-        <adw-box orientation="horizontal" spacing="xl" style="align-items: center;">
+        <adw-box class="adw-box adw-box-horizontal adw-box-spacing-xl" style="align-items: center;">
             <adw-avatar
                 size="96"
                 image-src="{{ url_for('static', filename=user_profile.profile_photo_url) if user_profile.profile_photo_url else default_avatar_url }}"
                 text="{{ user_profile.username }}">
             </adw-avatar>
-            <adw-box orientation="vertical" spacing="xs">
+            <adw-box class="adw-box adw-box-vertical adw-box-spacing-xs">
                 {% if user_profile.full_name %}
                     <adw-label title-level="1">{{ user_profile.full_name }}</adw-label>
                     <adw-label title-level="3" class="secondary-text">@{{ user_profile.username }}</adw-label>
@@ -62,7 +62,7 @@
 
         {# Edit Profile Button #}
         {% if current_user == user_profile %}
-        <adw-box orientation="horizontal" justify="start" style="margin-top: var(--spacing-m); margin-bottom: var(--spacing-l);">
+        <adw-box class="adw-box adw-box-horizontal justify-start" style="margin-top: var(--spacing-m); margin-bottom: var(--spacing-l);">
             <adw-button href="{{ url_for('edit_profile') }}" suggested>Edit Profile</adw-button>
         </adw-box>
         {% endif %}

--- a/app-demo/templates/search_results.html
+++ b/app-demo/templates/search_results.html
@@ -23,7 +23,7 @@
     {% if posts %}
         <adw-list-box class="blog-posts-list">
             {% for post in posts %}
-            <adw-box orientation="vertical" class="blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
+            <adw-box class="adw-box adw-box-vertical blog-post-card" style="margin-bottom: var(--spacing-l); padding: var(--spacing-m); border-radius: var(--border-radius-md); border: 1px solid var(--border-color); list-style-type: none;">
                 <h3 style="margin-top:0; margin-bottom: var(--spacing-xs);"><a href="{{ url_for('view_post', post_id=post.id) }}" class="post-title" style="text-decoration: none; color: var(--link-color);">{{ post.title }}</a></h3>
                 <p class="post-meta" style="font-size: var(--font-size-small); color: var(--secondary-text-color); margin-bottom: var(--spacing-s);">
                     By: <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username if post.author else 'Unknown Author' }}</a>

--- a/docs/general/web-components.md
+++ b/docs/general/web-components.md
@@ -23,7 +23,7 @@ Once `js/components.js` (or the bundled `adwaita-web.js`) is included in your pa
 **Example: Using `<adw-button>` and `<adw-entry>`**
 
 ```html
-<adw-box orientation="vertical" spacing="m">
+<adw-box class="adw-box adw-box-vertical adw-box-spacing-m">
   <adw-label title-level="1">Login Form</adw-label>
   <adw-entry-row title="Username" placeholder="Enter your username"></adw-entry-row>
   <adw-password-entry-row title="Password" placeholder="Enter your password"></adw-password-entry-row>

--- a/docs/widgets/box.md
+++ b/docs/widgets/box.md
@@ -15,17 +15,17 @@ Adw.Box.factory(options = {}) -> AdwBoxElement // Assuming AdwBoxElement is the 
 
 **Parameters:**
 
-*   `options` (Object, optional): Configuration options, mapped to attributes of the `<adw-box>`:
-    *   `orientation` (String, optional): Sets the `orientation` attribute (`"horizontal"` or `"vertical"`).
-    *   `align` (String, optional): Sets the `align` attribute (e.g., `"start"`, `"center"`, `"end"`).
-    *   `justify` (String, optional): Sets the `justify` attribute (e.g., `"start"`, `"center"`, `"between"`).
-    *   `spacing` (String, optional): Sets the `spacing` attribute (e.g., `"s"`, `"m"`, or a CSS value).
-    *   `fillChildren` (Boolean, optional): If `true`, sets the `fill-children` attribute.
+*   `options` (Object, optional): Configuration options. The factory function will add appropriate CSS classes to the `<adw-box>` element based on these options:
+    *   `orientation` (String, optional): Adds `"adw-box-horizontal"` (default) or `"adw-box-vertical"`.
+    *   `align` (String, optional): Adds class like `"align-center"` (e.g., `"start"`, `"center"`, `"end"`).
+    *   `justify` (String, optional): Adds class like `"justify-between"` (e.g., `"start"`, `"center"`, `"between"`).
+    *   `spacing` (String, optional): Adds class like `"adw-box-spacing-m"` (e.g., `"s"`, `"m"`, or a CSS value - though presets are preferred for classes).
+    *   `fillChildren` (Boolean, optional): If `true`, adds class `"adw-box-fill-children"`.
     *   `children` (Array<Node>, optional): An array of DOM nodes to append as children to the created `<adw-box>` element. These will be handled by the default slot.
 
 **Returns:**
 
-*   `(AdwBoxElement)`: The created `<adw-box>` Web Component instance.
+*   `(AdwBoxElement)`: The created `<adw-box>` Web Component instance, with CSS classes applied.
 
 **Example:**
 
@@ -37,23 +37,22 @@ Adw.Box.factory(options = {}) -> AdwBoxElement // Assuming AdwBoxElement is the 
 
   // Horizontal box with spacing and centered alignment
   const hbox = createAdwBox({
-    orientation: "horizontal",
-    spacing: "m",
-    align: "center"
+    orientation: "horizontal", // results in class "adw-box-horizontal"
+    spacing: "m",          // results in class "adw-box-spacing-m"
+    align: "center"          // results in class "align-center"
   });
   // Append children (which are now also Web Components or standard elements)
   hbox.appendChild(createAdwButton("Button 1")); // Assuming createAdwButton exists
-  const label = document.createElement('adw-label'); // Example: createAdwLabel might not exist yet
+  const label = document.createElement('adw-label');
   label.textContent = "Some Text";
   hbox.appendChild(label);
-  // hbox.appendChild(createAdwEntry({ placeholder: "Input..." })); // If createAdwEntry exists
   container.appendChild(hbox);
 
   // Vertical box
   const vbox = createAdwBox({
-    orientation: "vertical",
-    spacing: "s",
-    fillChildren: true // Sets the fill-children attribute
+    orientation: "vertical", // results in class "adw-box-vertical"
+    spacing: "s",          // results in class "adw-box-spacing-s"
+    fillChildren: true     // results in class "adw-box-fill-children"
   });
   vbox.appendChild(createAdwButton("Top Button (fills)"));
   vbox.appendChild(createAdwButton("Bottom Button (fills)"));
@@ -66,17 +65,36 @@ Adw.Box.factory(options = {}) -> AdwBoxElement // Assuming AdwBoxElement is the 
 
 ## Web Component: `<adw-box>`
 
-A declarative way to use Adwaita box containers.
+A declarative way to use Adwaita box containers. Styling and behavior are controlled by applying CSS classes.
 
 **HTML Tag:** `<adw-box>`
 
-**Attributes:**
+**CSS Classes for Styling:**
 
-*   `orientation` (String, optional): `"horizontal"` (default) or `"vertical"`.
-*   `spacing` (String, optional): Spacing preset (e.g., `"xs"`, `"s"`, `"m"`, `"l"`, `"xl"`) or a CSS value.
-*   `align` (String, optional): `align-items` value (e.g., `"start"`, `"center"`, `"end"`, `"stretch"`).
-*   `justify` (String, optional): `justify-content` value (e.g., `"start"`, `"center"`, `"end"`, `"between"`).
-*   `fill-children` (Boolean, optional): If present, children will attempt to grow to fill space.
+*   **Base Class:** `adw-box` (should always be present on the element you want to act as a box, often the `<adw-box>` custom element itself, or a `div` inside it if the custom element is just a slot provider).
+*   **Orientation:**
+    *   `adw-box-horizontal` (default if neither is specified on a plain `div.adw-box`)
+    *   `adw-box-vertical`
+*   **Spacing (Gap):**
+    *   `adw-box-spacing-xs`
+    *   `adw-box-spacing-s`
+    *   `adw-box-spacing-m`
+    *   `adw-box-spacing-l`
+    *   `adw-box-spacing-xl`
+*   **Alignment (`align-items`):**
+    *   `align-start`
+    *   `align-center`
+    *   `align-end`
+    *   `align-stretch`
+*   **Justification (`justify-content`):**
+    *   `justify-start`
+    *   `justify-center`
+    *   `justify-end`
+    *   `justify-between`
+    *   `justify-around`
+    *   `justify-evenly`
+*   **Fill Children:**
+    *   `adw-box-fill-children` (children will attempt to grow to fill space)
 
 **Slots:**
 
@@ -86,7 +104,7 @@ A declarative way to use Adwaita box containers.
 
 ```html
 <!-- Horizontal box with medium spacing, items centered vertically -->
-<adw-box orientation="horizontal" spacing="m" align="center" style="border: 1px solid var(--borders-color); padding: 5px;">
+<adw-box class="adw-box adw-box-horizontal adw-box-spacing-m align-center" style="border: 1px solid var(--borders-color); padding: 5px;">
   <adw-button suggested>Save</adw-button>
   <adw-label>Status: OK</adw-label>
   <adw-spinner active size="small"></adw-spinner>
@@ -95,7 +113,7 @@ A declarative way to use Adwaita box containers.
 <br/>
 
 <!-- Vertical box, children stretched horizontally -->
-<adw-box orientation="vertical" spacing="s" align="stretch" style="border: 1px solid var(--borders-color); padding: 5px; width: 200px;">
+<adw-box class="adw-box adw-box-vertical adw-box-spacing-s align-stretch" style="border: 1px solid var(--borders-color); padding: 5px; width: 200px;">
   <adw-button>First Item</adw-button>
   <adw-entry placeholder="Type here..."></adw-entry>
   <adw-button flat>Last Item</adw-button>
@@ -104,7 +122,7 @@ A declarative way to use Adwaita box containers.
 <br/>
 
 <!-- Horizontal box where children fill available width -->
-<adw-box orientation="horizontal" spacing="xs" fill-children
+<adw-box class="adw-box adw-box-horizontal adw-box-spacing-xs adw-box-fill-children"
            style="border: 1px solid var(--borders-color); padding: 5px; width: 100%;">
   <adw-button style="min-width: 100px;">A</adw-button> <!-- flex-grow will be applied -->
   <adw-label style="text-align: center;">B (Centered)</adw-label>
@@ -115,7 +133,7 @@ A declarative way to use Adwaita box containers.
 ## Styling
 
 *   Primary SCSS: `scss/_box.scss`
-*   The component primarily uses CSS Flexbox properties (`display: flex`, `flex-direction`, `gap`, `align-items`, `justify-content`).
+*   The component relies on CSS Flexbox properties (`display: flex`, `flex-direction`, `gap`, `align-items`, `justify-content`) applied through the utility classes.
 *   Spacing classes like `adw-box-spacing-m` apply CSS variables like `var(--spacing-m)` to the `gap` property.
 *   `adw-box-fill-children` class makes direct children of the box have `flex-grow: 1`.
 

--- a/docs/widgets/row.md
+++ b/docs/widgets/row.md
@@ -95,7 +95,7 @@ A declarative way to use Adwaita row elements.
   </adw-row>
 
   <adw-row activated interactive id="wc-row-2">
-    <adw-box align="center" spacing="m">
+    <adw-box class="adw-box align-center adw-box-spacing-m">
       <!-- Placeholder for an icon -->
       <span style="font-size: 24px;">⭐</span>
       <adw-label>Selected Item</adw-label>

--- a/docs/widgets/toolbarview.md
+++ b/docs/widgets/toolbarview.md
@@ -157,7 +157,7 @@ A declarative way to define Adwaita toolbar views.
     officia deserunt mollit anim id est laborum.</p>
   </div>
 
-  <adw-box slot="bottom-bar" spacing="m" align="center"
+  <adw-box class="adw-box adw-box-spacing-m align-center" slot="bottom-bar"
            style="padding: var(--spacing-s); border-top: 1px solid var(--borders-color);">
     <adw-label>Status: Ready</adw-label>
     <div style="flex-grow: 1;"></div> <!-- Spacer -->

--- a/docs/widgets/window.md
+++ b/docs/widgets/window.md
@@ -79,7 +79,7 @@ A declarative way to define an Adwaita application window structure.
     <p>This is the content area of the
        <code>&lt;adw-application-window&gt;</code>.</p>
     <p>It can contain any HTML or other Adwaita components.</p>
-    <adw-box spacing="m">
+    <adw-box class="adw-box adw-box-spacing-m">
         <adw-button suggested>Confirm</adw-button>
         <adw-button>Cancel</adw-button>
     </adw-box>

--- a/docs/widgets/wrapbox.md
+++ b/docs/widgets/wrapbox.md
@@ -4,40 +4,27 @@ An AdwWrapBox is a layout container that arranges its children in a line (horizo
 
 ## JavaScript Factory: `Adw.createWrapBox()`
 
-Creates an Adwaita-styled wrap box container.
+Creates an Adwaita-styled wrap box container by creating an `<adw-wrap-box>` element and applying CSS classes.
 
 **Signature:**
 
 ```javascript
-Adw.createWrapBox(options = {}) -> HTMLDivElement
+Adw.createWrapBox(options = {}) -> AdwWrapBoxElement
 ```
 
 **Parameters:**
 
-*   `options` (Object, optional): Configuration options:
-    *   `children` (Array<HTMLElement>, optional): Child elements to add to the
-        wrap box.
-    *   `orientation` (String, optional): Main layout direction before wrapping.
-        Can be `"horizontal"` (default) or `"vertical"`.
-    *   `spacing` (String | Number, optional): Gap between items along the main
-        axis and cross axis if `lineSpacing` is not set. Can be a predefined
-        Adwaita spacing unit (e.g., "s", "m") or a CSS value (e.g., "10px",
-        10 for 10px). Defaults to a medium spacing.
-    *   `lineSpacing` (String | Number, optional): Gap between lines of wrapped
-        items (cross-axis spacing). If not set, `spacing` is used for both item
-        and line gaps.
-    *   `align` (String, optional): `align-items` value (cross-axis alignment of
-        items within a line). E.g., `"start"`, `"center"`, `"end"`, `"stretch"`.
-        Defaults to `"start"`.
-    *   `justify` (String, optional): `justify-content` value (main-axis
-        alignment of items within a line). E.g., `"start"`, `"center"`, `"end"`,
-        `"between"`. Defaults to `"start"`.
-    *   *Note: `align-content` (for alignment of wrapped lines) might also be
-        configurable or default to stretch/start.*
+*   `options` (Object, optional): Configuration options. The factory function will add appropriate CSS classes to the `<adw-wrap-box>` element:
+    *   `children` (Array<HTMLElement>, optional): Child elements to add to the wrap box (will be slotted).
+    *   `orientation` (String, optional): Adds `"wrap-box-horizontal"` (default) or `"wrap-box-vertical"`.
+    *   `spacing` (String, optional): Adds class like `"wrap-box-spacing-m"` (e.g., "xs", "s", "m", "l", "xl"). This controls the `gap` property.
+    *   `lineSpacing` (String, optional): *Note: This option is not directly mapped to a separate class in the CSS-first refactor if it differs from `spacing`. `spacing` controls the overall `gap`. For distinct row/column gaps, custom styling might be needed on the element.*
+    *   `align` (String, optional): Adds class like `"wrap-align-center"` (e.g., `"start"`, `"center"`, `"end"`, `"stretch"`, `"baseline"`). Controls `align-items`.
+    *   `justify` (String, optional): Adds class like `"wrap-justify-between"` (e.g., `"start"`, `"center"`, `"end"`, `"between"`, `"around"`, `"evenly"`). Controls `justify-content`.
 
 **Returns:**
 
-*   `(HTMLDivElement)`: The created `<div>` element representing the wrap box.
+*   `(AdwWrapBoxElement)`: The created `<adw-wrap-box>` Web Component instance, with CSS classes applied.
 
 **Example:**
 
@@ -60,8 +47,8 @@ Adw.createWrapBox(options = {}) -> HTMLDivElement
 
   // Horizontal WrapBox
   const hWrapBox = Adw.createWrapBox({
-    children: items.map(item => item.cloneNode(true)), // Pass clones if items array is reused
-    spacing: "s", // "var(--spacing-s)" for gap
+    children: items.map(item => item.cloneNode(true)),
+    spacing: "s",
     align: "center"
   });
   hContainer.appendChild(hWrapBox);
@@ -70,31 +57,53 @@ Adw.createWrapBox(options = {}) -> HTMLDivElement
   const vWrapBox = Adw.createWrapBox({
     children: items.slice(0,5).map(item => {
         const btn = item.cloneNode(true);
-        btn.style.width = "100%"; // Make buttons take full width of column
+        btn.style.width = "100%";
         return btn;
     }),
     orientation: "vertical",
     spacing: "xs",
-    lineSpacing: "m", // Different spacing between columns
-    align: "stretch" // Stretch items in the cross axis (horizontally here)
+    // lineSpacing: "m", // For distinct line spacing, apply custom style for row-gap or column-gap
+    align: "stretch"
   });
+  // Example for custom line spacing if needed:
+  // vWrapBox.style.rowGap = 'var(--spacing-m)'; // If orientation is horizontal
+  // vWrapBox.style.columnGap = 'var(--spacing-m)'; // If orientation is vertical
   vContainer.appendChild(vWrapBox);
 </script>
 ```
 
 ## Web Component: `<adw-wrap-box>`
 
-A declarative way to use Adwaita wrap box containers.
+A declarative way to use Adwaita wrap box containers. Styling and behavior are controlled by applying CSS classes directly to the `<adw-wrap-box>` element.
 
 **HTML Tag:** `<adw-wrap-box>`
 
-**Attributes:**
+**CSS Classes for Styling:**
 
-*   `orientation` (String, optional): `"horizontal"` (default) or `"vertical"`.
-*   `spacing` (String, optional): Spacing preset (e.g., `"xs"`, `"s"`, `"m"`) or a CSS value for gap between items.
-*   `line-spacing` (String, optional): Spacing preset or CSS value for gap between wrapped lines.
-*   `align` (String, optional): `align-items` value (e.g., `"start"`, `"center"`, `"end"`, `"stretch"`).
-*   `justify` (String, optional): `justify-content` value (e.g., `"start"`, `"center"`, `"end"`, `"between"`).
+*   **Base Class:** `adw-wrap-box` (This class is automatically handled by the component's internal structure or should be applied to the host element if it's expected to behave as the wrap box directly).
+*   **Orientation:**
+    *   `wrap-box-horizontal` (default, `flex-direction: row;`)
+    *   `wrap-box-vertical` (`flex-direction: column;`)
+*   **Spacing (Gap):**
+    *   `wrap-box-spacing-xs`
+    *   `wrap-box-spacing-s`
+    *   `wrap-box-spacing-m` (default gap if no spacing class is specified by the SCSS for `.adw-wrap-box` base)
+    *   `wrap-box-spacing-l`
+    *   `wrap-box-spacing-xl`
+    *   *Note:* These classes set a uniform `gap`. If you need different `row-gap` and `column-gap` (equivalent to a distinct `line-spacing`), you may need to apply custom inline styles or additional CSS.
+*   **Alignment (`align-items` on the cross-axis):**
+    *   `wrap-align-start` (default)
+    *   `wrap-align-center`
+    *   `wrap-align-end`
+    *   `wrap-align-stretch`
+    *   `wrap-align-baseline`
+*   **Justification (`justify-content` on the main-axis):**
+    *   `wrap-justify-start` (default)
+    *   `wrap-justify-center`
+    *   `wrap-justify-end`
+    *   `wrap-justify-between`
+    *   `wrap-justify-around`
+    *   `wrap-justify-evenly`
 
 **Slots:**
 
@@ -104,7 +113,7 @@ A declarative way to use Adwaita wrap box containers.
 
 ```html
 <p>Horizontal Wrapping (default):</p>
-<adw-wrap-box spacing="m" align="start" style="border: 1px solid var(--borders-color); padding: var(--spacing-s); max-width: 400px;">
+<adw-wrap-box class="adw-wrap-box wrap-box-spacing-m wrap-align-start" style="border: 1px solid var(--borders-color); padding: var(--spacing-s); max-width: 400px;">
   <adw-button style="width: 120px;">Button 1</adw-button>
   <adw-button style="width: 150px;">Button Two</adw-button>
   <adw-button style="width: 100px;">Item C</adw-button>
@@ -113,8 +122,8 @@ A declarative way to use Adwaita wrap box containers.
 </adw-wrap-box>
 
 <p style="margin-top: 1em;">Vertical Wrapping (items form new columns):</p>
-<adw-wrap-box orientation="vertical" spacing="s" line-spacing="l" align="stretch"
-              style="border: 1px solid var(--borders-color); padding: var(--spacing-s); height: 120px; width: 300px;">
+<adw-wrap-box class="adw-wrap-box wrap-box-vertical wrap-box-spacing-s wrap-align-stretch"
+              style="border: 1px solid var(--borders-color); padding: var(--spacing-s); height: 120px; width: 300px; column-gap: var(--spacing-l); /* Custom line spacing */">
   <adw-button>Alpha</adw-button>
   <adw-button>Beta</adw-button>
   <adw-button>Gamma</adw-button>
@@ -127,9 +136,7 @@ A declarative way to use Adwaita wrap box containers.
 
 *   Primary SCSS: `scss/_wrap_box.scss`.
 *   The component uses CSS Flexbox with `flex-wrap: wrap;`.
-*   `gap`, `row-gap`, `column-gap` are used for spacing based on `spacing` and `line-spacing` attributes.
-*   `align-items` and `justify-content` are set based on `align` and `justify` attributes.
-*   `flex-direction` is set based on the `orientation` attribute.
+*   Styling (orientation, gap, alignment, justification) is primarily controlled by the CSS classes applied to the `<adw-wrap-box>` host element.
 
 ---
 Next: [Clamp](./clamp.md)

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
             <!-- Accent Color Picker -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Theme Controls</adw-label>
-                <adw-box orientation="horizontal" spacing="s" id="accent-color-picker-box" style="align-items: center; margin-bottom: var(--spacing-m); flex-wrap: wrap;">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s" id="accent-color-picker-box" style="align-items: center; margin-bottom: var(--spacing-m); flex-wrap: wrap;">
                     <adw-label>Accent Color:</adw-label>
                     {/* Declarative buttons will be placed here directly.
                         The Adw.getAccentColors() usually returns:
@@ -186,7 +186,7 @@ if (accentPickerBox) {
             <!-- Icons Section -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Icons (&lt;adw-icon&gt;)</adw-label>
-                <adw-box orientation="horizontal" spacing="m" style="align-items: center; font-size: 24px;">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-m" style="align-items: center; font-size: 24px;">
                     <adw-icon icon-name="actions/document-new-symbolic" aria-label="New Document"></adw-icon>
                     <adw-icon icon-name="actions/document-save-symbolic" style="color: var(--accent-color);"></adw-icon>
                     <adw-icon icon-name="status/dialog-error-symbolic" style="color: var(--error-color); font-size: 32px;"></adw-icon>
@@ -204,7 +204,7 @@ if (accentPickerBox) {
             <!-- Controls Section (Checkbox, Radio, Switch, SpinButton, SplitButton, ToggleButton, ToggleGroup) -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Controls</adw-label>
-                <adw-box orientation="vertical" spacing="m">
+                <adw-box class="adw-box adw-box-vertical adw-box-spacing-m">
                     <adw-row>
                         <adw-checkbox label="Enable Feature" id="chk-1" checked></adw-checkbox>
                         <adw-checkbox label="Disabled Checkbox" disabled></adw-checkbox>
@@ -263,7 +263,7 @@ if (accentPickerBox) {
             <!-- Links Section -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Links</adw-label>
-                <adw-box orientation="vertical" spacing="s">
+                <adw-box class="adw-box adw-box-vertical adw-box-spacing-s">
                     <adw-label is-body>Standard HTML links should inherit Adwaita styling:</adw-label>
                     <a href="javascript:void(0);" onclick="mainToastOverlayRef && mainToastOverlayRef.addToast({ title: 'Standard link clicked!', timeout: 1.5 })">This is a standard link</a>
                     <adw-label is-body style="margin-top: var(--spacing-s);">A link within a sentence <a href="javascript:void(0);" onclick="mainToastOverlayRef && mainToastOverlayRef.addToast({ title: 'Inline link clicked!', timeout: 1.5 })">like this</a> should also be styled.</adw-label>
@@ -322,7 +322,7 @@ if (accentPickerBox) {
             <!-- Dialogs Section -->
             <section class="widget-showcase">
                 <adw-label title-level="2">Dialogs</adw-label>
-                <adw-box orientation="horizontal" spacing="s">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s">
                     <adw-button id="trigger-alert-dialog">Show Alert Dialog</adw-button>
                     <adw-button id="trigger-about-dialog">Show About Dialog</adw-button>
                     <adw-button id="trigger-preferences-dialog">Show Preferences Dialog</adw-button>
@@ -388,7 +388,7 @@ if (accentPickerBox) {
                 </adw-status-page>
 
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">Banner & Toast</adw-label>
-                <adw-box orientation="horizontal" spacing="s" id="banner-toast-trigger-container">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s" id="banner-toast-trigger-container">
                     <adw-button id="trigger-info-banner">Show Info Banner</adw-button>
                     <adw-button id="trigger-error-banner">Show Error Banner</adw-button>
                     <adw-button id="trigger-toast">Show Toast</adw-button>
@@ -407,7 +407,7 @@ if (accentPickerBox) {
             <section class="widget-showcase">
                 <adw-label title-level="2">Layouts</adw-label>
                 <adw-label title-level="3">Box</adw-label>
-                <adw-box orientation="horizontal" spacing="m" style="padding:var(--spacing-s); border:1px dashed var(--border-color);">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-m" style="padding:var(--spacing-s); border:1px dashed var(--border-color);">
                     <adw-button>Box Child 1</adw-button>
                     <adw-label>Box Child 2</adw-label>
                     <adw-entry placeholder="Box Child 3"></adw-entry>
@@ -421,17 +421,17 @@ if (accentPickerBox) {
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">Flap</adw-label>
                  <adw-button id="toggle-main-flap">Toggle Flap</adw-button>
                 <adw-flap id="main-flap-example" style="border: 1px solid var(--border-color); margin-top: var(--spacing-s); min-height: 150px;">
-                    <adw-box slot="flap-content" style="padding: var(--spacing-m); background: var(--sidebar-bg-color);" min-width="200px">
+                    <adw-box class="adw-box" slot="flap-content" style="padding: var(--spacing-m); background: var(--sidebar-bg-color);" min-width="200px">
                         <adw-label title-level="3">Flap Content</adw-label>
                         <adw-action-row title="Settings"></adw-action-row>
                     </adw-box>
-                    <adw-box slot="main-content" style="padding: var(--spacing-m);">
+                    <adw-box class="adw-box" slot="main-content" style="padding: var(--spacing-m);">
                         <adw-label title-level="3">Main Content (Flap Demo)</adw-label>
                     </adw-box>
                 </adw-flap>
 
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">WrapBox</adw-label>
-                <adw-wrap-box spacing="s" line-spacing="m" align="center" style="padding:var(--spacing-s); border:1px dashed var(--border-color); min-height: 100px;">
+                <adw-wrap-box class="adw-wrap-box wrap-box-spacing-s wrap-align-center" style="padding:var(--spacing-s); border:1px dashed var(--border-color); min-height: 100px; gap: var(--spacing-m); /* Explicitly setting line-spacing via gap for demo */">
                     <adw-button>Button 1</adw-button>
                     <adw-button suggested>Button 2 (Suggested)</adw-button>
                     <adw-button destructive>Button 3 (Destructive)</adw-button>
@@ -444,16 +444,16 @@ if (accentPickerBox) {
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">BreakpointBin</adw-label>
                 <adw-label is-body style="margin-bottom: var(--spacing-xs);">Resize the browser window to see different children shown by BreakpointBin. Children are defined with `data-condition` (min-width).</adw-label>
                 <adw-breakpoint-bin default-child-name="small" style="padding:var(--spacing-s); border:1px dashed var(--border-color); min-height: 100px; resize: horizontal; overflow: auto; max-width: 100%;">
-                    <adw-box data-condition="0" data-name="small" style="background-color: var(--theme-color-red-2); padding: var(--spacing-m);">
+                    <adw-box class="adw-box" data-condition="0" data-name="small" style="background-color: var(--theme-color-red-2); padding: var(--spacing-m);">
                         <adw-label title-level="4">Small View (0px+)</adw-label>
                         <adw-label is-body>This is shown when the BreakpointBin is narrow.</adw-label>
                     </adw-box>
-                    <adw-box data-condition="400" data-name="medium" style="background-color: var(--theme-color-green-2); padding: var(--spacing-m);">
+                    <adw-box class="adw-box" data-condition="400" data-name="medium" style="background-color: var(--theme-color-green-2); padding: var(--spacing-m);">
                         <adw-label title-level="4">Medium View (400px+)</adw-label>
                         <adw-label is-body>This appears when the BreakpointBin is a bit wider.</adw-label>
                         <adw-button>A Button</adw-button>
                     </adw-box>
-                    <adw-box data-condition="700" data-name="large" style="background-color: var(--theme-color-blue-2); padding: var(--spacing-m);">
+                    <adw-box class="adw-box" data-condition="700" data-name="large" style="background-color: var(--theme-color-blue-2); padding: var(--spacing-m);">
                         <adw-label title-level="4">Large View (700px+)</adw-label>
                         <adw-label is-body>This is for wider BreakpointBin containers.</adw-label>
                         <adw-entry placeholder="Enter something..."></adw-entry>
@@ -511,7 +511,7 @@ if (accentPickerBox) {
                         <adw-window-title slot="title" title="ToolbarView Top"></adw-window-title>
                         <adw-button slot="start" icon-name="actions/go-up-symbolic" id="tbv-hide-top" title="Hide Top Bar"></adw-button>
                     </adw-header-bar>
-                    <adw-box orientation="vertical" spacing="m" style="padding: var(--spacing-l); align-items: center;">
+                    <adw-box class="adw-box adw-box-vertical adw-box-spacing-m" style="padding: var(--spacing-l); align-items: center;">
                         <adw-label title-level="4">Main Content Area</adw-label>
                         <adw-label is-body>This is the main content of the ToolbarView.</adw-label>
                         <adw-spinner active></adw-spinner>
@@ -521,14 +521,14 @@ if (accentPickerBox) {
                         <adw-button slot="end" icon-name="actions/go-down-symbolic" id="tbv-hide-bottom" title="Hide Bottom Bar"></adw-button>
                     </adw-header-bar>
                 </adw-toolbar-view>
-                <adw-box orientation="horizontal" spacing="s" style="margin-top: var(--spacing-s);">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s" style="margin-top: var(--spacing-s);">
                     <adw-button id="tbv-show-top">Show Top Bar</adw-button>
                     <adw-button id="tbv-show-bottom">Show Bottom Bar</adw-button>
                 </adw-box>
 
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">Carousel</adw-label>
                 <adw-carousel id="my-carousel" show-nav-buttons autoplay loop style="min-height: 200px; width: 100%; max-width: 500px; margin-bottom: var(--spacing-s); border: 1px solid var(--border-color);">
-                    <adw-box style="background-color: var(--theme-color-blue-1); width: 100%; height: 100%; display:flex; align-items:center; justify-content:center;">
+                    <adw-box class="adw-box" style="background-color: var(--theme-color-blue-1); width: 100%; height: 100%; display:flex; align-items:center; justify-content:center;">
                         <adw-label title-level="1">Slide 1</adw-label>
                     </adw-box>
                     <adw-status-page title="Slide 2" icon-name="emoji/face-smile-symbolic" style="width: 100%; height: 100%;">
@@ -538,7 +538,7 @@ if (accentPickerBox) {
                         <adw-label title-level="1" style="color: var(--theme-color-green-5);">Slide 3 (Plain Div)</adw-label>
                     </div>
                 </adw-carousel>
-                <adw-box orientation="horizontal" spacing="s">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s">
                      <adw-button id="carousel-prev">Prev</adw-button>
                      <adw-button id="carousel-next">Next</adw-button>
                      <adw-spin-button id="carousel-goto-slide" min="0" max="2" value="0"></adw-spin-button>
@@ -553,7 +553,7 @@ if (accentPickerBox) {
                         <adw-action-row title="Item 2" activatable data-item-id="item2"></adw-action-row>
                         <adw-action-row title="Item 3 (No Content)" activatable data-item-id="item3"></adw-action-row>
                     </adw-list-box>
-                    <adw-box slot="content" id="nav-split-content-area" orientation="vertical" spacing="m" style="padding: var(--spacing-l); align-items:center; justify-content:center;">
+                    <adw-box class="adw-box adw-box-vertical adw-box-spacing-m" slot="content" id="nav-split-content-area" style="padding: var(--spacing-l); align-items:center; justify-content:center;">
                         <adw-status-page title="Select an Item" icon-name="actions/edit-select-all-symbolic">
                             <adw-label slot="description">Content will appear here.</adw-label>
                         </adw-status-page>
@@ -568,7 +568,7 @@ if (accentPickerBox) {
                         <adw-action-row title="Option A" activatable data-option-id="optionA"></adw-action-row>
                         <adw-action-row title="Option B" activatable data-option-id="optionB"></adw-action-row>
                     </adw-list-box>
-                    <adw-box slot="content" id="overlay-split-content-area" orientation="vertical" spacing="m" style="padding: var(--spacing-l); align-items:center; justify-content:center;">
+                    <adw-box class="adw-box adw-box-vertical adw-box-spacing-m" slot="content" id="overlay-split-content-area" style="padding: var(--spacing-l); align-items:center; justify-content:center;">
                         <adw-status-page title="Main Content" icon-name="emoji/face-plain-symbolic">
                             <adw-label slot="description">Sidebar is on the end for this demo.</adw-label>
                         </adw-status-page>
@@ -581,7 +581,7 @@ if (accentPickerBox) {
                 <adw-navigation-view id="my-navigation-view" style="border: 1px solid var(--border-color); min-height: 350px; margin-bottom:var(--spacing-s);">
                     <!-- Initial page defined in JS -->
                 </adw-navigation-view>
-                <adw-box orientation="horizontal" spacing="s">
+                <adw-box class="adw-box adw-box-horizontal adw-box-spacing-s">
                     <adw-button id="nav-view-push-page2">Push Page 2</adw-button>
                     <adw-button id="nav-view-push-page3">Push Page 3 (Custom Header)</adw-button>
                     <adw-button id="nav-view-pop" disabled>Pop Page (JS enables)</adw-button>
@@ -591,13 +591,13 @@ if (accentPickerBox) {
                 <adw-label title-level="3" style="margin-top:var(--spacing-m);">TabView</adw-label>
                  <adw-tab-view id="main-tab-view" style="border: 1px solid var(--border-color); min-height: 200px;">
                     <adw-tab-page name="tab1" title="First Tab" icon-name="categories/applications-graphics-symbolic">
-                        <adw-box style="padding:var(--spacing-l);">Content of Tab 1</adw-box>
+                        <adw-box class="adw-box" style="padding:var(--spacing-l);">Content of Tab 1</adw-box>
                     </adw-tab-page>
                     <adw-tab-page name="tab2" title="Second Tab" icon-name="categories/applications-multimedia-symbolic" active>
-                        <adw-box style="padding:var(--spacing-l);">Content of Tab 2. More text to see wrapping.</adw-box>
+                        <adw-box class="adw-box" style="padding:var(--spacing-l);">Content of Tab 2. More text to see wrapping.</adw-box>
                     </adw-tab-page>
                     <adw-tab-page name="tab3" title="Third Tab (Closeable)" icon-name="categories/applications-utilities-symbolic" closeable>
-                        <adw-box style="padding:var(--spacing-l);">This tab can be closed.</adw-box>
+                        <adw-box class="adw-box" style="padding:var(--spacing-l);">This tab can be closed.</adw-box>
                     </adw-tab-page>
                 </adw-tab-view>
                 <details>

--- a/index1.html
+++ b/index1.html
@@ -160,10 +160,10 @@
                 <adw-label title-level="1">Layouts</adw-label>
                 <div class="widget-showcase">
                     <adw-label title-level="2">AdwBox</adw-label>
-                    <adw-box orientation="horizontal" spacing="m" style="border:1px solid var(--border-color); padding: var(--spacing-s);">
+                    <adw-box class="adw-box adw-box-horizontal adw-box-spacing-m" style="border:1px solid var(--border-color); padding: var(--spacing-s);">
                         <adw-button>One</adw-button><adw-label>Two</adw-label><adw-entry placeholder="Three"></adw-entry>
                     </adw-box>
-                    <adw-box orientation="vertical" spacing="s" style="border:1px solid var(--border-color); padding: var(--spacing-s); margin-top:var(--spacing-s);">
+                    <adw-box class="adw-box adw-box-vertical adw-box-spacing-s" style="border:1px solid var(--border-color); padding: var(--spacing-s); margin-top:var(--spacing-s);">
                         <adw-button>Alpha</adw-button><adw-label>Beta</adw-label>
                     </adw-box>
                 </div>
@@ -181,7 +181,7 @@
                 </div>
                 <div class="widget-showcase">
                     <adw-label title-level="2">AdwWrapBox</adw-label>
-                    <adw-wrap-box spacing="s" line-spacing="m" style="border:1px solid var(--border-color); padding:var(--spacing-s);">
+                    <adw-wrap-box class="adw-wrap-box wrap-box-spacing-s" style="border:1px solid var(--border-color); padding:var(--spacing-s); row-gap: var(--spacing-m); /* Explicitly setting line-spacing via row-gap */">
                         <adw-button>Item 1</adw-button><adw-button>Item 2</adw-button><adw-button>Item 3</adw-button>
                         <adw-button>Another Item 4</adw-button><adw-button>Item 5 is a bit longer</adw-button>
                     </adw-wrap-box>
@@ -306,8 +306,8 @@
                     <adw-label title-level="2">AdwFlap</adw-label>
                     <adw-button id="toggle-flap-btn">Toggle Flap</adw-button>
                     <adw-flap id="demo-flap" style="border: 1px solid var(--border-color); min-height: 150px; margin-top: var(--spacing-s);">
-                        <adw-box slot="flap-content" style="padding:var(--spacing-m); background: var(--sidebar-bg-color);" min-width="180px">Flap Content</adw-box>
-                        <adw-box slot="main-content" style="padding:var(--spacing-m);">Main Content for Flap</adw-box>
+                        <adw-box class="adw-box" slot="flap-content" style="padding:var(--spacing-m); background: var(--sidebar-bg-color);" min-width="180px">Flap Content</adw-box>
+                        <adw-box class="adw-box" slot="main-content" style="padding:var(--spacing-m);">Main Content for Flap</adw-box>
                     </adw-flap>
                 </div>
 
@@ -315,7 +315,7 @@
                     <adw-label title-level="2">AdwToolbarView</adw-label>
                     <adw-toolbar-view style="border: 1px solid var(--border-color); min-height: 200px;">
                         <adw-header-bar slot="top-bar"><adw-window-title slot="title" title="Top Bar"></adw-window-title></adw-header-bar>
-                        <adw-box style="padding:var(--spacing-m); align-items:center; justify-content:center; flex-grow:1;">Toolbar Content</adw-box>
+                        <adw-box class="adw-box" style="padding:var(--spacing-m); align-items:center; justify-content:center; flex-grow:1;">Toolbar Content</adw-box>
                         <adw-header-bar slot="bottom-bar"><adw-window-title slot="title" title="Bottom Bar"></adw-window-title></adw-header-bar>
                     </adw-toolbar-view>
                 </div>
@@ -335,7 +335,7 @@
                             <adw-action-row title="Mail"></adw-action-row>
                             <adw-action-row title="Calendar"></adw-action-row>
                          </adw-list-box>
-                         <adw-box slot="content" style="padding:var(--spacing-m);">Detail Content Area</adw-box>
+                         <adw-box class="adw-box" slot="content" style="padding:var(--spacing-m);">Detail Content Area</adw-box>
                     </adw-navigation-split-view>
                 </div>
 
@@ -345,7 +345,7 @@
                          <adw-list-box slot="sidebar" style="min-width:180px; background:var(--secondary-sidebar-bg-color);">
                             <adw-action-row title="Filter Options"></adw-action-row>
                          </adw-list-box>
-                         <adw-box slot="content" style="padding:var(--spacing-m);">Main Content for Overlay</adw-box>
+                         <adw-box class="adw-box" slot="content" style="padding:var(--spacing-m);">Main Content for Overlay</adw-box>
                     </adw-overlay-split-view>
                 </div>
 


### PR DESCRIPTION
- Refactored AdwBox, AdwBin, and AdwWrapBox to be primarily CSS-driven, with JavaScript components now acting as simple wrappers or slot providers.
- Updated factory functions for these components to apply CSS classes instead of attributes or inline styles for layout properties.
- Updated AdwClamp to use CSS classes for `scrollable` state, while retaining JS for dynamic `max-width`.
- Updated all usage examples in demo pages (index.html, index1.html), app-demo templates, and documentation to reflect the new class-based approach for these layout components.
- Ensured SCSS files for these components define the necessary classes for styling.
- This change aims to reduce JavaScript manipulation for styling in these layout components, making them lighter and more reliant on CSS.