### PR TITLE
Fix: Remove non-existent location field from profile edit route

### DIFF
--- a/app-demo/routes/profile_routes.py
+++ b/app-demo/routes/profile_routes.py
@@ -104,7 +104,6 @@ def edit_profile():
             strip=True
         )
         current_user.full_name = form.full_name.data
-        current_user.location = form.location.data
         current_user.website_url = form.website_url.data
         current_user.is_profile_public = form.is_profile_public.data
         current_user.street_address = form.street_address.data


### PR DESCRIPTION
The ProfileEditForm and the User model do not have a 'location' attribute. This commit removes the line attempting to assign form.location.data to current_user.location in the edit_profile route, which was causing an AttributeError.