### PR TITLE
Fix: Ensure Markdown renders in post listings and increase excerpt le…

### DIFF
--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -20,9 +20,12 @@
                         on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                     </p>
                     {% if post.content %}
-                    <p class="post-excerpt">
-                        {{ post.content | striptags | truncate(150, True) }}
-                    </p>
+                    <div class="post-excerpt styled-text-content"> {# Apply styled-text-content for potential formatting #}
+                        {# This will render HTML then truncate. For true HTML excerpt, logic would be more complex. #}
+                        {# For now, let's render a portion then allow CSS to hide overflow, or truncate HTML carefully. #}
+                        {# A simpler plain text excerpt from rendered markdown: #}
+                        {{ (post.content | markdown_to_html_and_sanitize | striptags | truncate(350, True)) if post.content else '' }}
+                    </div>
                     {% endif %}
 
                     {% if post.categories %}

--- a/app-demo/templates/posts_by_category.html
+++ b/app-demo/templates/posts_by_category.html
@@ -26,7 +26,7 @@
                         By: <a href="{{ url_for('profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
                         on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         <br>
-                        {{ post.content | striptags | truncate(150, True) }}
+                        {{ (post.content | markdown_to_html_and_sanitize | striptags | truncate(150, True)) if post.content else '' }}
                     </span>
                 </adw-action-row>
                 {% if post.categories or post.tags %}

--- a/app-demo/templates/posts_by_tag.html
+++ b/app-demo/templates/posts_by_tag.html
@@ -26,7 +26,7 @@
                         By: <a href="{{ url_for('profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
                         on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         <br>
-                        {{ post.content | striptags | truncate(150, True) }}
+                        {{ (post.content | markdown_to_html_and_sanitize | striptags | truncate(150, True)) if post.content else '' }}
                     </span>
                 </adw-action-row>
 

--- a/app-demo/templates/search_results.html
+++ b/app-demo/templates/search_results.html
@@ -33,7 +33,7 @@
                         By: <a href="{{ url_for('profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
                         on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         <br>
-                        {{ post.content | striptags | truncate(150, True) }}
+                        {{ (post.content | markdown_to_html_and_sanitize | striptags | truncate(150, True)) if post.content else '' }}
                     </span>
                     {# Suffix slot could be used for 'Read More' or other actions, but direct navigation is fine for action row #}
                 </adw-action-row>


### PR DESCRIPTION
…ngth

- Updated post listing templates (index.html, search_results.html, posts_by_category.html, posts_by_tag.html) to apply the `markdown_to_html_and_sanitize` filter to post content before stripping tags and truncating for excerpts. This prevents raw Markdown syntax from being displayed in listings.
- Increased the excerpt length on the home page (index.html) to 350 characters to show more content.
- Confirmed that existing links (post title, 'View Details' button) serve as 'Read More' functionality.