### PR TITLE
Feature: Remove redundant Location field and Post Titles

### DIFF
--- a/app-demo/forms.py
+++ b/app-demo/forms.py
@@ -46,7 +46,6 @@ def get_category_pk(obj):
     return None
 
 class PostForm(FlaskForm):
-    title = StringField('Title', validators=[DataRequired(), Length(min=1, max=120)])
     content = TextAreaField('Content (Markdown)', validators=[DataRequired()]) # Updated label
     categories = QuerySelectMultipleField(
         'Categories',
@@ -71,7 +70,6 @@ class ProfileEditForm(FlaskForm):
         validators=[Optional(), Length(max=5000)]
     )
     profile_photo = FileField('Profile Photo (Max 2MB)', validators=[Optional()])
-    location = StringField('Location', validators=[Optional(), Length(max=100)])
     website_url = StringField('Website URL', validators=[Optional(), Length(max=200)])
 
     # New fields for enhanced profile

--- a/app-demo/models.py
+++ b/app-demo/models.py
@@ -13,7 +13,6 @@ class User(UserMixin, db.Model):
     profile_info = db.Column(db.Text, nullable=True)
     profile_photo_url = db.Column(db.String(512), nullable=True)
     full_name = db.Column(db.String(120), nullable=True)
-    location = db.Column(db.String(100), nullable=True)
     website_url = db.Column(db.String(200), nullable=True)
 
     # New fields for enhanced profile
