### PR TITLE
fix: Standardize markdown filter usage in templates

### DIFF
--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -23,7 +23,7 @@
             <div class="blog-post-card__excerpt styled-text-content">
                 {# Rendered HTML excerpt, truncated by CSS if too long, or use a JS solution for smarter HTML truncation #}
                 {# For now, rendering a portion of Markdown. This should be improved for proper HTML excerpt. #}
-                {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
+                {{ (post.content | truncate(600) | markdown ) if post.content else '' }}
             </div>
             {% endif %}
             <footer class="blog-post-card__footer">

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -43,7 +43,7 @@
         </header>
 
         <div class="post-content styled-text-content"> {# Added styled-text-content for prose styling #}
-            {{ post.content | markdown_to_html }}
+            {{ post.content | markdown }}
         </div>
 
         {# Likes and Actions Section - Placed before Author Bio for prominence #}

--- a/app-demo/templates/posts_by_category.html
+++ b/app-demo/templates/posts_by_category.html
@@ -32,7 +32,7 @@
                     </header>
                     {% if post.content %}
                     <div class="blog-post-card__excerpt styled-text-content">
-                     {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
+                     {{ (post.content | truncate(600) | markdown ) if post.content else '' }}
                     </div>
                     {% endif %}
                     <footer class="blog-post-card__footer">

--- a/app-demo/templates/posts_by_tag.html
+++ b/app-demo/templates/posts_by_tag.html
@@ -32,7 +32,7 @@
                     </header>
                     {% if post.content %}
                     <div class="blog-post-card__excerpt styled-text-content">
-                     {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
+                     {{ (post.content | truncate(600) | markdown ) if post.content else '' }}
                     </div>
                     {% endif %}
                     <footer class="blog-post-card__footer">

--- a/app-demo/templates/search_results.html
+++ b/app-demo/templates/search_results.html
@@ -34,7 +34,7 @@
                     </header>
                     {% if post.content %}
                     <div class="blog-post-card__excerpt styled-text-content">
-                     {{ (post.content | truncate(600) | markdown_to_html ) if post.content else '' }}
+                     {{ (post.content | truncate(600) | markdown ) if post.content else '' }}
                     </div>
                     {% endif %}
                     <footer class="blog-post-card__footer">


### PR DESCRIPTION
Corrects a TemplateRuntimeError caused by inconsistent naming of the markdown filter. The filter was registered as 'markdown' but some templates were still calling 'markdown_to_html'.

This commit updates the following templates to use `| markdown` for rendering post content, consistent with the registered filter name:
- index.html
- post.html
- posts_by_category.html
- posts_by_tag.html
- search_results.html

The `feed.html` template was already using the correct `| markdown` filter. This ensures Markdown content is correctly processed and rendered across all relevant views.