### PR TITLE
Feature: Streamline post creation to immediate publish

### DIFF
--- a/app-demo/forms.py
+++ b/app-demo/forms.py
@@ -60,8 +60,7 @@ class PostForm(FlaskForm):
         'Tags (comma-separated)',
         validators=[Optional(), Length(max=250)]
     )
-    save_draft = SubmitField('Save Draft')
-    publish = SubmitField('Publish')
+    submit = SubmitField('Post') # Single submit button
 
 class ProfileEditForm(FlaskForm):
     full_name = StringField('Display Name', validators=[Optional(), Length(max=120)])

--- a/app-demo/models.py
+++ b/app-demo/models.py
@@ -185,8 +185,10 @@ class Post(db.Model):
         lazy='subquery',
         backref=db.backref('posts', lazy=True)
     )
-    is_published = db.Column(db.Boolean, nullable=False, default=True)
-    published_at = db.Column(db.DateTime, nullable=True)
+    # is_published defaults to True, implying posts are published on creation.
+    # The route logic will handle setting published_at.
+    is_published = db.Column(db.Boolean, nullable=False, default=True, server_default=db.true())
+    published_at = db.Column(db.DateTime, nullable=True) # Set at time of creation by route logic
     # Relationship for top-level comments moved to be defined here
     comments = db.relationship(
         'Comment',

--- a/app-demo/templates/create_post.html
+++ b/app-demo/templates/create_post.html
@@ -65,8 +65,7 @@
         </section>
 
         <div class="adw-box horizontal justify-end adw-box-spacing-s" style="margin-top: var(--spacing-l);" id="create-post-form-actions">
-            {{ form.save_draft(class="adw-button", id="save-draft-button") }}
-            {{ form.publish(class="adw-button suggested-action", id="publish-button") }}
+            {{ form.submit(class="adw-button suggested-action", id="submit-button") }} {# Changed to single submit button #}
             <adw-spinner size="small" active="false" style="margin-left: var(--spacing-xs);"></adw-spinner>
         </div>
     </form>
@@ -79,23 +78,17 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('form.stacked-form');
-    const saveButton = document.getElementById('save-draft-button');
-    const publishButton = document.getElementById('publish-button');
+    const submitButton = document.getElementById('submit-button');
     const actionsContainer = document.getElementById('create-post-form-actions');
     let spinner;
     if (actionsContainer) {
         spinner = actionsContainer.querySelector('adw-spinner');
     }
 
-    if (form && spinner && (saveButton || publishButton)) {
+    if (form && spinner && submitButton) {
         form.addEventListener('submit', function() {
-            // Disable buttons
-            if (saveButton) {
-                saveButton.disabled = true;
-            }
-            if (publishButton) {
-                publishButton.disabled = true;
-            }
+            // Disable button
+            submitButton.disabled = true;
             // Show spinner
             if (spinner) {
                 spinner.setAttribute('active', 'true');

--- a/app-demo/templates/dashboard.html
+++ b/app-demo/templates/dashboard.html
@@ -13,15 +13,15 @@
         {% for post in user_posts %}
         <div class="adw-action-row blog-post-dashboard-item">
             <div class="adw-action-row-content" style="display: flex; flex-direction: column; gap: var(--spacing-xxs);">
-                <h3 class="adw-action-row-title" style="font-size: var(--font-size-large);">{{ post.title }}</h3>
+                <h3 class="adw-action-row-title" style="font-size: var(--font-size-large);">
+                    <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.content | striptags | truncate(80, True) }}</a>
+                </h3>
                 <div class="adw-action-row-subtitle">
-                    Status:
-                    {% if post.is_published %}
-                        <span style="color: var(--success-color);">Published</span>
-                        {% if post.published_at %} (on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d') }}</time>){% endif %}
-                    {% else %}
-                        <span style="color: var(--warning-fg-color);">Draft</span>
-                    {% endif %}
+                    {%- if post.published_at -%}
+                        Published: <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                    {%- else -%}
+                        Created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                    {%- endif -%}
                     <br>
                     Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                 </div>
@@ -30,7 +30,7 @@
                 <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-button flat">View</a>
                 <a href="{{ url_for('post.edit_post', post_id=post.id) }}" class="adw-button">Edit</a>
                 {% set delete_form = delete_forms[post.id] %}
-                <form method="POST" action="{{ url_for('post.delete_post', post_id=post.id) }}" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this post? \\n\\n\'{{ post.title|escapejs }}\'');">
+                <form method="POST" action="{{ url_for('post.delete_post', post_id=post.id) }}" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this post?');">
                     {{ delete_form.hidden_tag() }}
                     <button type="submit" class="adw-button destructive-action">Delete</button>
                 </form>

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -70,8 +70,7 @@
                 {% endif %}
             </div>
             <div class="adw-box horizontal adw-box-spacing-s align-center"> {# Group for right buttons, added align-center for spinner #}
-                {{ form.save_draft(class="adw-button", id="save-draft-button") }}
-                {{ form.publish(class="adw-button suggested-action", id="publish-button") }}
+                {{ form.submit(class="adw-button suggested-action", id="submit-button", value="Update Post") }} {# Changed to single submit button, label "Update Post" #}
                 <adw-spinner size="small" active="false" style="margin-left: var(--spacing-xs);"></adw-spinner>
             </div>
         </div>
@@ -156,10 +155,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Form submission spinner logic
     const form = document.querySelector('form.stacked-form[method="POST"]'); // More specific form selector
-    const saveButton = document.getElementById('save-draft-button');
-    const publishButton = document.getElementById('publish-button');
+    const submitButton = document.getElementById('submit-button');
     const cancelEditButton = document.getElementById('cancel-edit-button');
-    // const deletePostButton = openDialogBtn; // Already defined above
+    // const deletePostButton = openDialogBtn; // Already defined and handled by dialog logic or page navigation
 
     const actionsContainer = document.getElementById('edit-post-form-actions');
     let spinner;
@@ -167,14 +165,12 @@ document.addEventListener('DOMContentLoaded', function() {
         spinner = actionsContainer.querySelector('adw-spinner');
     }
 
-    if (form && spinner) {
+    if (form && spinner && submitButton) { // Ensure submitButton exists
         form.addEventListener('submit', function(event) {
-            // Check which button triggered the submit if possible, or disable all
-            // For simplicity, disable all main action buttons on any submit from this form
-            if (saveButton) saveButton.disabled = true;
-            if (publishButton) publishButton.disabled = true;
-            if (cancelEditButton) cancelEditButton.style.pointerEvents = 'none'; // Disable link
-            if (openDialogBtn) openDialogBtn.disabled = true; // Disable delete button too
+            // Disable all action buttons on form submission
+            submitButton.disabled = true;
+            if (cancelEditButton) cancelEditButton.style.pointerEvents = 'none'; // Disable link behavior
+            if (openDialogBtn) openDialogBtn.disabled = true;
 
             if (spinner) {
                 spinner.setAttribute('active', 'true');

--- a/app-demo/templates/feed.html
+++ b/app-demo/templates/feed.html
@@ -12,8 +12,8 @@
     {% if activities_list and activities_list|length > 0 %}
         <div class="feed-activities-container adw-list-box"> {# Using adw-list-box for simpler activity items, can be changed #}
             {% for activity in activities_list %}
-                {% if activity.type == 'created_post' and activity.target_post and activity.target_post.is_published %}
-                    {# Render 'created_post' as a full post card #}
+                {% if activity.type == 'created_post' and activity.target_post %}
+                    {# Render 'created_post' as a full post card. is_published check removed as posts are now always published. #}
                     <article class="adw-card blog-post-item-card feed-activity-item">
                         <header class="blog-post-card__header">
                             <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -12,15 +12,13 @@
             <div class="post-meta-detail">
                 <p class="adw-label body">
                     By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
-                    {% if not post.is_published and current_user == post.author %}
-                        (Draft created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>) <span class="adw-label caption draft-indicator">(Draft)</span>
-                    {% elif post.is_published and post.published_at %}
-                        on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time> (Published)
-                    {% else %}
-                         (Created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>)
-                    {% endif %}
+                    {%- if post.published_at -%}
+                        on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                    {%- else -%} {# Should not happen for new posts, fallback for old data or if published_at was somehow not set #}
+                        on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                    {%- endif -%}
                 </p>
-                {% if post.updated_at and post.updated_at != post.created_at and (post.published_at is none or post.updated_at != post.published_at) and not (not post.is_published and current_user == post.author and post.updated_at == post.created_at) %}
+                {% if post.updated_at and post.updated_at != (post.published_at or post.created_at) %}
                     <p class="adw-label caption last-updated">(Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>)</p>
                 {% endif %}
             </div>

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -168,13 +168,11 @@
                         <header class="blog-post-card__header">
                             {# Post title removed, content will be linked in footer or by making card clickable if desired #}
                             <div class="blog-post-card__meta adw-label caption">
-                                {% if not post.is_published and current_user == post.author %}
-                                    Draft - Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% elif post.is_published and post.published_at %}
+                                {%- if post.published_at -%}
                                     Published: <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% else %} {# Fallback for created but not explicitly draft/published with date (should ideally be covered by above) #}
+                                {%- else -%} {# Should ideally not happen for new posts, but fallback for old data #}
                                     Created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% endif %}
+                                {%- endif -%}
                             </div>
                         </header>
                         {# No excerpt shown on profile post list for brevity, or could add a short one #}


### PR DESCRIPTION
Removes the 'Save Draft' / 'Publish' workflow for posts. All new posts are now immediately published.

Changes include:
- Simplified `PostForm` to a single submit action.
- Updated create/edit post templates to reflect the single action button.
- Modified `Post` model: `is_published` now defaults to True.
- Updated `post_routes`: `create_post` always publishes; `edit_post` no longer handles draft status.
- Removed draft indicators and related logic from display templates (profile, post view, dashboard, feed).

This change makes the posting experience more direct and aligned with common social media application patterns.