### PR TITLE
Fix: Ensure SASS is installed for SCSS compilation

### DIFF
--- a/build-adwaita-web.sh
+++ b/build-adwaita-web.sh
@@ -52,6 +52,7 @@ mkdir -p "${ADWAITA_WEB_COMPILED_CSS_DIR}"
 
 # Compile SASS to CSS
 echo "--- Compiling SASS to CSS (${SASS_INPUT_FILE} -> ${COMPILED_CSS_FILE_PATH}) ---"
+# Ensure SASS is installed and in PATH (e.g., via `npm install -g sass`)
 # Use SASS from PATH (installed globally via npm)
 SASS_EXEC="sass"
 # Modified to let SASS output directly to stderr for better error visibility with set -e


### PR DESCRIPTION
The SCSS build was failing due to the 'sass' command not being found. This was resolved by installing SASS globally (e.g., `npm install -g sass`).

No SCSS code changes were ultimately needed as the original syntax was correct.

Added a comment to the build script to note the SASS dependency for future reference.