### PR TITLE
Fix: Refine unhiding logic with requestAnimationFrame for FOUC

### DIFF
--- a/adwaita-web/js/components.js
+++ b/adwaita-web/js/components.js
@@ -306,14 +306,16 @@ window.addEventListener('DOMContentLoaded', () => {
         appWindow.style.border = '5px solid red';
         console.log(new Date().toISOString(), 'COMPONENTS.JS: Applied RED BORDER to appWindow for visual debug.');
 
-        setTimeout(() => {
-            console.log(new Date().toISOString(), 'COMPONENTS.JS: Timeout: Removing red border and adw-initializing class.');
-            appWindow.style.border = ''; // Remove border
-            appWindow.classList.remove('adw-initializing'); // This class might now be redundant if 'hidden' works well
-            // Optionally, explicitly set visibility if there are concerns about CSS specificity or timing.
-            // appWindow.style.visibility = 'visible';
-            console.log(new Date().toISOString(), '[Debug] Adwaita initialized, application window made visible (after visual cue).');
-        }, 1000); // Keep border for 1 second
+        // Give the browser a chance to process the removal of 'hidden' and component connections
+        requestAnimationFrame(() => {
+            console.log(new Date().toISOString(), 'COMPONENTS.JS: First requestAnimationFrame callback.');
+            requestAnimationFrame(() => {
+                console.log(new Date().toISOString(), 'COMPONENTS.JS: Second requestAnimationFrame callback. Removing border and adw-initializing class.');
+                appWindow.style.border = ''; // Remove border
+                appWindow.classList.remove('adw-initializing');
+                console.log(new Date().toISOString(), '[Debug] Adwaita initialized, application window made visible (after rAF and visual cue).');
+            });
+        });
 
     } else {
         console.warn(new Date().toISOString(), '[Debug] Adwaita initialized, but adw-application-window.adw-initializing not found to make visible.');


### PR DESCRIPTION
This commit attempts to further mitigate FOUC and perceived header refresh issues by using `requestAnimationFrame` when making the main application window visible.

Changes:
- In `adwaita-web/js/components.js`:
  - Modified the `DOMContentLoaded` listener to use a nested `requestAnimationFrame` call before removing the `.adw-initializing` class (which controls `visibility: hidden`).
  - This is intended to give the browser more opportunity to process DOM changes (like `hidden` attribute removal) and component initializations before the final reveal, potentially leading to a smoother visual transition.
  - The 1-second `setTimeout` for the visual red border cue has been removed in favor of this `requestAnimationFrame` timing; the border will now flash very briefly.

All extensive diagnostic logging added previously remains in place to help analyze the effects of this change.