### PR TITLE
Fix UndefinedError for UserPhoto in templates

### DIFF
--- a/app-demo/__init__.py
+++ b/app-demo/__init__.py
@@ -120,7 +120,8 @@ def create_app(config_name=None):
         return {
             'current_user': current_user, # From flask_login
             'default_avatar_url': url_for('static', filename='img/default_avatar.png'),
-            'site_settings': models.SiteSetting # Make SiteSetting model available
+            'site_settings': models.SiteSetting, # Make SiteSetting model available
+            'UserPhoto': models.UserPhoto      # Make UserPhoto model available for ordering
         }
 
     @app.context_processor


### PR DESCRIPTION
Makes the UserPhoto model available in the global Jinja2 template context. This resolves an `UndefinedError` that occurred in the `profile.html` template when trying to sort gallery photos using `UserPhoto.uploaded_at`.

The `inject_global_template_variables` context processor in `app-demo/__init__.py` has been updated to include `UserPhoto`.