### PR TITLE
fix: Correct profile URL generation in comments and add comment notif…

### DIFF
--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -131,7 +131,7 @@
                <img src="{{ comment_avatar }}" alt="{{ comment.author.username }} avatar" class="adw-avatar__image">
             </span>
             <div class="comment-author-meta">
-                 <a href="{{ url_for('profile', username=comment.author.username) }}" class="adw-link comment-author-link-strong">{{ comment.author.username }}</a>
+                 <a href="{{ url_for('profile.view_profile', username=comment.author.username) }}" class="adw-link comment-author-link-strong">{{ comment.author.username }}</a>
                 <small class="adw-label caption comment-timestamp"><time datetime="{{ comment.created_at.isoformat() }}">{{ comment.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time></small>
             </div>
         </header>


### PR DESCRIPTION
…ications

This commit addresses two items:

1.  Fixes a `werkzeug.routing.exceptions.BuildError` in `post.html`. The `url_for` call for comment author profile links was using an incorrect endpoint name ('profile' instead of 'profile.view_profile'). This has been corrected.

2.  Adds notification generation for new comments on a user's posts:
    - When a user comments on a post, a 'new_comment' notification is created for the post's author, unless the commenter is the author.
    - The notification includes `related_post_id` and `related_comment_id`.
    - `notifications.html` was already prepared to display this type of notification, including linking to the specific comment via an anchor.