### PR TITLE
fix: Register markdown filter correctly for feed

### DIFF
--- a/app-demo/__init__.py
+++ b/app-demo/__init__.py
@@ -110,8 +110,8 @@ def create_app(config_name=None):
         if not isinstance(value, str): value = str(value)
         return Markup(value.replace('\\', '\\\\').replace("'", "\\'").replace('"', '\\"').replace('\n', '\\n').replace('\r', '\\r').replace('/', '\\/'))
 
-    @app.template_filter('markdown_to_html') # Simpler name for template
-    def markdown_filter(text):
+    @app.template_filter('markdown') # Changed decorator to register as 'markdown'
+    def actual_markdown_filter(text): # Function name can be anything
         return markdown_to_html_and_sanitize_util(text)
 
     # Context processors


### PR DESCRIPTION
The activity feed was attempting to use a Jinja filter named 'markdown' which was not correctly registered under that name, leading to a TemplateAssertionError.

This commit ensures the markdown conversion utility (markdown_to_html_and_sanitize_util from utils.py) is registered with the Jinja2 environment using the name 'markdown', matching its usage in the feed.html template.

The underlying markdown processing and sanitization logic in utils.py was already in place and is now correctly invoked.