### PR TITLE
Feat: Add subtle drop shadows to listboxes, action rows, and cards

### DIFF
--- a/adwaita-web/scss/_action_row.scss
+++ b/adwaita-web/scss/_action_row.scss
@@ -19,6 +19,10 @@
                                          // If used standalone on a card, card provides bg.
                                          // If within a listbox on a card, listbox provides bg.
   gap: var(--spacing-m); // Use gap for spacing prefix, content, and suffix
+  // Apply subtle shadow to action rows.
+  // If inside a listbox with its own shadow, this might be visually merged or overridden.
+  // This is primarily for standalone action rows or those in flat listboxes.
+  box-shadow: var(--subtle-box-shadow);
 
   &.has-subtitle {
     // Adjust padding for rows with subtitles to achieve ~70px height

--- a/adwaita-web/scss/_card.scss
+++ b/adwaita-web/scss/_card.scss
@@ -28,7 +28,8 @@
   // Box shadow for cards: a subtle outer shadow.
   // For the inner border effect common in boxed lists, that's usually applied to rows within.
   // For a standalone card, it might just have the background and shadow.
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05);
+  // The actual box-shadow is now applied via the @include mixins.apply-card-style;
+  // box-shadow: var(--stronger-card-box-shadow); // This line is effectively handled by the mixin
 
   // If a card is meant to look like a boxed list container, it might also have an effective "inner border"
   // This could be approximated by an inset shadow using --card-shade-color or by styling child elements.
@@ -50,7 +51,8 @@
     }
      &:focus, &:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color), 0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05);
+        // Combine focus ring with the new stronger card shadow
+        box-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color), var(--stronger-card-box-shadow);
     }
   }
 }
@@ -64,7 +66,7 @@
   background-color: var(--card-bg-color);
   color: var(--card-fg-color);
   border-radius: var(--border-radius-large);
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05);
+  box-shadow: var(--stronger-card-box-shadow); // Use the new stronger shadow variable
   text-align: inherit; // Inherit text align from card content if any
   display: block; // Make button behave like a block card
 
@@ -77,7 +79,8 @@
   }
   &:focus, &:focus-visible {
       outline: none;
-      box-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color), 0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05);
+      // Combine focus ring with the new stronger card shadow
+      box-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color), var(--stronger-card-box-shadow);
   }
 
   // Content inside the button should be padded by the card's padding.

--- a/adwaita-web/scss/_listbox.scss
+++ b/adwaita-web/scss/_listbox.scss
@@ -18,6 +18,10 @@
   // Default listbox might have a subtle border or rely on context (e.g. inside a card or scrolled window)
   // For now, let's assume a subtle border similar to other views.
   border: var(--border-width) solid var(--border-color);
+  // Add the new subtle box shadow for default list boxes
+  &:not(.boxed-list):not(.flat) {
+    box-shadow: var(--subtle-box-shadow);
+  }
 
 
   // DEPRECATED: .content class was an old alias for .boxed-list.

--- a/adwaita-web/scss/_mixins.scss
+++ b/adwaita-web/scss/_mixins.scss
@@ -120,6 +120,6 @@
   color: var(--card-fg-color);
   border-radius: var(--border-radius-large); // Libadwaita cards use a larger radius
   padding: var(--spacing-m); // Default padding for a card
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05); // Default card shadow
+  box-shadow: var(--stronger-card-box-shadow); // Use the new stronger shadow variable
   display: block; // Cards are typically block elements
 }

--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -290,6 +290,11 @@ $accent-definitions: (
   --popover-box-shadow-dark: 0 2px 8px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.25); // Darker shadow for dark theme
   --popover-box-shadow: var(--popover-box-shadow-light);
 
+  // General purpose subtle shadow for elements like default list-boxes or action rows
+  --subtle-box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 1px 1px rgba(0,0,0,0.03);
+  // Stronger shadow for cards, as per user request
+  --stronger-card-box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 2px 5px rgba(0,0,0,0.06);
+
 
   --border-radius-small: 4px;
   --border-radius-medium: 6px;
@@ -470,6 +475,10 @@ $accent-definitions: (
     // --border-opacity for dark theme might need adjustment if it's different in libadwaita's high contrast dark.
     // For now, using the same --border-color definition which relies on currentColor.
     --popover-box-shadow: var(--popover-box-shadow-dark);
+
+    // Overrides for new shadows in dark theme
+    --subtle-box-shadow: 0 1px 2px rgba(0,0,0,0.12), 0 1px 1px rgba(0,0,0,0.1);
+    --stronger-card-box-shadow: 0 2px 4px rgba(0,0,0,0.15), 0 3px 7px rgba(0,0,0,0.12);
 
     // Input States for Dark Theme
     --input-readonly-bg-color: #{$input-readonly-bg-color-dark};


### PR DESCRIPTION
Implemented the following changes:
- Defined new CSS custom properties for box shadows:
  - `--subtle-box-shadow` for listboxes and action rows.
  - `--stronger-card-box-shadow` for cards.
  - Values are provided for both light and dark themes.
- Applied `--subtle-box-shadow` to default `.adw-list-box` (excluding .flat and .boxed-list variants).
- Applied `--subtle-box-shadow` to `.adw-action-row`.
- Updated `.adw-card` and the `apply-card-style` mixin to use `--stronger-card-box-shadow`. This also affects `.adw-button.card` and focus states.

These changes aim to bring the appearance of these elements closer to native Adwaita by adding appropriate drop shadows as requested.