### PR TITLE
Add Adwaita fonts, dashboard, related posts, and UI tweaks

### DIFF
--- a/app-demo/static/css/app-demo-custom.css
+++ b/app-demo/static/css/app-demo-custom.css
@@ -228,13 +228,31 @@
 }
 
 /* Ensure textarea styled like adw-entry if .adw-textarea is used with .adw-entry */
-textarea.adw-entry.adw-textarea {
-    /* Most styles should be inherited from .adw-entry.
-       Specific overrides for textarea if needed: */
-    line-height: $line-height-base; /* from _variables.scss SASS var */
-    min-height: 120px; /* Example min height */
-    resize: vertical;
+textarea.adw-entry.adw-textarea,
+textarea.adw-textarea { /* General styling for adw-textarea */
+    /* Most styles should be inherited from .adw-entry if both classes are used.
+       Specific overrides for textarea: */
+    line-height: 1.5; /* A common default, adjust if needed */
+    min-height: 120px; /* Example min height for multi-line text */
+    resize: vertical; /* Allow vertical resizing */
+    padding: var(--spacing-s) var(--spacing-m); /* Consistent padding with entries */
+    border-radius: var(--input-border-radius, var(--border-radius-default));
+    border: 1px solid var(--input-border-color, var(--border-color));
+    background-color: var(--input-bg-color, var(--window-bg-color));
+    color: var(--input-fg-color, var(--text-color));
+    font-family: var(--document-font-family); /* Ensure correct font */
+    font-size: var(--font-size-base);
 }
+
+textarea.adw-entry.adw-textarea:focus,
+textarea.adw-textarea:focus {
+    border-color: var(--input-focus-border-color, var(--accent-color));
+    /* Adwaita entries often get a 2px bottom border or an outline on focus.
+       For textarea, a consistent border color change is usually fine. */
+    outline: none; /* Remove default browser outline if custom focus is handled by border */
+     /* box-shadow: 0 0 0 2px var(--accent-bg-color); /* Example focus ring, if desired */
+}
+
 
 /* Styles for prose content within post-content or comments */
 .styled-text-content p,
@@ -411,6 +429,59 @@ hr.section-divider {
 .theme-dark .login-prompt-comment {
      background-color: var(--theme-color-secondary-container, var(--background-secondary-color-dark));
 }
+
+/* Adwaita Font Integration */
+@font-face {
+    font-family: 'AdwaitaSans';
+    src: url('../fonts/sans/AdwaitaSans-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'AdwaitaSans';
+    src: url('../fonts/sans/AdwaitaSans-Italic.ttf') format('truetype');
+    font-weight: normal;
+    font-style: italic;
+}
+
+/* Assuming AdwaitaSans doesn't have specific bold/italic-bold files,
+   the browser will typically faux-bold/italic if needed.
+   If specific bold files were available, they would be added here. */
+
+@font-face {
+    font-family: 'AdwaitaMono';
+    src: url('../fonts/mono/AdwaitaMono-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'AdwaitaMono';
+    src: url('../fonts/mono/AdwaitaMono-Italic.ttf') format('truetype');
+    font-weight: normal;
+    font-style: italic;
+}
+
+@font-face {
+    font-family: 'AdwaitaMono';
+    src: url('../fonts/mono/AdwaitaMono-Bold.ttf') format('truetype');
+    font-weight: bold;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'AdwaitaMono';
+    src: url('../fonts/mono/AdwaitaMono-BoldItalic.ttf') format('truetype');
+    font-weight: bold;
+    font-style: italic;
+}
+
+:root {
+    --document-font-family: 'AdwaitaSans', 'Cantarell', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --monospace-font-family: 'AdwaitaMono', 'Monaco', 'Menlo', 'Courier New', monospace;
+}
+
 
 /* Accent Color Overrides */
 /* :root is equivalent to html but with higher specificity for overrides if needed */

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -88,6 +88,7 @@
                     </span>
                 {% endif %}
             </a>
+            <a href="{{ url_for('dashboard') }}" class="adw-button flat" title="Dashboard">My Posts</a>
             <a href="{{ url_for('settings_page') }}" class="adw-button flat circular" title="Settings">
                 <span class="adw-icon icon-ui-settings-symbolic"></span>
             </a>

--- a/app-demo/templates/dashboard.html
+++ b/app-demo/templates/dashboard.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+
+{% block title %}My Posts - Dashboard{% endblock %}
+
+{% block content %}
+<div class="adw-preferences-page" role="main"> {# Using preferences-page for consistent page styling #}
+    <header class="adw-preferences-page__header">
+        <h1 class="adw-preferences-page__title">My Posts Dashboard</h1>
+    </header>
+
+    {% if user_posts %}
+    <div class="adw-list-box">
+        {% for post in user_posts %}
+        <div class="adw-action-row blog-post-dashboard-item">
+            <div class="adw-action-row-content" style="display: flex; flex-direction: column; gap: var(--spacing-xxs);">
+                <h3 class="adw-action-row-title" style="font-size: var(--font-size-large);">{{ post.title }}</h3>
+                <div class="adw-action-row-subtitle">
+                    Status:
+                    {% if post.is_published %}
+                        <span style="color: var(--success-color);">Published</span>
+                        {% if post.published_at %} (on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d') }}</time>){% endif %}
+                    {% else %}
+                        <span style="color: var(--warning-fg-color);">Draft</span>
+                    {% endif %}
+                    <br>
+                    Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                </div>
+            </div>
+            <div class="adw-action-row-suffix adw-box adw-box-spacing-s" style="align-items: center;">
+                <a href="{{ url_for('view_post', post_id=post.id) }}" class="adw-button flat">View</a>
+                <a href="{{ url_for('edit_post', post_id=post.id) }}" class="adw-button">Edit</a>
+                {# For delete, using a direct form submission per row to use the existing POST route #}
+                <form method="POST" action="{{ url_for('delete_post', post_id=post.id) }}" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this post? \\n\\n\'{{ post.title|escapejs }}\'');">
+                    {{ csrf_token() }} {# Important: Include CSRF token if your forms generally need it #}
+                    <button type="submit" class="adw-button destructive-action">Delete</button>
+                </form>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <div class="adw-status-page">
+        <span class="adw-icon icon-actions-document-new-symbolic adw-status-page-icon" style="font-size: 3rem;"></span>
+        <h2 class="adw-status-page-title">No Posts Yet</h2>
+        <p class="adw-status-page-description">You haven't created any posts. Why not start now?</p>
+        <div class="adw-status-page-actions">
+            <a href="{{ url_for('create_post') }}" class="adw-button suggested-action">Create Your First Post</a>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<style>
+/* Simple style for inline form */
+.inline-form {
+    display: inline; /* Allows button to sit alongside other buttons naturally */
+}
+.blog-post-dashboard-item .adw-action-row-subtitle {
+    font-size: var(--font-size-small);
+    line-height: 1.4;
+}
+</style>
+{% endblock %}

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -164,6 +164,25 @@
     </div>
     {% endif %}
 
+    {% if related_posts %}
+    <section class="related-posts-section" aria-labelledby="related-posts-heading" style="margin-top: var(--spacing-xl);">
+        <h2 id="related-posts-heading" class="adw-title-2">Related Posts</h2>
+        <div class="adw-list-box">
+            {% for related_post in related_posts %}
+            <a href="{{ url_for('view_post', post_id=related_post.id) }}" class="adw-action-row activatable">
+                <div class="adw-action-row-content">
+                    <span class="adw-action-row-title">{{ related_post.title }}</span>
+                    {% if related_post.author %}
+                    <span class="adw-action-row-subtitle">By {{ related_post.author.username }}</span>
+                    {% endif %}
+                </div>
+                <span class="adw-action-row__chevron"></span>
+            </a>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
     <div class="adw-box adw-box-spacing-s" style="justify-content: center; margin-top: var(--spacing-xl);">
          <a href="{{ url_for('index') }}" class="adw-button"><span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Posts</a>
     </div>


### PR DESCRIPTION
- Integrated AdwaitaSans and AdwaitaMono fonts into app-demo via @font-face rules and CSS custom property overrides.
- Added a new User Dashboard page (/dashboard) that lists the logged-in user's posts (drafts and published) with view/edit/delete actions.
- Implemented a 'Related Posts' section on the single post page, showing posts with shared tags.
- Improved styling for textareas to align better with Adwaita entry fields.
- Ensured changes are consistent with AGENTS.md instructions.