### PR TITLE
Fix: Resolve 'Adw is not defined' JS error in settings

### DIFF
--- a/app-demo/templates/settings.html
+++ b/app-demo/templates/settings.html
@@ -60,9 +60,7 @@ document.addEventListener('DOMContentLoaded', function() {
         themeSelect.addEventListener('change', function() {
             const newTheme = this.value;
             console.log('Theme changed to:', newTheme);
-            if (Adw && typeof Adw.setTheme === 'function') {
-                Adw.setTheme(newTheme); // This should handle localStorage and class updates
-            }
+            // Removed: Adw.setTheme(newTheme); - base.html handles class changes on reload
 
             if (csrfToken) {
                 fetch("{{ url_for('save_theme_preference') }}", {
@@ -76,11 +74,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(response => response.json())
                 .then(data => {
                     console.log('Theme save response:', data);
-                    if (data.message) Adw.createToast(data.message, { type: data.status });
+                    if (data.message) alert(data.message);
+                    if (data.status === 'success') {
+                        location.reload(); // Reload to apply theme changes via base.html script
+                    }
                 })
                 .catch(error => {
                     console.error('Error saving theme:', error);
-                    Adw.createToast('Error saving theme preference.', { type: 'error' });
+                    alert('Error saving theme preference.');
                 });
             }
         });
@@ -91,9 +92,7 @@ document.addEventListener('DOMContentLoaded', function() {
         accentSelect.addEventListener('change', function() {
             const newAccent = this.value;
             console.log('Accent color changed to:', newAccent);
-            if (Adw && typeof Adw.setAccentColor === 'function') {
-                Adw.setAccentColor(newAccent); // This should handle localStorage and class updates
-            }
+            // Removed: Adw.setAccentColor(newAccent); - base.html handles class changes on reload
 
             if (csrfToken) {
                 fetch("{{ url_for('save_accent_color_preference') }}", {
@@ -107,11 +106,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(response => response.json())
                 .then(data => {
                     console.log('Accent save response:', data);
-                     if (data.message) Adw.createToast(data.message, { type: data.status });
+                    if (data.message) alert(data.message);
+                    if (data.status === 'success') {
+                        location.reload(); // Reload to apply accent changes via base.html script
+                    }
                 })
                 .catch(error => {
                     console.error('Error saving accent color:', error);
-                    Adw.createToast('Error saving accent color preference.', { type: 'error' });
+                    alert('Error saving accent color preference.');
                 });
             }
         });


### PR DESCRIPTION
- Removed calls to undefined `Adw.setTheme()`, `Adw.setAccentColor()`, and `Adw.createToast()` from `app-demo/templates/settings.html`.
- Theme and accent color changes now rely on page reload (triggered by `location.reload()` after successful save) to apply visual updates via the existing script in `base.html`.
- Replaced toast notifications with standard `alert()` for user feedback on save success or failure.

This fixes the JavaScript console error and ensures theme/accent preferences remain functional.