@@ -163,7 +162,6 @@ class Category(db.Model):
 
 class Post(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.String(120), nullable=False)
     content = db.Column(db.Text, nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     created_at = db.Column(

--- a/app-demo/routes/general_routes.py
+++ b/app-demo/routes/general_routes.py
@@ -68,7 +68,7 @@ def search_results():
         try:
             posts_query = Post.query.filter(
                 Post.is_published==True, # Ensure only published posts are searchable by public
-                or_(Post.title.ilike(search_term), Post.content.ilike(search_term))
+                Post.content.ilike(search_term) # Search only in content now
             ).order_by(Post.published_at.desc(), Post.created_at.desc())
 
             pagination = posts_query.paginate(page=page, per_page=per_page, error_out=False)

--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -15,17 +15,6 @@
                 <h2 class="adw-title-2" id="post-details-title">Post Details</h2>
             </header>
 
-            {# Title Entry Row #}
-            <div class="adw-entry-row {{ 'has-error' if form.title.errors else '' }}">
-                <div class="adw-entry-row-text-content">
-                    <label for="{{ form.title.id or 'title_input' }}" class="adw-entry-row-title">{{ form.title.label.text }}</label>
-                    {% if form.title.errors %}
-                        <span class="adw-entry-row-subtitle error-text">{{ form.title.errors|join(' ') }}</span>
-                    {% endif %}
-                </div>
-                <input type="text" id="{{ form.title.id or 'title_input' }}" name="{{ form.title.name }}" value="{{ form.title.data or '' }}" class="adw-entry adw-entry-row-entry" placeholder="Enter post title" {% if form.title.flags.required %}required{% endif %}>
-            </div>
-
             {# Content Textarea - Revised Structure #}
             <div class="form-field-container {{ 'has-error' if form.content.errors else '' }}" style="padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m);">
                 <label for="{{ form.content.id or 'content_input' }}" class="adw-label" style="display: block; margin-bottom: var(--spacing-xs);">{{ form.content.label.text }}</label>

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -15,17 +15,6 @@
                 <h2 class="adw-title-2" id="edit-post-details-title">Post Details</h2>
             </header>
 
-            {# Title Entry Row #}
-            <div class="adw-entry-row {{ 'has-error' if form.title.errors else '' }}">
-                <div class="adw-entry-row-text-content">
-                    <label for="{{ form.title.id or 'title_input' }}" class="adw-entry-row-title">{{ form.title.label.text }}</label>
-                    {% if form.title.errors %}
-                        <span class="adw-entry-row-subtitle error-text">{{ form.title.errors|join(' ') }}</span>
-                    {% endif %}
-                </div>
-                <input type="text" id="{{ form.title.id or 'title_input' }}" name="{{ form.title.name }}" value="{{ form.title.data or '' }}" class="adw-entry adw-entry-row-entry" placeholder="Enter post title" {% if form.title.flags.required %}required{% endif %}>
-            </div>
-
             {# Content Textarea - Revised Structure #}
             <div class="form-field-container {{ 'has-error' if form.content.errors else '' }}" style="padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m);">
                 <label for="{{ form.content.id or 'content_input' }}" class="adw-label" style="display: block; margin-bottom: var(--spacing-xs);">{{ form.content.label.text }}</label>

--- a/app-demo/templates/edit_profile.html
+++ b/app-demo/templates/edit_profile.html
@@ -47,16 +47,6 @@
                  </div>
             </div>
 
-
-            {# Location Entry Row #}
-            <div class="adw-entry-row {{ 'has-error' if form.location.errors else '' }}">
-                <div class="adw-entry-row-text-content">
-                    <label for="{{ form.location.id or 'location_input' }}" class="adw-entry-row-title">{{ form.location.label.text }}</label>
-                    {% if form.location.errors %}<span class="adw-entry-row-subtitle error-text">{{ form.location.errors|join(' ') }}</span>{% endif %}
-                </div>
-                <input type="text" id="{{ form.location.id or 'location_input' }}" name="{{ form.location.name }}" value="{{ form.location.data or '' }}" class="adw-entry adw-entry-row-entry" placeholder="e.g., City, Country">
-            </div>
-
             {# Website URL Entry Row #}
             <div class="adw-entry-row {{ 'has-error' if form.website_url.errors else '' }}">
                 <div class="adw-entry-row-text-content">

--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -11,21 +11,21 @@
         {% for post in posts %}
         <article class="adw-card blog-post-item-card">
             <header class="blog-post-card__header">
-                <h2 class="adw-title-2 blog-post-card__title">
-                    <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.title }}</a>
-                </h2>
+                {# Post title removed #}
                 <div class="blog-post-card__meta adw-label caption">
                     By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
-                    on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
+                    on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else 'Unknown date' }}</time> {# Show time as well #}
                 </div>
             </header>
-            {% if post.content %}
-            <div class="blog-post-card__excerpt styled-text-content">
-                {# Rendered HTML excerpt, truncated by CSS if too long, or use a JS solution for smarter HTML truncation #}
-                {# For now, rendering a portion of Markdown. This should be improved for proper HTML excerpt. #}
-                {{ (post.content | truncate(600) | markdown ) if post.content else '' }}
-            </div>
-            {% endif %}
+            <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link post-content-link"> {# Make content clickable #}
+                {% if post.content %}
+                <div class="blog-post-card__excerpt styled-text-content">
+                    {# Rendered HTML excerpt, truncated by CSS if too long, or use a JS solution for smarter HTML truncation #}
+                    {# For now, rendering a portion of Markdown. This should be improved for proper HTML excerpt. #}
+                    {{ (post.content | truncate(600) | markdown ) if post.content else '' }}
+                </div>
+                {% endif %}
+            </a>
             <footer class="blog-post-card__footer">
                 <div class="blog-post-card__terms">
                     {% if post.categories %}

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 
-{% block page_title %}{{ post.title }}{% endblock %}
+{% block page_title %}Post by {{ post.author.username }}{% endblock %}
 
-{% block header_title %}{{ post.title }}{% endblock %}
+{% block header_title %}Post by {{ post.author.username }}{% endblock %}
 
 {% block content %}
 <div class="post-view"> {# Removed adw-clamp content-clamp as base.html provides clamp #}
     <article class="post-article adw-card blog-content-card"> {# Added adw-card and specific class #}
         <header class="post-header">
-            <h1 class="adw-title-1">{{ post.title }}{% if not post.is_published and current_user == post.author %} <span class="adw-label caption draft-indicator">(Draft)</span>{% endif %}</h1>
+            {# Title h1 removed #}
             <div class="post-meta-detail">
                 <p class="adw-label body">
                     By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -132,14 +132,6 @@
                 </div>
                 {% endif %}
 
-                {# General Location (if still desired alongside detailed address) #}
-                {% if user_profile.location %}
-                <div class="adw-action-row">
-                    <span class="adw-action-row__title">Location</span>
-                    <span class="adw-action-row__subtitle">{{ user_profile.location }}</span>
-                </div>
-                {% endif %}
-
                 {% if user_profile.website_url %}
                     {% if user_profile.website_url.startswith('http://') or user_profile.website_url.startswith('https://') %}
                     <a href="{{ user_profile.website_url }}" target="_blank" class="adw-action-row activatable">
@@ -174,14 +166,14 @@
                     {% for post in posts_pagination.items %}
                     <article class="adw-card blog-post-item-card">
                         <header class="blog-post-card__header">
-                            <h2 class="adw-title-2 blog-post-card__title">
-                                <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">
-                                    {{ post.title }}{% if not post.is_published and current_user == post.author %} <span class="adw-label caption">(Draft)</span>{% endif %}
-                                </a>
-                            </h2>
+                            {# Post title removed, content will be linked in footer or by making card clickable if desired #}
                             <div class="blog-post-card__meta adw-label caption">
-                                {% if post.is_published and post.published_at %}
+                                {% if not post.is_published and current_user == post.author %}
+                                    <span class="adw-label caption">(Draft)</span> -
+                                {% elif post.is_published and post.published_at %}
                                     Published: <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                                {% elif not post.is_published %}
+                                    Draft - Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                                 {% elif not post.is_published %}
                                     Draft - Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                                 {% else %}
@@ -261,7 +253,7 @@
                     {% for comment in comments_pagination.items %}
                     <a href="{{ url_for('post.view_post', post_id=comment.post_id, _anchor='comment-' ~ comment.id) }}" class="adw-action-row activatable">
                         <div class="adw-action-row__text">
-                            <span class="adw-action-row__title">On post: "{{ comment.post.title }}"</span>
+                            <span class="adw-action-row__title">Comment on post by {{ comment.post.author.username }}</span>
                             <span class="adw-action-row__subtitle">"{{ comment.text | truncate(100, True) }}"</span>
                             <small class="adw-label caption">
                                 <time datetime="{{ comment.created_at.isoformat() }}">{{ comment.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>


### PR DESCRIPTION
Based on user feedback, this commit removes:
1. The generic 'Location' field from user profiles, forms, and the User model, as detailed address fields serve this purpose.
2. The 'Title' attribute from Posts, including:
    - Removal from PostForm and Post model.
    - Removal from create/edit post templates.
    - Updated display templates (index, profile, single post) to present posts without titles, focusing on content.
    - Adjusted routes and search functionality to operate without post titles.

These changes aim to streamline profile information and align the post structure more closely with typical social media updates that don't always have explicit titles.