### PR TITLE
Feature: Make feed the homepage and include user's own posts

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -105,15 +105,19 @@
         {% endif %}
         <nav class="adw-list-box flat sidebar-nav" aria-label="Main Navigation">
             {% block sidebar_nav %}
-                <a href="{{ url_for('general.index') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.index' }}">
-                    <span class="adw-action-row-icon icon-actions-go-home-symbolic"></span>
-                    <span class="adw-action-row-title">Home</span>
-                </a>
+                {% if current_user.is_authenticated %}
+                    <a href="{{ url_for('general.activity_feed') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.activity_feed' or request.endpoint == 'general.index' }}">
+                        <span class="adw-action-row-icon icon-actions-go-home-symbolic"></span>
+                        <span class="adw-action-row-title">Home</span> {# "Home" now points to feed for logged-in users #}
+                    </a>
+                {% else %}
+                    <a href="{{ url_for('general.index') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.index' }}">
+                        <span class="adw-action-row-icon icon-actions-go-home-symbolic"></span>
+                        <span class="adw-action-row-title">Home</span>
+                    </a>
+                {% endif %}
             {% if current_user.is_authenticated %}
-                <a href="{{ url_for('general.activity_feed') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.activity_feed' }}">
-                    <span class="adw-action-row-icon icon-content-view-grid-symbolic"></span>
-                    <span class="adw-action-row-title">Feed</span>
-                </a>
+                {# The "Feed" link is removed as "Home" now serves this purpose for logged-in users #}
                 <a href="{{ url_for('general.find_users') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.find_users' }}">
                     <span class="adw-action-row-icon icon-actions-system-search-symbolic"></span>
                     <span class="adw-action-row-title">Find Users</span>


### PR DESCRIPTION
This commit implements the following improvements:
1.  **Activity Feed Includes Own Posts:** The activity feed for a logged-in user now includes their own activities (e.g., their new posts, likes) in addition to activities from users they follow.
2.  **Feed as Homepage for Logged-in Users:** The root path ('/') now redirects authenticated users to their activity feed. Anonymous users will continue to see the public list of recent posts.
3.  **Updated Sidebar Navigation:** For authenticated users, the "Home" link in the sidebar now points to their activity feed, and the redundant separate "Feed" link has been removed to simplify navigation.