### PR TITLE
Fix: Resolve CSRF errors and improve Adwaita UI/UX for app-demo

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -53,28 +53,27 @@
     })();
   </script>
 
-    <header class="adw-header-bar">
-        <div class="adw-header-bar__start">
-            {# <a href="{{ url_for('index') }}" class="adw-button icon-only" title="Home">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8.5 1.5A1.5 1.5 0 0 0 7 0H1.5A1.5 1.5 0 0 0 0 1.5v13A1.5 1.5 0 0 0 1.5 16h13a1.5 1.5 0 0 0 1.5-1.5v-13A1.5 1.5 0 0 0 14.5 0H9a1.5 1.5 0 0 0-1.5 1.5H8.5zM8 15H1.5a.5.5 0 0 1-.5-.5V1.5a.5.5 0 0 1 .5-.5H7V.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .5.5v13a.5.5 0 0 1-.5.5H8zM5 5.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H5.5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H5.5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1H5.5a.5.5 0 0 1-.5-.5z"/></svg>
-            </a> #}
-            <h1 class="adw-header-bar__title">Blog Demo</h1>
-        </div>
-        <div class="adw-header-bar__center">
-             <a href="{{ url_for('index') }}" class="adw-button flat">Home</a>
-             <a href="{{ url_for('about_page') }}" class="adw-button flat">About</a>
-             <a href="{{ url_for('contact_page') }}" class="adw-button flat">Contact</a>
-        </div>
-        <div class="adw-header-bar__end">
-            <form action="{{ url_for('search_results') }}" method="GET" style="display: flex; align-items: center; gap: var(--spacing-xs);">
-                <input type="search" name="q" placeholder="Search..." value="{{ request.args.get('q', '') }}" class="adw-entry">
-                <button type="submit" class="adw-button flat circular" aria-label="Search">
-                    <span class="adw-icon icon-actions-system-search-symbolic"></span>
-                </button>
-            </form>
+<header class="adw-header-bar">
+    <div class="adw-header-bar__start">
+        <a href="{{ url_for('index') }}" class="adw-header-bar__title site-title-link">Blog Demo</a>
+    </div>
+    <div class="adw-header-bar__center">
+        {# Optionally, a view-specific title could be injected here using a block #}
+        {% block header_title %}{% endblock %}
+    </div>
+    <div class="adw-header-bar__end">
+        {% block header_actions_start %}{% endblock %} {# For buttons like "Edit Profile" #}
+        <form action="{{ url_for('search_results') }}" method="GET" class="header-search-form">
+            <input type="search" name="q" placeholder="Search..." value="{{ request.args.get('q', '') }}" class="adw-entry">
+            <button type="submit" class="adw-button flat circular" aria-label="Search">
+                <span class="adw-icon icon-actions-system-search-symbolic"></span>
+            </button>
+        </form>
+
         {% if current_user.is_authenticated %}
             <a href="{{ url_for('create_post') }}" class="adw-button suggested-action">New Post</a>
-            <a href="{{ url_for('profile', username=current_user.username) }}" class="adw-button flat circular" title="View Profile">
+
+            <a href="{{ url_for('profile', username=current_user.username) }}" class="adw-button flat circular profile-avatar-button" title="View Profile">
                 {% if current_user.profile_photo_url %}
                     <span class="adw-avatar size-small">
                         <img src="{{ url_for('static', filename=current_user.profile_photo_url) }}" alt="Avatar">
@@ -82,22 +81,46 @@
                 {% else %}
                     <span class="adw-avatar size-small">
                         <span class="adw-avatar-text">
-                            {% set name_parts = current_user.username.split() %}
-                            {{ name_parts[0][0]|upper if (name_parts|length >= 1 and name_parts[0]) else 'U' }}
+                            {{ current_user.username[0]|upper if current_user.username else 'U' }}
                         </span>
                     </span>
                 {% endif %}
             </a>
-            <a href="{{ url_for('dashboard') }}" class="adw-button flat" title="Dashboard">My Posts</a>
-            <a href="{{ url_for('settings_page') }}" class="adw-button flat circular" title="Settings">
-                <span class="adw-icon icon-ui-settings-symbolic"></span>
-            </a>
+            <a href="{{ url_for('dashboard') }}" class="adw-button flat" title="My Posts">Dashboard</a>
+            <a href="{{ url_for('settings_page') }}" class="adw-button flat" title="Settings">Settings</a>
             <a href="{{ url_for('logout') }}" class="adw-button flat">Logout</a>
         {% else %}
+            {# About and Contact are moved to footer for logged-out users too for consistency #}
             <a href="{{ url_for('login') }}" class="adw-button">Login</a>
         {% endif %}
-        </div>
-    </header>
+    </div>
+</header>
+
+<style>
+.adw-header-bar__start .site-title-link {
+    text-decoration: none;
+    color: inherit;
+    font-weight: bold; /* Make it look more like a title */
+}
+.adw-header-bar__start .site-title-link:hover,
+.adw-header-bar__start .site-title-link:focus {
+    text-decoration: none;
+}
+.adw-header-bar__end {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s, 8px); /* Default gap if var not defined */
+}
+.header-search-form {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs, 4px); /* Default gap */
+}
+.profile-avatar-button img, .profile-avatar-button .adw-avatar-text {
+    vertical-align: middle;
+}
+</style>
+
     <div class="page-content-wrapper"> {# Replaced adw-page for more control #}
         {% with messages = get_flashed_messages(with_categories=true) %}
           {% if messages %}
@@ -123,6 +146,66 @@
             {% block content %}{% endblock %}
         </main>
     </div>
+
+    <footer class="app-footer adw-toolbar">
+        <div class="adw-toolbar__start">
+            <span class="adw-label caption">&copy; {% now "utc", "%Y" %} Blog Demo.</span>
+        </div>
+        <div class="adw-toolbar__center">
+            {# Optional: social links or other footer content #}
+        </div>
+        <div class="adw-toolbar__end">
+            <a href="{{ url_for('about_page') }}" class="adw-button flat">About</a>
+            <a href="{{ url_for('contact_page') }}" class="adw-button flat">Contact</a>
+        </div>
+    </footer>
+
+    <style>
+    .app-footer {
+        border-top: 1px solid var(--border-color, #cccccc);
+        padding: var(--spacing-s, 8px) var(--spacing-m, 12px);
+        margin-top: var(--spacing-xl, 24px);
+        background-color: var(--window-bg-color, white);
+    }
+    /* Ensure footer items have good spacing */
+    .app-footer .adw-toolbar__end {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-s, 8px);
+    }
+
+    /* Basic CSS-only Expander Row */
+    .adw-css-expander-row summary.adw-action-row {
+        list-style: none; /* Remove default marker */
+        position: relative;
+        /* Ensure chevron is included in padding calculation if using padding-right on summary */
+    }
+    .adw-css-expander-row summary.adw-action-row::-webkit-details-marker {
+        display: none; /* Hide WebKit default marker */
+    }
+    .adw-css-expander-row summary.adw-action-row::after { /* Custom chevron */
+        content: '';
+        display: inline-block;
+        width: 0.5em;
+        height: 0.5em;
+        border-right: 0.15em solid currentColor;
+        border-bottom: 0.15em solid currentColor;
+        transform: rotate(45deg); /* Default: pointing down-right (like Adwaita's pan-end-symbolic) */
+        transition: transform 0.2s ease-out;
+        position: absolute;
+        right: var(--spacing-l, 12px); /* Adwaita action row typically has padding, place chevron within it */
+        top: 50%;
+        margin-top: -0.35em; /* Adjust vertical based on chevron size and border */
+        opacity: 0.7;
+    }
+    .adw-css-expander-row[open] > summary.adw-action-row::after {
+        transform: rotate(-135deg); /* Pointing up-right */
+    }
+    .adw-css-expander-row .adw-expander-row-content {
+        /* Content is already styled inline in profile.html, this is just a placeholder */
+    }
+    </style>
+
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app-demo/templates/dashboard.html
+++ b/app-demo/templates/dashboard.html
@@ -29,9 +29,9 @@
             <div class="adw-action-row-suffix adw-box adw-box-spacing-s" style="align-items: center;">
                 <a href="{{ url_for('view_post', post_id=post.id) }}" class="adw-button flat">View</a>
                 <a href="{{ url_for('edit_post', post_id=post.id) }}" class="adw-button">Edit</a>
-                {# For delete, using a direct form submission per row to use the existing POST route #}
+                {% set delete_form = delete_forms[post.id] %}
                 <form method="POST" action="{{ url_for('delete_post', post_id=post.id) }}" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this post? \\n\\n\'{{ post.title|escapejs }}\'');">
-                    {{ csrf_token() }} {# Important: Include CSRF token if your forms generally need it #}
+                    {{ delete_form.hidden_tag() }}
                     <button type="submit" class="adw-button destructive-action">Delete</button>
                 </form>
             </div>

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -73,10 +73,21 @@
             </div>
         </div>
 
-        <div class="form-actions-container">
-            <a href="{{ url_for('view_post', post_id=post.id) }}" class="adw-button flat">Cancel</a>
-            {{ form.save_draft(class="adw-button " ~ ('suggested-action' if post.is_published else '')) }}
-            {{ form.publish(class="adw-button " ~ ('suggested-action' if not post.is_published else '')) }}
+        <div class="form-actions-container" style="display: flex; justify-content: space-between; align-items: center; margin-top: var(--spacing-l);">
+            {# Existing buttons on one side #}
+            <div class="adw-box adw-box-spacing-s">
+                <a href="{{ url_for('view_post', post_id=post.id) }}" class="adw-button flat">Cancel</a>
+                {{ form.save_draft(class="adw-button " ~ ('suggested-action' if post.is_published else '')) }}
+                {{ form.publish(class="adw-button " ~ ('suggested-action' if not post.is_published else '')) }}
+            </div>
+
+            {# Delete button on the other side #}
+            {% if delete_form %}
+            <form method="POST" action="{{ url_for('delete_post', post_id=post.id) }}" class="inline-form" onsubmit="return confirm('Are you sure you want to permanently delete this post? \\n\\n\'{{ post.title|escapejs }}\'');" style="margin: 0;">
+                {{ delete_form.hidden_tag() }} {# CSRF token #}
+                <button type="submit" class="adw-button destructive-action">Delete Post</button>
+            </form>
+            {% endif %}
         </div>
     </form>
   </div>

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -2,104 +2,161 @@
 
 {% block title %}Profile: {{ user_profile.username }}{% endblock %}
 
-{% block headerbar %}
-<adw-header-bar>
-    <adw-window-title slot="title" title="{{ user_profile.username }}'s Profile"></adw-window-title>
-    <adw-button slot="start" icon-name="go-previous-symbolic" href="{{ url_for('index') }}" aria-label="Back to Home"></adw-button>
+{% block header_title %}
+    {# This will be placed in the adw-header-bar__center by base.html #}
+    {# We might want a back button or other actions specific to this page in the main header,
+       but the base header already has site navigation. For now, just a title. #}
+    <h1 class="adw-header-bar__title">{{ user_profile.username }}'s Profile</h1>
+{% endblock %}
+
+{% block header_actions_start %}
     {% if current_user == user_profile %}
-    <adw-button slot="end" text="Edit Profile" href="{{ url_for('edit_profile') }}" suggested></adw-button>
+        <a href="{{ url_for('edit_profile') }}" class="adw-button suggested-action">Edit Profile</a>
     {% endif %}
-</adw-header-bar>
 {% endblock %}
 
 {% block content %}
-<adw-clamp class="adw-clamp-xl">
-    <adw-box orientation="vertical" spacing="l" style="padding-top: var(--spacing-l);">
+<div class="adw-clamp adw-clamp-xl">
+    <div class="adw-box adw-box-vertical adw-box-spacing-l" style="padding-top: var(--spacing-l);">
 
         {# User Header Info #}
-        <adw-box orientation="horizontal" spacing="xl" align="center">
-            <adw-avatar image="{{ url_for('static', filename=user_profile.profile_photo_url) if user_profile.profile_photo_url else default_avatar_url }}" text="{{ user_profile.username }}" size="96"></adw-avatar>
-            <adw-box orientation="vertical" spacing="xs">
-                <adw-label title-level="1">{{ user_profile.full_name or user_profile.username }}</adw-label>
-                {% if user_profile.full_name %}
-                <adw-label is-caption>@{{ user_profile.username }}</adw-label>
+        <div class="adw-box adw-box-spacing-xl align-center"> {# Horizontal by default #}
+            <div class="adw-avatar size-huge"> {# size-huge for 96px from _avatar.scss comments #}
+                {% if user_profile.profile_photo_url %}
+                <img src="{{ url_for('static', filename=user_profile.profile_photo_url) }}" alt="{{ user_profile.username }} avatar">
+                {% else %}
+                <img src="{{ default_avatar_url }}" alt="{{ user_profile.username }} default avatar">
                 {% endif %}
-            </adw-box>
-        </adw-box>
+            </div>
+            <div class="adw-box adw-box-vertical adw-box-spacing-xs">
+                <h1 class="adw-label title-1">{{ user_profile.full_name or user_profile.username }}</h1>
+                {% if user_profile.full_name %}
+                <span class="adw-label adw-caption">@{{ user_profile.username }}</span>
+                {% endif %}
+            </div>
+        </div>
 
         {# Profile Details Group #}
-        <adw-preferences-group title="About {{user_profile.username}}">
-            {% if user_profile.profile_info %}
-            <adw-expander-row title="Bio" subtitle="View user's biography">
-                <div style="padding: var(--spacing-m); white-space: pre-wrap;">
-                    {{ user_profile.profile_info | safe }}
-                </div>
-            </adw-expander-row>
-            {% else %}
-            <adw-action-row title="Bio" subtitle="No bio provided."></adw-action-row>
-            {% endif %}
-
-            {% if user_profile.location %}
-            <adw-action-row title="Location" subtitle="{{ user_profile.location }}"></adw-action-row>
-            {% endif %}
-
-            {% if user_profile.website_url %}
-                {% if user_profile.website_url.startswith('http://') or user_profile.website_url.startswith('https://') %}
-                <adw-action-row title="Website" subtitle="{{ user_profile.website_url }}" href="{{ user_profile.website_url }}" target="_blank" activatable></adw-action-row>
+        <div class="adw-preferences-group" role="group" aria-labelledby="profile-details-title-{{user_profile.id}}">
+             <div class="adw-preferences-group__title-container">
+                <h2 class="adw-preferences-group__title title-2" id="profile-details-title-{{user_profile.id}}">About {{user_profile.username}}</h2>
+            </div>
+            <div class="adw-list-box">
+                {% if user_profile.profile_info %}
+                <details class="adw-css-expander-row">
+                    <summary class="adw-action-row">
+                        <span class="adw-action-row__text">
+                            <span class="adw-action-row__title">Bio</span>
+                            <span class="adw-action-row__subtitle">View user's biography</span>
+                        </span>
+                        {# Custom chevron will be applied via CSS to summary::after #}
+                    </summary>
+                    <div class="adw-expander-row-content" style="padding: var(--spacing-m); white-space: pre-wrap; border-top: 1px solid var(--borders-color, #ddd); margin-top: -1px;">
+                        {{ user_profile.profile_info | safe }}
+                    </div>
+                </details>
                 {% else %}
-                <adw-action-row title="Website" subtitle="{{ user_profile.website_url }} (Not a valid link)"></adw-action-row>
+                <div class="adw-action-row">
+                    <span class="adw-action-row__title">Bio</span>
+                    <span class="adw-action-row__subtitle">No bio provided.</span>
+                </div>
                 {% endif %}
-            {% endif %}
 
-            {% if current_user == user_profile %}
-            <adw-action-row title="Profile Privacy" subtitle="{{ 'Public' if user_profile.is_profile_public else 'Private (Only you can see full details)' }}"></adw-action-row>
-            {% endif %}
-        </adw-preferences-group>
+                {% if user_profile.location %}
+                <div class="adw-action-row">
+                    <span class="adw-action-row__title">Location</span>
+                    <span class="adw-action-row__subtitle">{{ user_profile.location }}</span>
+                </div>
+                {% endif %}
+
+                {% if user_profile.website_url %}
+                    {% if user_profile.website_url.startswith('http://') or user_profile.website_url.startswith('https://') %}
+                    <a href="{{ user_profile.website_url }}" target="_blank" class="adw-action-row activatable">
+                        <span class="adw-action-row__title">Website</span>
+                        <span class="adw-action-row__subtitle">{{ user_profile.website_url }}</span>
+                        <span class="adw-action-row__chevron"></span>
+                    </a>
+                    {% else %}
+                    <div class="adw-action-row">
+                        <span class="adw-action-row__title">Website</span>
+                        <span class="adw-action-row__subtitle">{{ user_profile.website_url }} (Not a valid link)</span>
+                    </div>
+                    {% endif %}
+                {% endif %}
+
+                {% if current_user == user_profile %}
+                <div class="adw-action-row">
+                    <span class="adw-action-row__title">Profile Privacy</span>
+                    <span class="adw-action-row__subtitle">{{ 'Public' if user_profile.is_profile_public else 'Private (Only you can see full details)' }}</span>
+                </div>
+                {% endif %}
+            </div>
+        </div>
 
         {# User Posts Section #}
-        <adw-preferences-group title="Posts by {{ user_profile.username }}">
+        <div class="adw-preferences-group" role="group" aria-labelledby="user-posts-title-{{user_profile.id}}">
+            <div class="adw-preferences-group__title-container">
+                <h2 class="adw-preferences-group__title title-2" id="user-posts-title-{{user_profile.id}}">Posts by {{ user_profile.username }}</h2>
+            </div>
             {% if posts_pagination and posts_pagination.items %}
-                <adw-list-box selectable>
+                <div class="adw-list-box"> {# Removed selectable as it might imply JS interaction not present #}
                     {% for post in posts_pagination.items %}
-                    <adw-action-row href="{{ url_for('view_post', post_id=post.id) }}" title="{{ post.title }}{% if not post.is_published and current_user == post.author %} (Draft){% endif %}" subtitle="{% if post.is_published and post.published_at %}Published: {{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC{% elif not post.is_published %}Draft - Last updated: {{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC{% else %}Created: {{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC{% endif %}" activatable></adw-action-row>
+                    <a href="{{ url_for('view_post', post_id=post.id) }}" class="adw-action-row activatable">
+                        <div class="adw-action-row__text">
+                            <span class="adw-action-row__title">{{ post.title }}{% if not post.is_published and current_user == post.author %} (Draft){% endif %}</span>
+                            <span class="adw-action-row__subtitle">{% if post.is_published and post.published_at %}Published: {{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC{% elif not post.is_published %}Draft - Last updated: {{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC{% else %}Created: {{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC{% endif %}</span>
+                        </div>
+                        <span class="adw-action-row__chevron"></span>
+                    </a>
                     {% endfor %}
-                </adw-list-box>
+                </div>
 
                 {# Pagination Controls - Using Adwaita ToggleGroup for a more native feel #}
                 {% if posts_pagination.pages > 1 %}
-                <adw-box orientation="horizontal" justify="center" style="margin-top: var(--spacing-l);">
-                    <adw-toggle-group>
+                <div class="adw-box adw-box-horizontal justify-center" style="margin-top: var(--spacing-l);">
+                    <div class="adw-toggle-group">
                         {% if posts_pagination.has_prev %}
-                            <adw-button icon-name="go-previous-symbolic" href="{{ url_for('profile', username=user_profile.username, page=posts_pagination.prev_num) }}"></adw-button>
+                            <a href="{{ url_for('profile', username=user_profile.username, page=posts_pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
+                                <span class="adw-icon icon-actions-go-previous-symbolic"></span>
+                            </a>
                         {% else %}
-                            <adw-button icon-name="go-previous-symbolic" disabled></adw-button>
+                            <button class="adw-button icon-only" disabled aria-label="Previous page">
+                                <span class="adw-icon icon-actions-go-previous-symbolic"></span>
+                            </button>
                         {% endif %}
 
                         {% for page_num in posts_pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
                             {% if page_num %}
                                 {% if page_num == posts_pagination.page %}
-                                    <adw-button text="{{ page_num }}" suggested disabled aria-current="page"></adw-button>
+                                    <button class="adw-button suggested-action" disabled aria-current="page">{{ page_num }}</button>
                                 {% else %}
-                                    <adw-button text="{{ page_num }}" href="{{ url_for('profile', username=user_profile.username, page=page_num) }}"></adw-button>
+                                    <a href="{{ url_for('profile', username=user_profile.username, page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
-                            {% elif loop.index != 1 and loop.index != posts_pagination.pages + 2 %} {# Avoid ellipsis at very start/end if not needed #}
-                                <adw-button text="…" flat disabled style="pointer-events: none;"></adw-button>
+                            {% elif loop.index != 1 and loop.index != posts_pagination.pages + posts_pagination.iter_pages()|length %}
+                                <button class="adw-button flat" disabled style="pointer-events: none;">…</button>
                             {% endif %}
                         {% endfor %}
 
                         {% if posts_pagination.has_next %}
-                            <adw-button icon-name="go-next-symbolic" href="{{ url_for('profile', username=user_profile.username, page=posts_pagination.next_num) }}"></adw-button>
+                             <a href="{{ url_for('profile', username=user_profile.username, page=posts_pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
+                                <span class="adw-icon icon-actions-go-next-symbolic"></span>
+                            </a>
                         {% else %}
-                            <adw-button icon-name="go-next-symbolic" disabled></adw-button>
+                            <button class="adw-button icon-only" disabled aria-label="Next page">
+                                <span class="adw-icon icon-actions-go-next-symbolic"></span>
+                            </button>
                         {% endif %}
-                    </adw-toggle-group>
-                </adw-box>
+                    </div>
+                </div>
                 {% endif %}
             {% else %}
-                <adw-status-page icon-name="document-new-symbolic" title="No Posts Yet" description="{{ user_profile.username }} has not made any posts.">
-                </adw-status-page>
+                <div class="adw-status-page">
+                    <span class="adw-icon icon-content-document-new-symbolic adw-status-page-icon" style="font-size: 3rem;"></span>
+                    <h3 class="adw-status-page-title">No Posts Yet</h3>
+                    <p class="adw-status-page-description">{{ user_profile.username }} has not made any posts.</p>
+                </div>
             {% endif %}
-        </adw-preferences-group>
-    </adw-box>
-</adw-clamp>
+        </div>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
This commit addresses several bugs and UI/UX issues in the app-demo:

Bug Fixes:
- Resolved CSRF token errors when deleting posts from the Dashboard by ensuring FlaskForm's hidden_tag is used.
- Added the missing "Delete Post" button to the Edit Post page, with CSRF protection and confirmation.
- Corrected redirect for post deletion to return to the Dashboard.

UI/UX Enhancements:
- Refactored the main header bar for better layout and clarity:
    - Site title links to home and is positioned at the start.
    - "About" and "Contact" links moved to a new site footer.
    - "Settings" button in header is now a text button.
- Ensured profile editing is accessible via an "Edit Profile" button in the header when viewing one's own profile (using a cleaner Jinja block).
- Reverted attempts to use Adwaita web components (e.g., <adw-password-entry-row>) as the necessary JavaScript is not integrated into app-demo. Forms now consistently use div-based Adwaita CSS classes (e.g., .adw-entry-row).
- Refactored profile.html to use div-based Adwaita CSS classes instead of non-functional web component tags, ensuring consistency with the CSS-only approach.
- Implemented a CSS-only expander row for the bio on the profile page.
- Reviewed and ensured general consistency of Adwaita styling across various pages (index, post, dashboard, settings, edit_profile).

Other Minor Improvements:
- Corrected Jinja date filter in base.html footer.
- Simplified avatar initial logic in base.html.