### PR TITLE
Fix: Correct DateField import path in forms.py

### DIFF
--- a/app-demo/forms.py
+++ b/app-demo/forms.py
@@ -9,7 +9,7 @@ from wtforms import (
     HiddenField, # Added for CommentForm parent_id if needed, StringField is fine too
     IntegerField
 )
-from wtforms.fields.html5 import DateField # Added for birthdate
+from wtforms.fields import DateField # Changed import for DateField
 from wtforms.validators import DataRequired, EqualTo, Length, Optional, NumberRange
 from wtforms.widgets import CheckboxInput, ListWidget # Ensure ListWidget is imported if used by QuerySelectMultipleField
 from wtforms_sqlalchemy.fields import QuerySelectMultipleField


### PR DESCRIPTION
Ensuring the import for DateField is `from wtforms.fields import DateField` to resolve ModuleNotFoundError for `wtforms.fields.html5` with WTForms 3.2.1.