### PR TITLE
Fix ModuleNotFoundError in setup_db.py and update docs

### DIFF
--- a/app-demo/README.md
+++ b/app-demo/README.md
@@ -88,8 +88,9 @@ This is a simple Flask-based Blog Content Management System that uses `libadwait
         If you are using the default application user `postgres` and have set its password to `postgres`, you might not need to create a new user, but ensure the `postgres` user has a password set in the database.
 
     *   **Initialize Database and Create Admin User**:
-        After configuring your environment variables and ensuring the database and user exist, run the setup script (ensure you are in the `app-demo` directory):
+        After configuring your environment variables and ensuring the database and user exist, navigate into the `app-demo` directory if you aren't already there. Then, run the setup script:
         ```bash
+        # Make sure you are in the app-demo directory
         python setup_db.py
         ```
         This script will:

--- a/app-demo/__init__.py
+++ b/app-demo/__init__.py
@@ -13,6 +13,10 @@ db = SQLAlchemy()
 login_manager = LoginManager()
 csrf = CSRFProtect()
 
+# Import models at the module level so they are registered with SQLAlchemy
+# and accessible via the package for scripts like setup_db.py
+from . import models # This will import app-demo/models.py
+
 def create_app(config_name=None):
     app = Flask(__name__, instance_relative_config=True)
 
@@ -60,9 +64,8 @@ def create_app(config_name=None):
     login_manager.login_message_category = 'info'
     csrf.init_app(app)
 
-    # Import models here to ensure they are registered with SQLAlchemy
-    # after db has been initialized with the app.
-    from . import models # This will import app-demo/models.py
+    # Models are imported at the module level now, no need to re-import here
+    # Ensure they are registered with SQLAlchemy (which happens when models.py is imported)
 
     @login_manager.user_loader
     def load_user(user_id_str):

--- a/app-demo/setup_db.py
+++ b/app-demo/setup_db.py
@@ -3,12 +3,30 @@
 # This script handles the initial setup of the database,
 # including table creation and initial user setup.
 
+import os
+import sys
 import argparse
 import getpass  # For hidden password input
 
+# Adjust sys.path to allow imports from the app_demo package
+# when running this script directly.
+# This adds the parent directory of the script's directory (app-demo) to sys.path,
+# which is the project root.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+import importlib
+
 # Import create_app and necessary models/db instance
-from app_demo import create_app, db # Post model not used in this script currently
-from app_demo.models import User
+# The actual directory/package name is 'app-demo'
+# We use importlib to load it because of the hyphen.
+app_module = importlib.import_module("app-demo")
+create_app = app_module.create_app
+db = app_module.db
+User = app_module.models.User
+
 
 def create_initial_user(flask_app):
     """


### PR DESCRIPTION
- Modified app-demo/setup_db.py to correctly adjust sys.path and use importlib to load the 'app-demo' package, resolving import errors when the script is run directly.
- Moved 'from . import models' to the module level in app-demo/__init__.py to ensure models are accessible when the package is imported by scripts.
- Updated app-demo/README.md to recommend running 'python setup_db.py' from within the app-demo directory.