### PR TITLE
Refactor: Further UI refinements and fixes post-re-audit

### DIFF
--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -17,7 +17,7 @@
 
             {# Content Textarea - Revised Structure #}
             <div class="form-field-container {{ 'has-error' if form.content.errors else '' }}" style="padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m);">
-                <label for="{{ form.content.id or 'content_input' }}" class="adw-label" style="display: block; margin-bottom: var(--spacing-xs);">{{ form.content.label.text }}</label>
+                <label for="{{ form.content.id or 'content_input' }}" class="adw-label" style="display: block; margin-bottom: var(--spacing-xs);">{{ form.content.label.text }} <span class="adw-label caption">(Supports Markdown)</span></label>
                 {% if form.content.errors %}
                     <p class="adw-label caption error-text" style="margin-bottom: var(--spacing-xs);">{{ form.content.errors|join(' ') }}</p>
                 {% endif %}

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -17,7 +17,7 @@
 
             {# Content Textarea - Revised Structure #}
             <div class="form-field-container {{ 'has-error' if form.content.errors else '' }}" style="padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m);">
-                <label for="{{ form.content.id or 'content_input' }}" class="adw-label" style="display: block; margin-bottom: var(--spacing-xs);">{{ form.content.label.text }}</label>
+                <label for="{{ form.content.id or 'content_input' }}" class="adw-label" style="display: block; margin-bottom: var(--spacing-xs);">{{ form.content.label.text }} <span class="adw-label caption">(Supports Markdown)</span></label>
                 {% if form.content.errors %}
                     <p class="adw-label caption error-text" style="margin-bottom: var(--spacing-xs);">{{ form.content.errors|join(' ') }}</p>
                 {% endif %}

--- a/app-demo/templates/feed.html
+++ b/app-demo/templates/feed.html
@@ -34,13 +34,9 @@
                                      <span class="adw-label caption feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
                                 </div>
                             </div>
-                            <h2 class="adw-title-2 blog-post-card__title">
-                                <a href="{{ url_for('post.view_post', post_id=activity.target_post.id) }}" class="adw-link">
-                                    {{ activity.target_post.title }}
-                                </a>
-                            </h2>
-                             {# Meta for publish date of post, not activity timestamp here #}
-                            <div class="blog-post-card__meta adw-label caption">
+                            {# Post title h2 removed #}
+                             {# Meta for publish date of post, not activity timestamp here, is part of the post card content #}
+                            <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
                                 {% if activity.target_post.published_at %}
                                     Published: <time datetime="{{ activity.target_post.published_at.isoformat() }}">{{ activity.target_post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                                 {% else %}
@@ -90,8 +86,7 @@
                         <div class="adw-action-row-text-content">
                             <span class="adw-action-row-title">
                                 <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">{{ activity.actor.full_name or activity.actor.username }}</a>
-                                liked
-                                <a href="{{ url_for('post.view_post', post_id=activity.target_post.id) }}" class="adw-link">"{{ activity.target_post.title }}"</a>.
+                                liked a <a href="{{ url_for('post.view_post', post_id=activity.target_post.id) }}" class="adw-link">post by {{ activity.target_post.author.username }}</a>.
                             </span>
                              <span class="adw-action-row-subtitle feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
                         </div>
@@ -104,8 +99,7 @@
                         <div class="adw-action-row-text-content">
                             <span class="adw-action-row-title">
                                 <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">{{ activity.actor.full_name or activity.actor.username }}</a>
-                                commented on
-                                <a href="{{ url_for('post.view_post', post_id=activity.target_post.id, _anchor='comment-' ~ activity.target_comment_id if activity.target_comment_id else 'post-comments-area') }}" class="adw-link">"{{ activity.target_post.title }}"</a>.
+                                commented on a <a href="{{ url_for('post.view_post', post_id=activity.target_post.id, _anchor='comment-' ~ activity.target_comment_id if activity.target_comment_id else 'post-comments-area') }}" class="adw-link">post by {{ activity.target_post.author.username }}</a>.
                             </span>
                             {# Optionally, show comment snippet here if available on activity model or fetched #}
                             <span class="adw-action-row-subtitle feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
@@ -132,7 +126,7 @@
                 {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
                     {% if page_num %}
                         {% if page_num == pagination.page %}
-                            <button class="adw-button suggested-action" disabled aria-current="page">{{ page_num }}</button>
+                            <button class="adw-button suggested" disabled aria-current="page">{{ page_num }}</button>
                         {% else %}
                             <a href="{{ url_for('general.activity_feed', page=page_num) }}" class="adw-button">{{ page_num }}</a>
                         {% endif %}

--- a/app-demo/templates/login.html
+++ b/app-demo/templates/login.html
@@ -52,16 +52,14 @@
       </div>
 
       <div class="adw-box horizontal justify-end" style="margin-top: var(--spacing-m);">
-        <button type="submit" class="adw-button suggested-action {{ 'full-width-button' if not form.registration_url else '' }}">{{ form.submit.label.text }}</button>
+        <button type="submit" class="adw-button suggested-action {{ 'full-width-button' if not site_settings.get('allow_registrations') else '' }}">{{ form.submit.label.text }}</button>
       </div>
-      {# TODO: Add link for registration if available from form object, e.g. form.registration_url #}
-      {# Example:
-      {% if form.registration_url %}
+
+      {% if site_settings.get('allow_registrations', False) %} {# Default to False if setting not present #}
       <div class="adw-box horizontal justify-center" style="margin-top: var(--spacing-m);">
-          <a href="{{ form.registration_url }}" class="adw-link">Don't have an account? Sign up</a>
+          <a href="{{ url_for('auth.register') }}" class="adw-link">Don't have an account? Sign up</a>
       </div>
       {% endif %}
-      #}
     </form>
 </div>
 {% endblock %}

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -12,13 +12,15 @@
             <div class="post-meta-detail">
                 <p class="adw-label body">
                     By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
-                    {% if post.is_published and post.published_at %}
+                    {% if not post.is_published and current_user == post.author %}
+                        (Draft created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>) <span class="adw-label caption draft-indicator">(Draft)</span>
+                    {% elif post.is_published and post.published_at %}
                         on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time> (Published)
                     {% else %}
-                         (Draft created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>)
+                         (Created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>)
                     {% endif %}
                 </p>
-                {% if post.updated_at and post.updated_at != post.created_at and (post.published_at is none or post.updated_at != post.published_at) %}
+                {% if post.updated_at and post.updated_at != post.created_at and (post.published_at is none or post.updated_at != post.published_at) and not (not post.is_published and current_user == post.author and post.updated_at == post.created_at) %}
                     <p class="adw-label caption last-updated">(Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>)</p>
                 {% endif %}
             </div>
@@ -221,11 +223,11 @@
         <h2 id="related-posts-heading" class="adw-title-2">Related Posts</h2>
         <div class="adw-list-box">
             {% for related_post in related_posts %}
-            <a href="{{ url_for('view_post', post_id=related_post.id) }}" class="adw-action-row activatable">
+            <a href="{{ url_for('post.view_post', post_id=related_post.id) }}" class="adw-action-row activatable">
                 <div class="adw-action-row-content">
-                    <span class="adw-action-row-title">{{ related_post.title }}</span>
-                    {% if related_post.author %}
-                    <span class="adw-action-row-subtitle">By {{ related_post.author.username }}</span>
+                    <span class="adw-action-row-title">Post by {{ related_post.author.username }}</span>
+                    {% if related_post.content %}
+                    <span class="adw-action-row-subtitle">{{ related_post.content | striptags | truncate(80) }}</span>
                     {% endif %}
                 </div>
                 <span class="adw-action-row__chevron"></span>

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -169,14 +169,10 @@
                             {# Post title removed, content will be linked in footer or by making card clickable if desired #}
                             <div class="blog-post-card__meta adw-label caption">
                                 {% if not post.is_published and current_user == post.author %}
-                                    <span class="adw-label caption">(Draft)</span> -
+                                    Draft - Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                                 {% elif post.is_published and post.published_at %}
                                     Published: <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% elif not post.is_published %}
-                                    Draft - Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% elif not post.is_published %}
-                                    Draft - Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% else %}
+                                {% else %} {# Fallback for created but not explicitly draft/published with date (should ideally be covered by above) #}
                                     Created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                                 {% endif %}
                             </div>


### PR DESCRIPTION
This commit builds upon the previous removal of post titles and location fields, incorporating further UI refinements identified during a re-audit:

- Corrected display of activities in `feed.html` that previously referenced post titles (e.g., 'liked post', 'commented on post').
- Updated 'Related Posts' section in `post.html` to no longer use post titles.
- Ensured draft status indicators are correctly displayed in `post.html` and `profile.html` after title removal.
- Added a '(Supports Markdown)' hint to content input fields in post creation/editing forms.
- Added a conditional registration link on `login.html` based on site settings.
- Standardized pagination button styling for the current page in `feed.html`.
- General code cleanup in templates related to these changes.