### PR TITLE
Fix: Correct url_for call for 'index' endpoint in post template

### DIFF
--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -220,7 +220,7 @@
     {% endif %}
 
     <div class="adw-box adw-box-spacing-s back-to-posts-container">
-         <a href="{{ url_for('index') }}" class="adw-button"><span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Posts</a>
+         <a href="{{ url_for('general.index') }}" class="adw-button"><span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Posts</a>
     </div>
 </div>
 


### PR DESCRIPTION
Changed `url_for('index')` to `url_for('general.index')` in app-demo/templates/post.html to resolve a BuildError.