### PR TITLE
Fix: Resolve all duplicate export errors in utils.js

### DIFF
--- a/adwaita-web/js/components/utils.js
+++ b/adwaita-web/js/components/utils.js
@@ -463,16 +463,3 @@ export function adwMakeFocusable(parentElement) {
                !hidden; // Check for hidden attribute on element or ancestors
     });
 }
-
-export {
-    ACCENT_COLOR_DEFINITIONS,
-    DEFAULT_ACCENT_COLOR_NAME,
-    getAccentColors,
-    setAccentColor,
-    loadSavedTheme,
-    toggleTheme,
-    applyFinalThemeAndAccent,
-    sanitizeHref,
-    getAdwCommonStyleSheet,
-    adwMakeFocusable
-};


### PR DESCRIPTION
- Removed the entire redundant final `export {...}` block from `adwaita-web/js/components/utils.js` as all its members were already exported at their respective definitions.
- Verified that `app-demo/templates/base.html` correctly has only a single import for `components.js`.