### PR TITLE
Fix: Correct template filter name to 'markdown_to_html'

### DIFF
--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -23,7 +23,7 @@
             <div class="blog-post-card__excerpt styled-text-content">
                 {# Rendered HTML excerpt, truncated by CSS if too long, or use a JS solution for smarter HTML truncation #}
                 {# For now, rendering a portion of Markdown. This should be improved for proper HTML excerpt. #}
-                {{ (post.content | truncate(600) | markdown_to_html_and_sanitize ) if post.content else '' }}
+                {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
             </div>
             {% endif %}
             <footer class="blog-post-card__footer">

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -43,7 +43,7 @@
         </header>
 
         <div class="post-content styled-text-content"> {# Added styled-text-content for prose styling #}
-            {{ post.content | markdown_to_html_and_sanitize }}
+            {{ post.content | markdown_to_html }}
         </div>
 
         {% if post.author %}

--- a/app-demo/templates/posts_by_category.html
+++ b/app-demo/templates/posts_by_category.html
@@ -32,7 +32,7 @@
                     </header>
                     {% if post.content %}
                     <div class="blog-post-card__excerpt styled-text-content">
-                        {{ (post.content | truncate(600) | markdown_to_html_and_sanitize ) if post.content else '' }}
+                     {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
                     </div>
                     {% endif %}
                     <footer class="blog-post-card__footer">

--- a/app-demo/templates/posts_by_tag.html
+++ b/app-demo/templates/posts_by_tag.html
@@ -32,7 +32,7 @@
                     </header>
                     {% if post.content %}
                     <div class="blog-post-card__excerpt styled-text-content">
-                        {{ (post.content | truncate(600) | markdown_to_html_and_sanitize ) if post.content else '' }}
+                     {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
                     </div>
                     {% endif %}
                     <footer class="blog-post-card__footer">

--- a/app-demo/templates/search_results.html
+++ b/app-demo/templates/search_results.html
@@ -34,7 +34,7 @@
                     </header>
                     {% if post.content %}
                     <div class="blog-post-card__excerpt styled-text-content">
-                        {{ (post.content | truncate(600) | markdown_to_html_and_sanitize ) if post.content else '' }}
+                     {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
                     </div>
                     {% endif %}
                     <footer class="blog-post-card__footer">


### PR DESCRIPTION
Changed filter name from 'markdown_to_html_and_sanitize' to 'markdown_to_html' in templates to match its registration in app-demo/__init__.py. This resolves the Jinja TemplateRuntimeError.