### PR TITLE
Add missing symbolic icon definitions to SCSS

### DIFF
--- a/adwaita-web/scss/_symbolic_icons.scss
+++ b/adwaita-web/scss/_symbolic_icons.scss
@@ -105,3 +105,4210 @@ $icon-base-path: '../data/icons/symbolic/';
     -webkit-mask-image: url($icon-base-path + 'bookmark-new-symbolic.svg');
     mask-image: url($icon-base-path + 'bookmark-new-symbolic.svg');
 }
+// Generated new icon definitions
+
+.icon-ac-adapter-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'ac-adapter-symbolic.svg');
+  mask-image: url($icon-base-path + 'ac-adapter-symbolic.svg');
+}
+
+.icon-accessories-calculator-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'accessories-calculator-symbolic.svg');
+  mask-image: url($icon-base-path + 'accessories-calculator-symbolic.svg');
+}
+
+.icon-accessories-character-map-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'accessories-character-map-symbolic.svg');
+  mask-image: url($icon-base-path + 'accessories-character-map-symbolic.svg');
+}
+
+.icon-accessories-dictionary-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'accessories-dictionary-symbolic.svg');
+  mask-image: url($icon-base-path + 'accessories-dictionary-symbolic.svg');
+}
+
+.icon-accessories-text-editor-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'accessories-text-editor-symbolic.svg');
+  mask-image: url($icon-base-path + 'accessories-text-editor-symbolic.svg');
+}
+
+.icon-action-unavailable-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'action-unavailable-symbolic.svg');
+  mask-image: url($icon-base-path + 'action-unavailable-symbolic.svg');
+}
+
+.icon-address-book-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'address-book-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'address-book-new-symbolic.svg');
+}
+
+.icon-airplane-mode-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'airplane-mode-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'airplane-mode-disabled-symbolic.svg');
+}
+
+.icon-airplane-mode-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'airplane-mode-symbolic.svg');
+  mask-image: url($icon-base-path + 'airplane-mode-symbolic.svg');
+}
+
+.icon-alarm-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'alarm-symbolic.svg');
+  mask-image: url($icon-base-path + 'alarm-symbolic.svg');
+}
+
+.icon-applets-screenshooter-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applets-screenshooter-symbolic.svg');
+  mask-image: url($icon-base-path + 'applets-screenshooter-symbolic.svg');
+}
+
+.icon-application-certificate-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-certificate-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-certificate-symbolic.svg');
+}
+
+.icon-application-certificate {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-certificate.svg');
+  mask-image: url($icon-base-path + 'application-certificate.svg');
+}
+
+.icon-application-exit-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-exit-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-exit-rtl-symbolic.svg');
+}
+
+.icon-application-exit-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-exit-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'application-exit-symbolic-rtl.svg');
+}
+
+.icon-application-exit-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-exit-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-exit-symbolic.svg');
+}
+
+.icon-application-rss+xml-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-rss+xml-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-rss+xml-symbolic.svg');
+}
+
+.icon-application-x-addon-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-addon-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-x-addon-symbolic.svg');
+}
+
+.icon-application-x-addon {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-addon.svg');
+  mask-image: url($icon-base-path + 'application-x-addon.svg');
+}
+
+.icon-application-x-appliance-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-appliance-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-x-appliance-symbolic.svg');
+}
+
+.icon-application-x-executable-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-executable-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-x-executable-symbolic.svg');
+}
+
+.icon-application-x-executable {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-executable.svg');
+  mask-image: url($icon-base-path + 'application-x-executable.svg');
+}
+
+.icon-application-x-firmware-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-firmware-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-x-firmware-symbolic.svg');
+}
+
+.icon-application-x-firmware {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-firmware.svg');
+  mask-image: url($icon-base-path + 'application-x-firmware.svg');
+}
+
+.icon-application-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-generic.svg');
+  mask-image: url($icon-base-path + 'application-x-generic.svg');
+}
+
+.icon-application-x-sharedlib-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-sharedlib-symbolic.svg');
+  mask-image: url($icon-base-path + 'application-x-sharedlib-symbolic.svg');
+}
+
+.icon-application-x-sharedlib {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'application-x-sharedlib.svg');
+  mask-image: url($icon-base-path + 'application-x-sharedlib.svg');
+}
+
+.icon-applications-engineering-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-engineering-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-engineering-symbolic.svg');
+}
+
+.icon-applications-games-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-games-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-games-symbolic.svg');
+}
+
+.icon-applications-graphics-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-graphics-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-graphics-symbolic.svg');
+}
+
+.icon-applications-multimedia-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-multimedia-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-multimedia-symbolic.svg');
+}
+
+.icon-applications-science-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-science-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-science-symbolic.svg');
+}
+
+.icon-applications-system-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-system-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-system-symbolic.svg');
+}
+
+.icon-applications-utilities-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'applications-utilities-symbolic.svg');
+  mask-image: url($icon-base-path + 'applications-utilities-symbolic.svg');
+}
+
+.icon-appointment-missed-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'appointment-missed-symbolic.svg');
+  mask-image: url($icon-base-path + 'appointment-missed-symbolic.svg');
+}
+
+.icon-appointment-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'appointment-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'appointment-new-symbolic.svg');
+}
+
+.icon-appointment-soon-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'appointment-soon-symbolic.svg');
+  mask-image: url($icon-base-path + 'appointment-soon-symbolic.svg');
+}
+
+.icon-audio-card-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-card-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-card-symbolic.svg');
+}
+
+.icon-audio-headphones-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-headphones-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-headphones-symbolic.svg');
+}
+
+.icon-audio-headphones {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-headphones.svg');
+  mask-image: url($icon-base-path + 'audio-headphones.svg');
+}
+
+.icon-audio-headset-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-headset-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-headset-symbolic.svg');
+}
+
+.icon-audio-headset {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-headset.svg');
+  mask-image: url($icon-base-path + 'audio-headset.svg');
+}
+
+.icon-audio-input-microphone-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-input-microphone-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-input-microphone-symbolic.svg');
+}
+
+.icon-audio-speakers-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-speakers-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-speakers-rtl-symbolic.svg');
+}
+
+.icon-audio-speakers-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-speakers-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'audio-speakers-symbolic-rtl.svg');
+}
+
+.icon-audio-speakers-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-speakers-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-speakers-symbolic.svg');
+}
+
+.icon-audio-volume-high-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-high-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-high-rtl-symbolic.svg');
+}
+
+.icon-audio-volume-high-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-high-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'audio-volume-high-symbolic-rtl.svg');
+}
+
+.icon-audio-volume-high-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-high-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-high-symbolic.svg');
+}
+
+.icon-audio-volume-low-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-low-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-low-rtl-symbolic.svg');
+}
+
+.icon-audio-volume-low-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-low-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'audio-volume-low-symbolic-rtl.svg');
+}
+
+.icon-audio-volume-low-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-low-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-low-symbolic.svg');
+}
+
+.icon-audio-volume-medium-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-medium-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-medium-rtl-symbolic.svg');
+}
+
+.icon-audio-volume-medium-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-medium-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'audio-volume-medium-symbolic-rtl.svg');
+}
+
+.icon-audio-volume-medium-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-medium-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-medium-symbolic.svg');
+}
+
+.icon-audio-volume-muted-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-muted-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-muted-rtl-symbolic.svg');
+}
+
+.icon-audio-volume-muted-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-muted-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'audio-volume-muted-symbolic-rtl.svg');
+}
+
+.icon-audio-volume-muted-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-muted-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-muted-symbolic.svg');
+}
+
+.icon-audio-volume-overamplified-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-overamplified-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-overamplified-rtl-symbolic.svg');
+}
+
+.icon-audio-volume-overamplified-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-overamplified-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'audio-volume-overamplified-symbolic-rtl.svg');
+}
+
+.icon-audio-volume-overamplified-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-volume-overamplified-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-volume-overamplified-symbolic.svg');
+}
+
+.icon-audio-x-generic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-x-generic-symbolic.svg');
+  mask-image: url($icon-base-path + 'audio-x-generic-symbolic.svg');
+}
+
+.icon-audio-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'audio-x-generic.svg');
+  mask-image: url($icon-base-path + 'audio-x-generic.svg');
+}
+
+.icon-auth-face-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'auth-face-symbolic.svg');
+  mask-image: url($icon-base-path + 'auth-face-symbolic.svg');
+}
+
+.icon-auth-fingerprint-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'auth-fingerprint-symbolic.svg');
+  mask-image: url($icon-base-path + 'auth-fingerprint-symbolic.svg');
+}
+
+.icon-auth-sim-locked-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'auth-sim-locked-symbolic.svg');
+  mask-image: url($icon-base-path + 'auth-sim-locked-symbolic.svg');
+}
+
+.icon-auth-sim-missing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'auth-sim-missing-symbolic.svg');
+  mask-image: url($icon-base-path + 'auth-sim-missing-symbolic.svg');
+}
+
+.icon-auth-sim-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'auth-sim-symbolic.svg');
+  mask-image: url($icon-base-path + 'auth-sim-symbolic.svg');
+}
+
+.icon-auth-smartcard-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'auth-smartcard-symbolic.svg');
+  mask-image: url($icon-base-path + 'auth-smartcard-symbolic.svg');
+}
+
+.icon-avatar-default-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'avatar-default-symbolic.svg');
+  mask-image: url($icon-base-path + 'avatar-default-symbolic.svg');
+}
+
+.icon-avatar-default {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'avatar-default.svg');
+  mask-image: url($icon-base-path + 'avatar-default.svg');
+}
+
+.icon-battery-action-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-action-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-action-symbolic.svg');
+}
+
+.icon-battery-caution-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-caution-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-caution-charging-symbolic.svg');
+}
+
+.icon-battery-caution-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-caution-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-caution-symbolic.svg');
+}
+
+.icon-battery-empty-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-empty-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-empty-charging-symbolic.svg');
+}
+
+.icon-battery-empty-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-empty-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-empty-symbolic.svg');
+}
+
+.icon-battery-full-charged-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-full-charged-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-full-charged-symbolic.svg');
+}
+
+.icon-battery-full-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-full-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-full-charging-symbolic.svg');
+}
+
+.icon-battery-full-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-full-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-full-symbolic.svg');
+}
+
+.icon-battery-good-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-good-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-good-charging-symbolic.svg');
+}
+
+.icon-battery-good-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-good-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-good-symbolic.svg');
+}
+
+.icon-battery-level-0-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-0-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-0-charging-symbolic.svg');
+}
+
+.icon-battery-level-0-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-0-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-0-symbolic.svg');
+}
+
+.icon-battery-level-10-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-10-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-10-charging-symbolic.svg');
+}
+
+.icon-battery-level-10-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-10-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-10-symbolic.svg');
+}
+
+.icon-battery-level-100-charged-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-100-charged-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-100-charged-symbolic.svg');
+}
+
+.icon-battery-level-100-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-100-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-100-symbolic.svg');
+}
+
+.icon-battery-level-20-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-20-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-20-charging-symbolic.svg');
+}
+
+.icon-battery-level-20-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-20-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-20-symbolic.svg');
+}
+
+.icon-battery-level-30-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-30-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-30-charging-symbolic.svg');
+}
+
+.icon-battery-level-30-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-30-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-30-symbolic.svg');
+}
+
+.icon-battery-level-40-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-40-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-40-charging-symbolic.svg');
+}
+
+.icon-battery-level-40-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-40-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-40-symbolic.svg');
+}
+
+.icon-battery-level-50-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-50-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-50-charging-symbolic.svg');
+}
+
+.icon-battery-level-50-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-50-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-50-symbolic.svg');
+}
+
+.icon-battery-level-60-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-60-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-60-charging-symbolic.svg');
+}
+
+.icon-battery-level-60-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-60-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-60-symbolic.svg');
+}
+
+.icon-battery-level-70-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-70-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-70-charging-symbolic.svg');
+}
+
+.icon-battery-level-70-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-70-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-70-symbolic.svg');
+}
+
+.icon-battery-level-80-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-80-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-80-charging-symbolic.svg');
+}
+
+.icon-battery-level-80-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-80-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-80-symbolic.svg');
+}
+
+.icon-battery-level-90-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-90-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-90-charging-symbolic.svg');
+}
+
+.icon-battery-level-90-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-level-90-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-level-90-symbolic.svg');
+}
+
+.icon-battery-low-charging-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-low-charging-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-low-charging-symbolic.svg');
+}
+
+.icon-battery-low-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-low-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-low-symbolic.svg');
+}
+
+.icon-battery-missing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-missing-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-missing-symbolic.svg');
+}
+
+.icon-battery-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'battery-symbolic.svg');
+  mask-image: url($icon-base-path + 'battery-symbolic.svg');
+}
+
+.icon-bluetooth-acquiring-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bluetooth-acquiring-symbolic.svg');
+  mask-image: url($icon-base-path + 'bluetooth-acquiring-symbolic.svg');
+}
+
+.icon-bluetooth-active-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bluetooth-active-symbolic.svg');
+  mask-image: url($icon-base-path + 'bluetooth-active-symbolic.svg');
+}
+
+.icon-bluetooth-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bluetooth-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'bluetooth-disabled-symbolic.svg');
+}
+
+.icon-bluetooth-disconnected-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bluetooth-disconnected-symbolic.svg');
+  mask-image: url($icon-base-path + 'bluetooth-disconnected-symbolic.svg');
+}
+
+.icon-bluetooth-hardware-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bluetooth-hardware-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'bluetooth-hardware-disabled-symbolic.svg');
+}
+
+.icon-bluetooth-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bluetooth-symbolic.svg');
+  mask-image: url($icon-base-path + 'bluetooth-symbolic.svg');
+}
+
+.icon-bookmark-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'bookmark-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'bookmark-new-symbolic.svg');
+}
+
+.icon-call-incoming-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'call-incoming-symbolic.svg');
+  mask-image: url($icon-base-path + 'call-incoming-symbolic.svg');
+}
+
+.icon-call-missed-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'call-missed-symbolic.svg');
+  mask-image: url($icon-base-path + 'call-missed-symbolic.svg');
+}
+
+.icon-call-outgoing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'call-outgoing-symbolic.svg');
+  mask-image: url($icon-base-path + 'call-outgoing-symbolic.svg');
+}
+
+.icon-call-start-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'call-start-symbolic.svg');
+  mask-image: url($icon-base-path + 'call-start-symbolic.svg');
+}
+
+.icon-call-stop-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'call-stop-symbolic.svg');
+  mask-image: url($icon-base-path + 'call-stop-symbolic.svg');
+}
+
+.icon-camera-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'camera-disabled-symbolic.svg');
+}
+
+.icon-camera-hardware-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-hardware-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'camera-hardware-disabled-symbolic.svg');
+}
+
+.icon-camera-photo-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-photo-symbolic.svg');
+  mask-image: url($icon-base-path + 'camera-photo-symbolic.svg');
+}
+
+.icon-camera-switch-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-switch-symbolic.svg');
+  mask-image: url($icon-base-path + 'camera-switch-symbolic.svg');
+}
+
+.icon-camera-video-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-video-symbolic.svg');
+  mask-image: url($icon-base-path + 'camera-video-symbolic.svg');
+}
+
+.icon-camera-web-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-web-symbolic.svg');
+  mask-image: url($icon-base-path + 'camera-web-symbolic.svg');
+}
+
+.icon-camera-web {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'camera-web.svg');
+  mask-image: url($icon-base-path + 'camera-web.svg');
+}
+
+.icon-changes-allow-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'changes-allow-symbolic.svg');
+  mask-image: url($icon-base-path + 'changes-allow-symbolic.svg');
+}
+
+.icon-changes-prevent-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'changes-prevent-symbolic.svg');
+  mask-image: url($icon-base-path + 'changes-prevent-symbolic.svg');
+}
+
+.icon-channel-insecure-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'channel-insecure-symbolic.svg');
+  mask-image: url($icon-base-path + 'channel-insecure-symbolic.svg');
+}
+
+.icon-channel-secure-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'channel-secure-symbolic.svg');
+  mask-image: url($icon-base-path + 'channel-secure-symbolic.svg');
+}
+
+.icon-chat-message-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'chat-message-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'chat-message-new-symbolic.svg');
+}
+
+.icon-checkbox-checked-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'checkbox-checked-symbolic.svg');
+  mask-image: url($icon-base-path + 'checkbox-checked-symbolic.svg');
+}
+
+.icon-checkbox-mixed-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'checkbox-mixed-symbolic.svg');
+  mask-image: url($icon-base-path + 'checkbox-mixed-symbolic.svg');
+}
+
+.icon-checkbox-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'checkbox-symbolic.svg');
+  mask-image: url($icon-base-path + 'checkbox-symbolic.svg');
+}
+
+.icon-color-select-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'color-select-symbolic.svg');
+  mask-image: url($icon-base-path + 'color-select-symbolic.svg');
+}
+
+.icon-colorimeter-colorhug-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'colorimeter-colorhug-symbolic.svg');
+  mask-image: url($icon-base-path + 'colorimeter-colorhug-symbolic.svg');
+}
+
+.icon-computer-apple-ipad-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'computer-apple-ipad-symbolic.svg');
+  mask-image: url($icon-base-path + 'computer-apple-ipad-symbolic.svg');
+}
+
+.icon-computer-fail-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'computer-fail-symbolic.svg');
+  mask-image: url($icon-base-path + 'computer-fail-symbolic.svg');
+}
+
+.icon-computer-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'computer-symbolic.svg');
+  mask-image: url($icon-base-path + 'computer-symbolic.svg');
+}
+
+.icon-computer {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'computer.svg');
+  mask-image: url($icon-base-path + 'computer.svg');
+}
+
+.icon-contact-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'contact-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'contact-new-symbolic.svg');
+}
+
+.icon-content-loading-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'content-loading-symbolic.svg');
+  mask-image: url($icon-base-path + 'content-loading-symbolic.svg');
+}
+
+.icon-daytime-sunrise-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'daytime-sunrise-symbolic.svg');
+  mask-image: url($icon-base-path + 'daytime-sunrise-symbolic.svg');
+}
+
+.icon-daytime-sunset-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'daytime-sunset-symbolic.svg');
+  mask-image: url($icon-base-path + 'daytime-sunset-symbolic.svg');
+}
+
+.icon-dialog-error-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'dialog-error-symbolic.svg');
+  mask-image: url($icon-base-path + 'dialog-error-symbolic.svg');
+}
+
+.icon-dialog-information-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'dialog-information-symbolic.svg');
+  mask-image: url($icon-base-path + 'dialog-information-symbolic.svg');
+}
+
+.icon-dialog-password-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'dialog-password-symbolic.svg');
+  mask-image: url($icon-base-path + 'dialog-password-symbolic.svg');
+}
+
+.icon-dialog-question-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'dialog-question-symbolic.svg');
+  mask-image: url($icon-base-path + 'dialog-question-symbolic.svg');
+}
+
+.icon-dialog-warning-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'dialog-warning-symbolic.svg');
+  mask-image: url($icon-base-path + 'dialog-warning-symbolic.svg');
+}
+
+.icon-display-brightness-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'display-brightness-symbolic.svg');
+  mask-image: url($icon-base-path + 'display-brightness-symbolic.svg');
+}
+
+.icon-display-projector-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'display-projector-symbolic.svg');
+  mask-image: url($icon-base-path + 'display-projector-symbolic.svg');
+}
+
+.icon-document-edit-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-edit-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-edit-symbolic.svg');
+}
+
+.icon-document-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-new-symbolic.svg');
+}
+
+.icon-document-open-recent-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-open-recent-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-open-recent-symbolic.svg');
+}
+
+.icon-document-open-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-open-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-open-symbolic.svg');
+}
+
+.icon-document-page-setup-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-page-setup-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-page-setup-symbolic.svg');
+}
+
+.icon-document-print-preview-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-print-preview-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-print-preview-symbolic.svg');
+}
+
+.icon-document-print-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-print-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-print-symbolic.svg');
+}
+
+.icon-document-properties-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-properties-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-properties-symbolic.svg');
+}
+
+.icon-document-revert-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-revert-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-revert-rtl-symbolic.svg');
+}
+
+.icon-document-revert-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-revert-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'document-revert-symbolic-rtl.svg');
+}
+
+.icon-document-revert-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-revert-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-revert-symbolic.svg');
+}
+
+.icon-document-save-as-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-save-as-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-save-as-symbolic.svg');
+}
+
+.icon-document-save-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-save-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-save-symbolic.svg');
+}
+
+.icon-document-send-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'document-send-symbolic.svg');
+  mask-image: url($icon-base-path + 'document-send-symbolic.svg');
+}
+
+.icon-drive-harddisk-ieee1394-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-harddisk-ieee1394-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-harddisk-ieee1394-symbolic.svg');
+}
+
+.icon-drive-harddisk-solidstate-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-harddisk-solidstate-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-harddisk-solidstate-symbolic.svg');
+}
+
+.icon-drive-harddisk-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-harddisk-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-harddisk-symbolic.svg');
+}
+
+.icon-drive-harddisk-system-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-harddisk-system-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-harddisk-system-symbolic.svg');
+}
+
+.icon-drive-harddisk-usb-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-harddisk-usb-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-harddisk-usb-symbolic.svg');
+}
+
+.icon-drive-harddisk {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-harddisk.svg');
+  mask-image: url($icon-base-path + 'drive-harddisk.svg');
+}
+
+.icon-drive-multidisk-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-multidisk-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-multidisk-symbolic.svg');
+}
+
+.icon-drive-multidisk {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-multidisk.svg');
+  mask-image: url($icon-base-path + 'drive-multidisk.svg');
+}
+
+.icon-drive-optical-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-optical-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-optical-symbolic.svg');
+}
+
+.icon-drive-optical {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-optical.svg');
+  mask-image: url($icon-base-path + 'drive-optical.svg');
+}
+
+.icon-drive-removable-media-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-removable-media-symbolic.svg');
+  mask-image: url($icon-base-path + 'drive-removable-media-symbolic.svg');
+}
+
+.icon-drive-removable-media {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'drive-removable-media.svg');
+  mask-image: url($icon-base-path + 'drive-removable-media.svg');
+}
+
+.icon-ebook-reader {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'ebook-reader.svg');
+  mask-image: url($icon-base-path + 'ebook-reader.svg');
+}
+
+.icon-edit-clear-all-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-clear-all-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-clear-all-symbolic.svg');
+}
+
+.icon-edit-clear-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-clear-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-clear-rtl-symbolic.svg');
+}
+
+.icon-edit-clear-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-clear-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'edit-clear-symbolic-rtl.svg');
+}
+
+.icon-edit-clear-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-clear-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-clear-symbolic.svg');
+}
+
+.icon-edit-copy-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-copy-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-copy-symbolic.svg');
+}
+
+.icon-edit-cut-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-cut-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-cut-symbolic.svg');
+}
+
+.icon-edit-delete-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-delete-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-delete-symbolic.svg');
+}
+
+.icon-edit-find-replace-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-find-replace-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-find-replace-symbolic.svg');
+}
+
+.icon-edit-find-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-find-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-find-symbolic.svg');
+}
+
+.icon-edit-paste-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-paste-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-paste-symbolic.svg');
+}
+
+.icon-edit-redo-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-redo-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'edit-redo-symbolic-rtl.svg');
+}
+
+.icon-edit-redo-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-redo-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-redo-symbolic.svg');
+}
+
+.icon-edit-select-all-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-select-all-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-select-all-symbolic.svg');
+}
+
+.icon-edit-select-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-select-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-select-symbolic.svg');
+}
+
+.icon-edit-undo-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-undo-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'edit-undo-symbolic-rtl.svg');
+}
+
+.icon-edit-undo-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'edit-undo-symbolic.svg');
+  mask-image: url($icon-base-path + 'edit-undo-symbolic.svg');
+}
+
+.icon-emoji-activities-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-activities-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-activities-symbolic.svg');
+}
+
+.icon-emoji-body-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-body-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-body-symbolic.svg');
+}
+
+.icon-emoji-flags-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-flags-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-flags-symbolic.svg');
+}
+
+.icon-emoji-food-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-food-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-food-symbolic.svg');
+}
+
+.icon-emoji-nature-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-nature-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-nature-symbolic.svg');
+}
+
+.icon-emoji-objects-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-objects-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-objects-symbolic.svg');
+}
+
+.icon-emoji-people-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-people-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-people-symbolic.svg');
+}
+
+.icon-emoji-recent-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-recent-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-recent-symbolic.svg');
+}
+
+.icon-emoji-symbols-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-symbols-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-symbols-symbolic.svg');
+}
+
+.icon-emoji-travel-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emoji-travel-symbolic.svg');
+  mask-image: url($icon-base-path + 'emoji-travel-symbolic.svg');
+}
+
+.icon-emote-love-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'emote-love-symbolic.svg');
+  mask-image: url($icon-base-path + 'emote-love-symbolic.svg');
+}
+
+.icon-error-correct-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'error-correct-symbolic.svg');
+  mask-image: url($icon-base-path + 'error-correct-symbolic.svg');
+}
+
+.icon-face-angel-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-angel-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-angel-symbolic.svg');
+}
+
+.icon-face-angry-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-angry-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-angry-symbolic.svg');
+}
+
+.icon-face-confused-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-confused-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-confused-symbolic.svg');
+}
+
+.icon-face-cool-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-cool-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-cool-symbolic.svg');
+}
+
+.icon-face-crying-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-crying-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-crying-symbolic.svg');
+}
+
+.icon-face-devilish-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-devilish-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-devilish-symbolic.svg');
+}
+
+.icon-face-embarrassed-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-embarrassed-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-embarrassed-symbolic.svg');
+}
+
+.icon-face-glasses-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-glasses-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-glasses-symbolic.svg');
+}
+
+.icon-face-kiss-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-kiss-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-kiss-symbolic.svg');
+}
+
+.icon-face-laugh-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-laugh-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-laugh-symbolic.svg');
+}
+
+.icon-face-monkey-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-monkey-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-monkey-symbolic.svg');
+}
+
+.icon-face-plain-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-plain-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-plain-symbolic.svg');
+}
+
+.icon-face-raspberry-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-raspberry-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-raspberry-symbolic.svg');
+}
+
+.icon-face-sad-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-sad-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-sad-symbolic.svg');
+}
+
+.icon-face-shutmouth-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-shutmouth-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-shutmouth-symbolic.svg');
+}
+
+.icon-face-sick-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-sick-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-sick-symbolic.svg');
+}
+
+.icon-face-smile-big-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-smile-big-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-smile-big-symbolic.svg');
+}
+
+.icon-face-smile-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-smile-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-smile-symbolic.svg');
+}
+
+.icon-face-smirk-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-smirk-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-smirk-symbolic.svg');
+}
+
+.icon-face-surprise-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-surprise-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-surprise-symbolic.svg');
+}
+
+.icon-face-tired-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-tired-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-tired-symbolic.svg');
+}
+
+.icon-face-uncertain-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-uncertain-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-uncertain-symbolic.svg');
+}
+
+.icon-face-wink-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-wink-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-wink-symbolic.svg');
+}
+
+.icon-face-worried-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-worried-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-worried-symbolic.svg');
+}
+
+.icon-face-yawn-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'face-yawn-symbolic.svg');
+  mask-image: url($icon-base-path + 'face-yawn-symbolic.svg');
+}
+
+.icon-find-location-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'find-location-symbolic.svg');
+  mask-image: url($icon-base-path + 'find-location-symbolic.svg');
+}
+
+.icon-focus-legacy-systray-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'focus-legacy-systray-symbolic.svg');
+  mask-image: url($icon-base-path + 'focus-legacy-systray-symbolic.svg');
+}
+
+.icon-focus-top-bar-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'focus-top-bar-symbolic.svg');
+  mask-image: url($icon-base-path + 'focus-top-bar-symbolic.svg');
+}
+
+.icon-focus-windows-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'focus-windows-symbolic.svg');
+  mask-image: url($icon-base-path + 'focus-windows-symbolic.svg');
+}
+
+.icon-folder-documents-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-documents-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-documents-symbolic.svg');
+}
+
+.icon-folder-documents {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-documents.svg');
+  mask-image: url($icon-base-path + 'folder-documents.svg');
+}
+
+.icon-folder-download-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-download-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-download-symbolic.svg');
+}
+
+.icon-folder-download {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-download.svg');
+  mask-image: url($icon-base-path + 'folder-download.svg');
+}
+
+.icon-folder-drag-accept-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-drag-accept-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-drag-accept-symbolic.svg');
+}
+
+.icon-folder-drag-accept {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-drag-accept.svg');
+  mask-image: url($icon-base-path + 'folder-drag-accept.svg');
+}
+
+.icon-folder-music-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-music-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-music-symbolic.svg');
+}
+
+.icon-folder-music {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-music.svg');
+  mask-image: url($icon-base-path + 'folder-music.svg');
+}
+
+.icon-folder-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-new-symbolic.svg');
+}
+
+.icon-folder-open-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-open-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-open-symbolic.svg');
+}
+
+.icon-folder-open {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-open.svg');
+  mask-image: url($icon-base-path + 'folder-open.svg');
+}
+
+.icon-folder-pictures-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-pictures-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-pictures-symbolic.svg');
+}
+
+.icon-folder-pictures {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-pictures.svg');
+  mask-image: url($icon-base-path + 'folder-pictures.svg');
+}
+
+.icon-folder-publicshare-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-publicshare-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-publicshare-symbolic.svg');
+}
+
+.icon-folder-publicshare {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-publicshare.svg');
+  mask-image: url($icon-base-path + 'folder-publicshare.svg');
+}
+
+.icon-folder-remote-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-remote-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-remote-symbolic.svg');
+}
+
+.icon-folder-remote {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-remote.svg');
+  mask-image: url($icon-base-path + 'folder-remote.svg');
+}
+
+.icon-folder-saved-search-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-saved-search-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-saved-search-symbolic.svg');
+}
+
+.icon-folder-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-symbolic.svg');
+}
+
+.icon-folder-templates-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-templates-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-templates-symbolic.svg');
+}
+
+.icon-folder-templates {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-templates.svg');
+  mask-image: url($icon-base-path + 'folder-templates.svg');
+}
+
+.icon-folder-videos-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-videos-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-videos-symbolic.svg');
+}
+
+.icon-folder-videos {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-videos.svg');
+  mask-image: url($icon-base-path + 'folder-videos.svg');
+}
+
+.icon-folder-visiting-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder-visiting-symbolic.svg');
+  mask-image: url($icon-base-path + 'folder-visiting-symbolic.svg');
+}
+
+.icon-folder {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'folder.svg');
+  mask-image: url($icon-base-path + 'folder.svg');
+}
+
+.icon-font-select-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'font-select-symbolic.svg');
+  mask-image: url($icon-base-path + 'font-select-symbolic.svg');
+}
+
+.icon-font-x-generic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'font-x-generic-symbolic.svg');
+  mask-image: url($icon-base-path + 'font-x-generic-symbolic.svg');
+}
+
+.icon-font-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'font-x-generic.svg');
+  mask-image: url($icon-base-path + 'font-x-generic.svg');
+}
+
+.icon-format-indent-less-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-indent-less-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-indent-less-rtl-symbolic.svg');
+}
+
+.icon-format-indent-less-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-indent-less-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'format-indent-less-symbolic-rtl.svg');
+}
+
+.icon-format-indent-less-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-indent-less-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-indent-less-symbolic.svg');
+}
+
+.icon-format-indent-more-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-indent-more-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-indent-more-rtl-symbolic.svg');
+}
+
+.icon-format-indent-more-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-indent-more-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'format-indent-more-symbolic-rtl.svg');
+}
+
+.icon-format-indent-more-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-indent-more-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-indent-more-symbolic.svg');
+}
+
+.icon-format-justify-center-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-justify-center-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-justify-center-symbolic.svg');
+}
+
+.icon-format-justify-fill-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-justify-fill-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-justify-fill-symbolic.svg');
+}
+
+.icon-format-justify-left-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-justify-left-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-justify-left-symbolic.svg');
+}
+
+.icon-format-justify-right-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-justify-right-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-justify-right-symbolic.svg');
+}
+
+.icon-format-text-bold-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-bold-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-bold-symbolic.svg');
+}
+
+.icon-format-text-direction-ltr-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-direction-ltr-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-direction-ltr-symbolic.svg');
+}
+
+.icon-format-text-direction-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-direction-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-direction-rtl-symbolic.svg');
+}
+
+.icon-format-text-direction-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-direction-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'format-text-direction-symbolic-rtl.svg');
+}
+
+.icon-format-text-direction-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-direction-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-direction-symbolic.svg');
+}
+
+.icon-format-text-italic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-italic-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-italic-symbolic.svg');
+}
+
+.icon-format-text-plaintext-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-plaintext-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-plaintext-symbolic.svg');
+}
+
+.icon-format-text-rich-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-rich-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-rich-symbolic.svg');
+}
+
+.icon-format-text-strikethrough-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-strikethrough-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-strikethrough-symbolic.svg');
+}
+
+.icon-format-text-underline-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'format-text-underline-symbolic.svg');
+  mask-image: url($icon-base-path + 'format-text-underline-symbolic.svg');
+}
+
+.icon-gnome-power-manager-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'gnome-power-manager-symbolic.svg');
+  mask-image: url($icon-base-path + 'gnome-power-manager-symbolic.svg');
+}
+
+.icon-go-bottom-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-bottom-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-bottom-symbolic.svg');
+}
+
+.icon-go-down-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-down-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-down-symbolic.svg');
+}
+
+.icon-go-first-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-first-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'go-first-symbolic-rtl.svg');
+}
+
+.icon-go-first-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-first-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-first-symbolic.svg');
+}
+
+.icon-go-home-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-home-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-home-symbolic.svg');
+}
+
+.icon-go-jump-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-jump-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-jump-rtl-symbolic.svg');
+}
+
+.icon-go-jump-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-jump-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'go-jump-symbolic-rtl.svg');
+}
+
+.icon-go-jump-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-jump-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-jump-symbolic.svg');
+}
+
+.icon-go-last-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-last-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'go-last-symbolic-rtl.svg');
+}
+
+.icon-go-last-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-last-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-last-symbolic.svg');
+}
+
+.icon-go-next-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-next-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'go-next-symbolic-rtl.svg');
+}
+
+.icon-go-next-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-next-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-next-symbolic.svg');
+}
+
+.icon-go-previous-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-previous-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'go-previous-symbolic-rtl.svg');
+}
+
+.icon-go-previous-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-previous-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-previous-symbolic.svg');
+}
+
+.icon-go-top-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-top-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-top-symbolic.svg');
+}
+
+.icon-go-up-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'go-up-symbolic.svg');
+  mask-image: url($icon-base-path + 'go-up-symbolic.svg');
+}
+
+.icon-goa-panel-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'goa-panel-symbolic.svg');
+  mask-image: url($icon-base-path + 'goa-panel-symbolic.svg');
+}
+
+.icon-help-about-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'help-about-symbolic.svg');
+  mask-image: url($icon-base-path + 'help-about-symbolic.svg');
+}
+
+.icon-help-browser-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'help-browser-symbolic.svg');
+  mask-image: url($icon-base-path + 'help-browser-symbolic.svg');
+}
+
+.icon-help-contents-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'help-contents-symbolic.svg');
+  mask-image: url($icon-base-path + 'help-contents-symbolic.svg');
+}
+
+.icon-help-faq-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'help-faq-symbolic.svg');
+  mask-image: url($icon-base-path + 'help-faq-symbolic.svg');
+}
+
+.icon-image-loading-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'image-loading-symbolic.svg');
+  mask-image: url($icon-base-path + 'image-loading-symbolic.svg');
+}
+
+.icon-image-loading {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'image-loading.svg');
+  mask-image: url($icon-base-path + 'image-loading.svg');
+}
+
+.icon-image-missing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'image-missing-symbolic.svg');
+  mask-image: url($icon-base-path + 'image-missing-symbolic.svg');
+}
+
+.icon-image-missing {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'image-missing.svg');
+  mask-image: url($icon-base-path + 'image-missing.svg');
+}
+
+.icon-image-x-generic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'image-x-generic-symbolic.svg');
+  mask-image: url($icon-base-path + 'image-x-generic-symbolic.svg');
+}
+
+.icon-image-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'image-x-generic.svg');
+  mask-image: url($icon-base-path + 'image-x-generic.svg');
+}
+
+.icon-inode-directory-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'inode-directory-symbolic.svg');
+  mask-image: url($icon-base-path + 'inode-directory-symbolic.svg');
+}
+
+.icon-inode-directory {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'inode-directory.svg');
+  mask-image: url($icon-base-path + 'inode-directory.svg');
+}
+
+.icon-inode-symlink {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'inode-symlink.svg');
+  mask-image: url($icon-base-path + 'inode-symlink.svg');
+}
+
+.icon-input-dialpad-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-dialpad-symbolic.svg');
+  mask-image: url($icon-base-path + 'input-dialpad-symbolic.svg');
+}
+
+.icon-input-gaming-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-gaming-symbolic.svg');
+  mask-image: url($icon-base-path + 'input-gaming-symbolic.svg');
+}
+
+.icon-input-gaming {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-gaming.svg');
+  mask-image: url($icon-base-path + 'input-gaming.svg');
+}
+
+.icon-input-keyboard-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-keyboard-symbolic.svg');
+  mask-image: url($icon-base-path + 'input-keyboard-symbolic.svg');
+}
+
+.icon-input-keyboard {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-keyboard.svg');
+  mask-image: url($icon-base-path + 'input-keyboard.svg');
+}
+
+.icon-input-mouse-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-mouse-symbolic.svg');
+  mask-image: url($icon-base-path + 'input-mouse-symbolic.svg');
+}
+
+.icon-input-mouse {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-mouse.svg');
+  mask-image: url($icon-base-path + 'input-mouse.svg');
+}
+
+.icon-input-tablet-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-tablet-symbolic.svg');
+  mask-image: url($icon-base-path + 'input-tablet-symbolic.svg');
+}
+
+.icon-input-tablet {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-tablet.svg');
+  mask-image: url($icon-base-path + 'input-tablet.svg');
+}
+
+.icon-input-touchpad-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'input-touchpad-symbolic.svg');
+  mask-image: url($icon-base-path + 'input-touchpad-symbolic.svg');
+}
+
+.icon-insert-image-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'insert-image-symbolic.svg');
+  mask-image: url($icon-base-path + 'insert-image-symbolic.svg');
+}
+
+.icon-insert-link-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'insert-link-symbolic.svg');
+  mask-image: url($icon-base-path + 'insert-link-symbolic.svg');
+}
+
+.icon-insert-object-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'insert-object-symbolic.svg');
+  mask-image: url($icon-base-path + 'insert-object-symbolic.svg');
+}
+
+.icon-insert-text-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'insert-text-symbolic.svg');
+  mask-image: url($icon-base-path + 'insert-text-symbolic.svg');
+}
+
+.icon-keyboard-brightness-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'keyboard-brightness-symbolic.svg');
+  mask-image: url($icon-base-path + 'keyboard-brightness-symbolic.svg');
+}
+
+.icon-list-add-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'list-add-symbolic.svg');
+  mask-image: url($icon-base-path + 'list-add-symbolic.svg');
+}
+
+.icon-list-drag-handle-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'list-drag-handle-symbolic.svg');
+  mask-image: url($icon-base-path + 'list-drag-handle-symbolic.svg');
+}
+
+.icon-list-remove-all-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'list-remove-all-symbolic.svg');
+  mask-image: url($icon-base-path + 'list-remove-all-symbolic.svg');
+}
+
+.icon-list-remove-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'list-remove-symbolic.svg');
+  mask-image: url($icon-base-path + 'list-remove-symbolic.svg');
+}
+
+.icon-location-services-active-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'location-services-active-symbolic.svg');
+  mask-image: url($icon-base-path + 'location-services-active-symbolic.svg');
+}
+
+.icon-location-services-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'location-services-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'location-services-disabled-symbolic.svg');
+}
+
+.icon-mail-attachment-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-attachment-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-attachment-symbolic.svg');
+}
+
+.icon-mail-forward-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-forward-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'mail-forward-symbolic-rtl.svg');
+}
+
+.icon-mail-forward-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-forward-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-forward-symbolic.svg');
+}
+
+.icon-mail-mark-important-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-mark-important-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-mark-important-symbolic.svg');
+}
+
+.icon-mail-mark-junk-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-mark-junk-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-mark-junk-symbolic.svg');
+}
+
+.icon-mail-mark-notjunk-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-mark-notjunk-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-mark-notjunk-symbolic.svg');
+}
+
+.icon-mail-message-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-message-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-message-new-symbolic.svg');
+}
+
+.icon-mail-read-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-read-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-read-symbolic.svg');
+}
+
+.icon-mail-replied-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-replied-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-replied-rtl-symbolic.svg');
+}
+
+.icon-mail-replied-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-replied-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'mail-replied-symbolic-rtl.svg');
+}
+
+.icon-mail-replied-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-replied-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-replied-symbolic.svg');
+}
+
+.icon-mail-reply-all-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-reply-all-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-reply-all-rtl-symbolic.svg');
+}
+
+.icon-mail-reply-all-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-reply-all-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'mail-reply-all-symbolic-rtl.svg');
+}
+
+.icon-mail-reply-all-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-reply-all-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-reply-all-symbolic.svg');
+}
+
+.icon-mail-reply-sender-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-reply-sender-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'mail-reply-sender-symbolic-rtl.svg');
+}
+
+.icon-mail-reply-sender-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-reply-sender-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-reply-sender-symbolic.svg');
+}
+
+.icon-mail-send-receive-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-send-receive-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-send-receive-symbolic.svg');
+}
+
+.icon-mail-send-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-send-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-send-symbolic.svg');
+}
+
+.icon-mail-unread-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mail-unread-symbolic.svg');
+  mask-image: url($icon-base-path + 'mail-unread-symbolic.svg');
+}
+
+.icon-mark-location-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'mark-location-symbolic.svg');
+  mask-image: url($icon-base-path + 'mark-location-symbolic.svg');
+}
+
+.icon-media-eject-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-eject-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-eject-symbolic.svg');
+}
+
+.icon-media-flash-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-flash-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-flash-symbolic.svg');
+}
+
+.icon-media-flash {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-flash.svg');
+  mask-image: url($icon-base-path + 'media-flash.svg');
+}
+
+.icon-media-floppy-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-floppy-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-floppy-symbolic.svg');
+}
+
+.icon-media-optical-bd-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-optical-bd-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-optical-bd-symbolic.svg');
+}
+
+.icon-media-optical-cd-audio-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-optical-cd-audio-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-optical-cd-audio-symbolic.svg');
+}
+
+.icon-media-optical-cd-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-optical-cd-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-optical-cd-symbolic.svg');
+}
+
+.icon-media-optical-dvd-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-optical-dvd-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-optical-dvd-symbolic.svg');
+}
+
+.icon-media-optical-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-optical-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-optical-symbolic.svg');
+}
+
+.icon-media-optical {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-optical.svg');
+  mask-image: url($icon-base-path + 'media-optical.svg');
+}
+
+.icon-media-playback-pause-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playback-pause-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playback-pause-symbolic.svg');
+}
+
+.icon-media-playback-start-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playback-start-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playback-start-symbolic.svg');
+}
+
+.icon-media-playback-stop-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playback-stop-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playback-stop-symbolic.svg');
+}
+
+.icon-media-playlist-consecutive-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playlist-consecutive-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playlist-consecutive-symbolic.svg');
+}
+
+.icon-media-playlist-repeat-song-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playlist-repeat-song-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playlist-repeat-song-symbolic.svg');
+}
+
+.icon-media-playlist-repeat-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playlist-repeat-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playlist-repeat-symbolic.svg');
+}
+
+.icon-media-playlist-shuffle-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-playlist-shuffle-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-playlist-shuffle-symbolic.svg');
+}
+
+.icon-media-record-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-record-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-record-symbolic.svg');
+}
+
+.icon-media-removable-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-removable-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-removable-symbolic.svg');
+}
+
+.icon-media-removable {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-removable.svg');
+  mask-image: url($icon-base-path + 'media-removable.svg');
+}
+
+.icon-media-seek-backward-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-seek-backward-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'media-seek-backward-symbolic-rtl.svg');
+}
+
+.icon-media-seek-backward-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-seek-backward-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-seek-backward-symbolic.svg');
+}
+
+.icon-media-seek-forward-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-seek-forward-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'media-seek-forward-symbolic-rtl.svg');
+}
+
+.icon-media-seek-forward-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-seek-forward-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-seek-forward-symbolic.svg');
+}
+
+.icon-media-skip-backward-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-skip-backward-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'media-skip-backward-symbolic-rtl.svg');
+}
+
+.icon-media-skip-backward-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-skip-backward-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-skip-backward-symbolic.svg');
+}
+
+.icon-media-skip-forward-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-skip-forward-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'media-skip-forward-symbolic-rtl.svg');
+}
+
+.icon-media-skip-forward-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-skip-forward-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-skip-forward-symbolic.svg');
+}
+
+.icon-media-tape-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-tape-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-tape-symbolic.svg');
+}
+
+.icon-media-view-subtitles-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-view-subtitles-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-view-subtitles-symbolic.svg');
+}
+
+.icon-media-zip-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'media-zip-symbolic.svg');
+  mask-image: url($icon-base-path + 'media-zip-symbolic.svg');
+}
+
+.icon-microphone-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'microphone-disabled-symbolic.svg');
+}
+
+.icon-microphone-hardware-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone-hardware-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'microphone-hardware-disabled-symbolic.svg');
+}
+
+.icon-microphone-sensitivity-high-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone-sensitivity-high-symbolic.svg');
+  mask-image: url($icon-base-path + 'microphone-sensitivity-high-symbolic.svg');
+}
+
+.icon-microphone-sensitivity-low-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone-sensitivity-low-symbolic.svg');
+  mask-image: url($icon-base-path + 'microphone-sensitivity-low-symbolic.svg');
+}
+
+.icon-microphone-sensitivity-medium-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone-sensitivity-medium-symbolic.svg');
+  mask-image: url($icon-base-path + 'microphone-sensitivity-medium-symbolic.svg');
+}
+
+.icon-microphone-sensitivity-muted-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone-sensitivity-muted-symbolic.svg');
+  mask-image: url($icon-base-path + 'microphone-sensitivity-muted-symbolic.svg');
+}
+
+.icon-microphone {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'microphone.svg');
+  mask-image: url($icon-base-path + 'microphone.svg');
+}
+
+.icon-model {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'model.svg');
+  mask-image: url($icon-base-path + 'model.svg');
+}
+
+.icon-modem-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'modem-symbolic.svg');
+  mask-image: url($icon-base-path + 'modem-symbolic.svg');
+}
+
+.icon-multimedia-player-apple-ipod-touch-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'multimedia-player-apple-ipod-touch-symbolic.svg');
+  mask-image: url($icon-base-path + 'multimedia-player-apple-ipod-touch-symbolic.svg');
+}
+
+.icon-multimedia-player-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'multimedia-player-symbolic.svg');
+  mask-image: url($icon-base-path + 'multimedia-player-symbolic.svg');
+}
+
+.icon-multimedia-volume-control-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'multimedia-volume-control-symbolic.svg');
+  mask-image: url($icon-base-path + 'multimedia-volume-control-symbolic.svg');
+}
+
+.icon-network-cellular-2g-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-2g-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-2g-symbolic.svg');
+}
+
+.icon-network-cellular-3g-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-3g-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-3g-symbolic.svg');
+}
+
+.icon-network-cellular-4g-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-4g-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-4g-symbolic.svg');
+}
+
+.icon-network-cellular-5g-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-5g-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-5g-symbolic.svg');
+}
+
+.icon-network-cellular-acquiring-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-acquiring-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-acquiring-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-acquiring-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-acquiring-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-acquiring-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-acquiring-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-acquiring-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-acquiring-symbolic.svg');
+}
+
+.icon-network-cellular-connected-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-connected-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-connected-symbolic.svg');
+}
+
+.icon-network-cellular-disabled-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-disabled-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-disabled-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-disabled-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-disabled-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-disabled-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-disabled-symbolic.svg');
+}
+
+.icon-network-cellular-edge-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-edge-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-edge-symbolic.svg');
+}
+
+.icon-network-cellular-gprs-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-gprs-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-gprs-symbolic.svg');
+}
+
+.icon-network-cellular-hardware-disabled-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-hardware-disabled-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-hardware-disabled-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-hardware-disabled-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-hardware-disabled-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-hardware-disabled-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-hardware-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-hardware-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-hardware-disabled-symbolic.svg');
+}
+
+.icon-network-cellular-hspa-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-hspa-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-hspa-symbolic.svg');
+}
+
+.icon-network-cellular-no-route-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-no-route-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-no-route-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-no-route-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-no-route-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-no-route-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-no-route-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-no-route-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-no-route-symbolic.svg');
+}
+
+.icon-network-cellular-offline-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-offline-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-offline-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-offline-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-offline-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-offline-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-offline-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-offline-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-offline-symbolic.svg');
+}
+
+.icon-network-cellular-signal-excellent-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-excellent-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-excellent-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-signal-excellent-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-excellent-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-excellent-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-signal-excellent-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-excellent-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-excellent-symbolic.svg');
+}
+
+.icon-network-cellular-signal-good-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-good-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-good-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-signal-good-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-good-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-good-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-signal-good-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-good-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-good-symbolic.svg');
+}
+
+.icon-network-cellular-signal-none-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-none-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-none-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-signal-none-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-none-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-none-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-signal-none-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-none-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-none-symbolic.svg');
+}
+
+.icon-network-cellular-signal-ok-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-ok-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-ok-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-signal-ok-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-ok-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-ok-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-signal-ok-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-ok-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-ok-symbolic.svg');
+}
+
+.icon-network-cellular-signal-weak-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-weak-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-weak-rtl-symbolic.svg');
+}
+
+.icon-network-cellular-signal-weak-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-weak-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-weak-symbolic-rtl.svg');
+}
+
+.icon-network-cellular-signal-weak-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-signal-weak-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-signal-weak-symbolic.svg');
+}
+
+.icon-network-cellular-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-cellular-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-cellular-symbolic.svg');
+}
+
+.icon-network-error-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-error-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-error-symbolic.svg');
+}
+
+.icon-network-idle-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-idle-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-idle-symbolic.svg');
+}
+
+.icon-network-no-route-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-no-route-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-no-route-symbolic.svg');
+}
+
+.icon-network-offline-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-offline-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-offline-symbolic.svg');
+}
+
+.icon-network-receive-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-receive-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-receive-symbolic-rtl.svg');
+}
+
+.icon-network-receive-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-receive-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-receive-symbolic.svg');
+}
+
+.icon-network-server-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-server-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-server-symbolic.svg');
+}
+
+.icon-network-server {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-server.svg');
+  mask-image: url($icon-base-path + 'network-server.svg');
+}
+
+.icon-network-transmit-receive-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-transmit-receive-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-transmit-receive-symbolic.svg');
+}
+
+.icon-network-transmit-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-transmit-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'network-transmit-symbolic-rtl.svg');
+}
+
+.icon-network-transmit-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-transmit-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-transmit-symbolic.svg');
+}
+
+.icon-network-vpn-acquiring-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-vpn-acquiring-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-vpn-acquiring-symbolic.svg');
+}
+
+.icon-network-vpn-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-vpn-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-vpn-disabled-symbolic.svg');
+}
+
+.icon-network-vpn-disconnected-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-vpn-disconnected-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-vpn-disconnected-symbolic.svg');
+}
+
+.icon-network-vpn-no-route-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-vpn-no-route-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-vpn-no-route-symbolic.svg');
+}
+
+.icon-network-vpn-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-vpn-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-vpn-symbolic.svg');
+}
+
+.icon-network-wired-acquiring-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wired-acquiring-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wired-acquiring-symbolic.svg');
+}
+
+.icon-network-wired-disconnected-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wired-disconnected-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wired-disconnected-symbolic.svg');
+}
+
+.icon-network-wired-no-route-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wired-no-route-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wired-no-route-symbolic.svg');
+}
+
+.icon-network-wired-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wired-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wired-symbolic.svg');
+}
+
+.icon-network-wireless-acquiring-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-acquiring-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-acquiring-symbolic.svg');
+}
+
+.icon-network-wireless-connected-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-connected-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-connected-symbolic.svg');
+}
+
+.icon-network-wireless-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-disabled-symbolic.svg');
+}
+
+.icon-network-wireless-encrypted-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-encrypted-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-encrypted-symbolic.svg');
+}
+
+.icon-network-wireless-hardware-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-hardware-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-hardware-disabled-symbolic.svg');
+}
+
+.icon-network-wireless-hotspot-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-hotspot-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-hotspot-symbolic.svg');
+}
+
+.icon-network-wireless-no-route-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-no-route-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-no-route-symbolic.svg');
+}
+
+.icon-network-wireless-offline-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-offline-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-offline-symbolic.svg');
+}
+
+.icon-network-wireless-signal-excellent-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-signal-excellent-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-signal-excellent-symbolic.svg');
+}
+
+.icon-network-wireless-signal-good-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-signal-good-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-signal-good-symbolic.svg');
+}
+
+.icon-network-wireless-signal-none-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-signal-none-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-signal-none-symbolic.svg');
+}
+
+.icon-network-wireless-signal-ok-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-signal-ok-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-signal-ok-symbolic.svg');
+}
+
+.icon-network-wireless-signal-weak-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-signal-weak-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-signal-weak-symbolic.svg');
+}
+
+.icon-network-wireless-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-wireless-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-wireless-symbolic.svg');
+}
+
+.icon-network-workgroup-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-workgroup-symbolic.svg');
+  mask-image: url($icon-base-path + 'network-workgroup-symbolic.svg');
+}
+
+.icon-network-workgroup {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'network-workgroup.svg');
+  mask-image: url($icon-base-path + 'network-workgroup.svg');
+}
+
+.icon-night-light-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'night-light-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'night-light-disabled-symbolic.svg');
+}
+
+.icon-night-light-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'night-light-symbolic.svg');
+  mask-image: url($icon-base-path + 'night-light-symbolic.svg');
+}
+
+.icon-non-starred-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'non-starred-symbolic.svg');
+  mask-image: url($icon-base-path + 'non-starred-symbolic.svg');
+}
+
+.icon-notifications-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'notifications-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'notifications-disabled-symbolic.svg');
+}
+
+.icon-object-flip-horizontal-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'object-flip-horizontal-symbolic.svg');
+  mask-image: url($icon-base-path + 'object-flip-horizontal-symbolic.svg');
+}
+
+.icon-object-flip-vertical-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'object-flip-vertical-symbolic.svg');
+  mask-image: url($icon-base-path + 'object-flip-vertical-symbolic.svg');
+}
+
+.icon-object-rotate-left-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'object-rotate-left-symbolic.svg');
+  mask-image: url($icon-base-path + 'object-rotate-left-symbolic.svg');
+}
+
+.icon-object-rotate-right-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'object-rotate-right-symbolic.svg');
+  mask-image: url($icon-base-path + 'object-rotate-right-symbolic.svg');
+}
+
+.icon-object-select-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'object-select-symbolic.svg');
+  mask-image: url($icon-base-path + 'object-select-symbolic.svg');
+}
+
+.icon-open-menu-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'open-menu-symbolic.svg');
+  mask-image: url($icon-base-path + 'open-menu-symbolic.svg');
+}
+
+.icon-orientation-landscape-inverse-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'orientation-landscape-inverse-symbolic.svg');
+  mask-image: url($icon-base-path + 'orientation-landscape-inverse-symbolic.svg');
+}
+
+.icon-orientation-landscape-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'orientation-landscape-symbolic.svg');
+  mask-image: url($icon-base-path + 'orientation-landscape-symbolic.svg');
+}
+
+.icon-orientation-portrait-left-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'orientation-portrait-left-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'orientation-portrait-left-symbolic-rtl.svg');
+}
+
+.icon-orientation-portrait-left-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'orientation-portrait-left-symbolic.svg');
+  mask-image: url($icon-base-path + 'orientation-portrait-left-symbolic.svg');
+}
+
+.icon-orientation-portrait-right-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'orientation-portrait-right-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'orientation-portrait-right-symbolic-rtl.svg');
+}
+
+.icon-orientation-portrait-right-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'orientation-portrait-right-symbolic.svg');
+  mask-image: url($icon-base-path + 'orientation-portrait-right-symbolic.svg');
+}
+
+.icon-package-x-generic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'package-x-generic-symbolic.svg');
+  mask-image: url($icon-base-path + 'package-x-generic-symbolic.svg');
+}
+
+.icon-package-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'package-x-generic.svg');
+  mask-image: url($icon-base-path + 'package-x-generic.svg');
+}
+
+.icon-pan-down-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pan-down-symbolic.svg');
+  mask-image: url($icon-base-path + 'pan-down-symbolic.svg');
+}
+
+.icon-pan-end-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pan-end-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'pan-end-symbolic-rtl.svg');
+}
+
+.icon-pan-end-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pan-end-symbolic.svg');
+  mask-image: url($icon-base-path + 'pan-end-symbolic.svg');
+}
+
+.icon-pan-start-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pan-start-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'pan-start-symbolic-rtl.svg');
+}
+
+.icon-pan-start-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pan-start-symbolic.svg');
+  mask-image: url($icon-base-path + 'pan-start-symbolic.svg');
+}
+
+.icon-pan-up-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pan-up-symbolic.svg');
+  mask-image: url($icon-base-path + 'pan-up-symbolic.svg');
+}
+
+.icon-pda-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'pda-symbolic.svg');
+  mask-image: url($icon-base-path + 'pda-symbolic.svg');
+}
+
+.icon-phone-apple-iphone-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'phone-apple-iphone-symbolic.svg');
+  mask-image: url($icon-base-path + 'phone-apple-iphone-symbolic.svg');
+}
+
+.icon-phone-old-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'phone-old-symbolic.svg');
+  mask-image: url($icon-base-path + 'phone-old-symbolic.svg');
+}
+
+.icon-phone-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'phone-symbolic.svg');
+  mask-image: url($icon-base-path + 'phone-symbolic.svg');
+}
+
+.icon-phone {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'phone.svg');
+  mask-image: url($icon-base-path + 'phone.svg');
+}
+
+.icon-power-profile-balanced-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'power-profile-balanced-symbolic.svg');
+  mask-image: url($icon-base-path + 'power-profile-balanced-symbolic.svg');
+}
+
+.icon-power-profile-performance-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'power-profile-performance-symbolic.svg');
+  mask-image: url($icon-base-path + 'power-profile-performance-symbolic.svg');
+}
+
+.icon-power-profile-power-saver-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'power-profile-power-saver-symbolic.svg');
+  mask-image: url($icon-base-path + 'power-profile-power-saver-symbolic.svg');
+}
+
+.icon-preferences-color-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-color-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-color-symbolic.svg');
+}
+
+.icon-preferences-desktop-accessibility-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-accessibility-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-accessibility-symbolic.svg');
+}
+
+.icon-preferences-desktop-appearance-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-appearance-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-appearance-symbolic.svg');
+}
+
+.icon-preferences-desktop-apps-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-apps-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-apps-symbolic.svg');
+}
+
+.icon-preferences-desktop-display-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-display-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-display-symbolic.svg');
+}
+
+.icon-preferences-desktop-font-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-font-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-font-symbolic.svg');
+}
+
+.icon-preferences-desktop-keyboard-shortcuts-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-keyboard-shortcuts-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-keyboard-shortcuts-symbolic.svg');
+}
+
+.icon-preferences-desktop-keyboard-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-keyboard-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-keyboard-symbolic.svg');
+}
+
+.icon-preferences-desktop-locale-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-locale-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-locale-symbolic.svg');
+}
+
+.icon-preferences-desktop-multitasking-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-multitasking-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-multitasking-symbolic.svg');
+}
+
+.icon-preferences-desktop-remote-desktop-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-remote-desktop-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-remote-desktop-symbolic.svg');
+}
+
+.icon-preferences-desktop-screensaver-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-screensaver-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-screensaver-symbolic.svg');
+}
+
+.icon-preferences-desktop-wallpaper-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-desktop-wallpaper-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-desktop-wallpaper-symbolic.svg');
+}
+
+.icon-preferences-other-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-other-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-other-symbolic.svg');
+}
+
+.icon-preferences-system-details-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-details-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-details-symbolic.svg');
+}
+
+.icon-preferences-system-devices-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-devices-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-devices-symbolic.svg');
+}
+
+.icon-preferences-system-network-proxy-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-network-proxy-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-network-proxy-symbolic.svg');
+}
+
+.icon-preferences-system-network-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-network-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-network-symbolic.svg');
+}
+
+.icon-preferences-system-notifications-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-notifications-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-notifications-symbolic.svg');
+}
+
+.icon-preferences-system-parental-controls-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-parental-controls-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-parental-controls-symbolic.svg');
+}
+
+.icon-preferences-system-privacy-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-privacy-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-privacy-symbolic.svg');
+}
+
+.icon-preferences-system-search-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-search-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-search-symbolic.svg');
+}
+
+.icon-preferences-system-sharing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-sharing-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-sharing-symbolic.svg');
+}
+
+.icon-preferences-system-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-symbolic.svg');
+}
+
+.icon-preferences-system-time-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'preferences-system-time-symbolic.svg');
+  mask-image: url($icon-base-path + 'preferences-system-time-symbolic.svg');
+}
+
+.icon-printer-error-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer-error-symbolic.svg');
+  mask-image: url($icon-base-path + 'printer-error-symbolic.svg');
+}
+
+.icon-printer-network-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer-network-symbolic.svg');
+  mask-image: url($icon-base-path + 'printer-network-symbolic.svg');
+}
+
+.icon-printer-network {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer-network.svg');
+  mask-image: url($icon-base-path + 'printer-network.svg');
+}
+
+.icon-printer-printing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer-printing-symbolic.svg');
+  mask-image: url($icon-base-path + 'printer-printing-symbolic.svg');
+}
+
+.icon-printer-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer-symbolic.svg');
+  mask-image: url($icon-base-path + 'printer-symbolic.svg');
+}
+
+.icon-printer-warning-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer-warning-symbolic.svg');
+  mask-image: url($icon-base-path + 'printer-warning-symbolic.svg');
+}
+
+.icon-printer {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'printer.svg');
+  mask-image: url($icon-base-path + 'printer.svg');
+}
+
+.icon-process-stop-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'process-stop-symbolic.svg');
+  mask-image: url($icon-base-path + 'process-stop-symbolic.svg');
+}
+
+.icon-radio-checked-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'radio-checked-symbolic.svg');
+  mask-image: url($icon-base-path + 'radio-checked-symbolic.svg');
+}
+
+.icon-radio-mixed-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'radio-mixed-symbolic.svg');
+  mask-image: url($icon-base-path + 'radio-mixed-symbolic.svg');
+}
+
+.icon-radio-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'radio-symbolic.svg');
+  mask-image: url($icon-base-path + 'radio-symbolic.svg');
+}
+
+.icon-rotation-allowed-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'rotation-allowed-symbolic.svg');
+  mask-image: url($icon-base-path + 'rotation-allowed-symbolic.svg');
+}
+
+.icon-rotation-locked-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'rotation-locked-symbolic.svg');
+  mask-image: url($icon-base-path + 'rotation-locked-symbolic.svg');
+}
+
+.icon-scanner-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'scanner-symbolic.svg');
+  mask-image: url($icon-base-path + 'scanner-symbolic.svg');
+}
+
+.icon-scanner {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'scanner.svg');
+  mask-image: url($icon-base-path + 'scanner.svg');
+}
+
+.icon-screen-shared-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'screen-shared-symbolic.svg');
+  mask-image: url($icon-base-path + 'screen-shared-symbolic.svg');
+}
+
+.icon-security-high-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'security-high-symbolic.svg');
+  mask-image: url($icon-base-path + 'security-high-symbolic.svg');
+}
+
+.icon-security-low-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'security-low-symbolic.svg');
+  mask-image: url($icon-base-path + 'security-low-symbolic.svg');
+}
+
+.icon-security-medium-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'security-medium-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'security-medium-rtl-symbolic.svg');
+}
+
+.icon-security-medium-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'security-medium-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'security-medium-symbolic-rtl.svg');
+}
+
+.icon-security-medium-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'security-medium-symbolic.svg');
+  mask-image: url($icon-base-path + 'security-medium-symbolic.svg');
+}
+
+.icon-selection-end-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'selection-end-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'selection-end-symbolic-rtl.svg');
+}
+
+.icon-selection-end-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'selection-end-symbolic.svg');
+  mask-image: url($icon-base-path + 'selection-end-symbolic.svg');
+}
+
+.icon-selection-mode-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'selection-mode-symbolic.svg');
+  mask-image: url($icon-base-path + 'selection-mode-symbolic.svg');
+}
+
+.icon-selection-start-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'selection-start-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'selection-start-symbolic-rtl.svg');
+}
+
+.icon-selection-start-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'selection-start-symbolic.svg');
+  mask-image: url($icon-base-path + 'selection-start-symbolic.svg');
+}
+
+.icon-semi-starred-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'semi-starred-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'semi-starred-rtl-symbolic.svg');
+}
+
+.icon-semi-starred-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'semi-starred-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'semi-starred-symbolic-rtl.svg');
+}
+
+.icon-semi-starred-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'semi-starred-symbolic.svg');
+  mask-image: url($icon-base-path + 'semi-starred-symbolic.svg');
+}
+
+.icon-send-to-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'send-to-symbolic.svg');
+  mask-image: url($icon-base-path + 'send-to-symbolic.svg');
+}
+
+.icon-sidebar-show-right-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'sidebar-show-right-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'sidebar-show-right-symbolic-rtl.svg');
+}
+
+.icon-sidebar-show-right-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'sidebar-show-right-symbolic.svg');
+  mask-image: url($icon-base-path + 'sidebar-show-right-symbolic.svg');
+}
+
+.icon-sidebar-show-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'sidebar-show-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'sidebar-show-symbolic-rtl.svg');
+}
+
+.icon-sidebar-show-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'sidebar-show-symbolic.svg');
+  mask-image: url($icon-base-path + 'sidebar-show-symbolic.svg');
+}
+
+.icon-software-update-available-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'software-update-available-symbolic.svg');
+  mask-image: url($icon-base-path + 'software-update-available-symbolic.svg');
+}
+
+.icon-software-update-urgent-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'software-update-urgent-symbolic.svg');
+  mask-image: url($icon-base-path + 'software-update-urgent-symbolic.svg');
+}
+
+.icon-star-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'star-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'star-new-symbolic.svg');
+}
+
+.icon-starred-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'starred-symbolic.svg');
+  mask-image: url($icon-base-path + 'starred-symbolic.svg');
+}
+
+.icon-start-here-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'start-here-symbolic.svg');
+  mask-image: url($icon-base-path + 'start-here-symbolic.svg');
+}
+
+.icon-system-file-manager-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-file-manager-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-file-manager-symbolic.svg');
+}
+
+.icon-system-help-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-help-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-help-symbolic.svg');
+}
+
+.icon-system-lock-screen-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-lock-screen-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-lock-screen-symbolic.svg');
+}
+
+.icon-system-log-out-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-log-out-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-log-out-rtl-symbolic.svg');
+}
+
+.icon-system-log-out-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-log-out-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'system-log-out-symbolic-rtl.svg');
+}
+
+.icon-system-log-out-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-log-out-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-log-out-symbolic.svg');
+}
+
+.icon-system-reboot-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-reboot-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-reboot-symbolic.svg');
+}
+
+.icon-system-run-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-run-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-run-symbolic.svg');
+}
+
+.icon-system-search-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-search-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-search-symbolic.svg');
+}
+
+.icon-system-shutdown-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-shutdown-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-shutdown-symbolic.svg');
+}
+
+.icon-system-software-install-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-software-install-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-software-install-symbolic.svg');
+}
+
+.icon-system-switch-user-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-switch-user-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-switch-user-rtl-symbolic.svg');
+}
+
+.icon-system-switch-user-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-switch-user-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'system-switch-user-symbolic-rtl.svg');
+}
+
+.icon-system-switch-user-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-switch-user-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-switch-user-symbolic.svg');
+}
+
+.icon-system-users-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'system-users-symbolic.svg');
+  mask-image: url($icon-base-path + 'system-users-symbolic.svg');
+}
+
+.icon-tab-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'tab-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'tab-new-symbolic.svg');
+}
+
+.icon-tablet-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'tablet-symbolic.svg');
+  mask-image: url($icon-base-path + 'tablet-symbolic.svg');
+}
+
+.icon-task-due-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'task-due-symbolic.svg');
+  mask-image: url($icon-base-path + 'task-due-symbolic.svg');
+}
+
+.icon-task-past-due-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'task-past-due-symbolic.svg');
+  mask-image: url($icon-base-path + 'task-past-due-symbolic.svg');
+}
+
+.icon-text-editor-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'text-editor-symbolic.svg');
+  mask-image: url($icon-base-path + 'text-editor-symbolic.svg');
+}
+
+.icon-text-html {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'text-html.svg');
+  mask-image: url($icon-base-path + 'text-html.svg');
+}
+
+.icon-text-x-generic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'text-x-generic-symbolic.svg');
+  mask-image: url($icon-base-path + 'text-x-generic-symbolic.svg');
+}
+
+.icon-text-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'text-x-generic.svg');
+  mask-image: url($icon-base-path + 'text-x-generic.svg');
+}
+
+.icon-text-x-preview {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'text-x-preview.svg');
+  mask-image: url($icon-base-path + 'text-x-preview.svg');
+}
+
+.icon-text-x-script {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'text-x-script.svg');
+  mask-image: url($icon-base-path + 'text-x-script.svg');
+}
+
+.icon-thunderbolt-acquiring-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'thunderbolt-acquiring-symbolic.svg');
+  mask-image: url($icon-base-path + 'thunderbolt-acquiring-symbolic.svg');
+}
+
+.icon-thunderbolt-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'thunderbolt-symbolic.svg');
+  mask-image: url($icon-base-path + 'thunderbolt-symbolic.svg');
+}
+
+.icon-tools-check-spelling-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'tools-check-spelling-symbolic.svg');
+  mask-image: url($icon-base-path + 'tools-check-spelling-symbolic.svg');
+}
+
+.icon-touch-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'touch-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'touch-disabled-symbolic.svg');
+}
+
+.icon-touchpad-disabled-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'touchpad-disabled-symbolic.svg');
+  mask-image: url($icon-base-path + 'touchpad-disabled-symbolic.svg');
+}
+
+.icon-tv-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'tv-symbolic.svg');
+  mask-image: url($icon-base-path + 'tv-symbolic.svg');
+}
+
+.icon-uninterruptible-power-supply-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'uninterruptible-power-supply-symbolic.svg');
+  mask-image: url($icon-base-path + 'uninterruptible-power-supply-symbolic.svg');
+}
+
+.icon-user-available-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-available-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-available-symbolic.svg');
+}
+
+.icon-user-away-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-away-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-away-symbolic.svg');
+}
+
+.icon-user-bookmarks-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-bookmarks-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-bookmarks-symbolic.svg');
+}
+
+.icon-user-bookmarks {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-bookmarks.svg');
+  mask-image: url($icon-base-path + 'user-bookmarks.svg');
+}
+
+.icon-user-busy-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-busy-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-busy-symbolic.svg');
+}
+
+.icon-user-desktop-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-desktop-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-desktop-symbolic.svg');
+}
+
+.icon-user-desktop {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-desktop.svg');
+  mask-image: url($icon-base-path + 'user-desktop.svg');
+}
+
+.icon-user-home-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-home-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-home-symbolic.svg');
+}
+
+.icon-user-home {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-home.svg');
+  mask-image: url($icon-base-path + 'user-home.svg');
+}
+
+.icon-user-idle-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-idle-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-idle-symbolic.svg');
+}
+
+.icon-user-info-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-info-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-info-symbolic.svg');
+}
+
+.icon-user-invisible-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-invisible-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-invisible-symbolic.svg');
+}
+
+.icon-user-not-tracked-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-not-tracked-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-not-tracked-symbolic.svg');
+}
+
+.icon-user-offline-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-offline-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-offline-symbolic.svg');
+}
+
+.icon-user-status-pending-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-status-pending-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-status-pending-symbolic.svg');
+}
+
+.icon-user-trash-full-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-trash-full-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-trash-full-symbolic.svg');
+}
+
+.icon-user-trash-full {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-trash-full.svg');
+  mask-image: url($icon-base-path + 'user-trash-full.svg');
+}
+
+.icon-user-trash-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-trash-symbolic.svg');
+  mask-image: url($icon-base-path + 'user-trash-symbolic.svg');
+}
+
+.icon-user-trash {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'user-trash.svg');
+  mask-image: url($icon-base-path + 'user-trash.svg');
+}
+
+.icon-utilities-terminal-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'utilities-terminal-symbolic.svg');
+  mask-image: url($icon-base-path + 'utilities-terminal-symbolic.svg');
+}
+
+.icon-value-decrease-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'value-decrease-symbolic.svg');
+  mask-image: url($icon-base-path + 'value-decrease-symbolic.svg');
+}
+
+.icon-value-increase-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'value-increase-symbolic.svg');
+  mask-image: url($icon-base-path + 'value-increase-symbolic.svg');
+}
+
+.icon-video-display-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'video-display-symbolic.svg');
+  mask-image: url($icon-base-path + 'video-display-symbolic.svg');
+}
+
+.icon-video-display {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'video-display.svg');
+  mask-image: url($icon-base-path + 'video-display.svg');
+}
+
+.icon-video-joined-displays-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'video-joined-displays-symbolic.svg');
+  mask-image: url($icon-base-path + 'video-joined-displays-symbolic.svg');
+}
+
+.icon-video-single-display-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'video-single-display-symbolic.svg');
+  mask-image: url($icon-base-path + 'video-single-display-symbolic.svg');
+}
+
+.icon-video-x-generic-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'video-x-generic-symbolic.svg');
+  mask-image: url($icon-base-path + 'video-x-generic-symbolic.svg');
+}
+
+.icon-video-x-generic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'video-x-generic.svg');
+  mask-image: url($icon-base-path + 'video-x-generic.svg');
+}
+
+.icon-view-app-grid-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-app-grid-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-app-grid-symbolic.svg');
+}
+
+.icon-view-conceal-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-conceal-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-conceal-symbolic.svg');
+}
+
+.icon-view-continuous-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-continuous-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-continuous-symbolic.svg');
+}
+
+.icon-view-dual-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-dual-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-dual-symbolic.svg');
+}
+
+.icon-view-fullscreen-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-fullscreen-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-fullscreen-symbolic.svg');
+}
+
+.icon-view-grid-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-grid-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-grid-symbolic.svg');
+}
+
+.icon-view-list-bullet-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-bullet-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-list-bullet-rtl-symbolic.svg');
+}
+
+.icon-view-list-bullet-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-bullet-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-list-bullet-symbolic-rtl.svg');
+}
+
+.icon-view-list-bullet-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-bullet-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-list-bullet-symbolic.svg');
+}
+
+.icon-view-list-ordered-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-ordered-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-list-ordered-rtl-symbolic.svg');
+}
+
+.icon-view-list-ordered-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-ordered-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-list-ordered-symbolic-rtl.svg');
+}
+
+.icon-view-list-ordered-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-ordered-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-list-ordered-symbolic.svg');
+}
+
+.icon-view-list-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-list-rtl-symbolic.svg');
+}
+
+.icon-view-list-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-list-symbolic-rtl.svg');
+}
+
+.icon-view-list-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-list-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-list-symbolic.svg');
+}
+
+.icon-view-mirror-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-mirror-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-mirror-symbolic.svg');
+}
+
+.icon-view-more-horizontal-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-more-horizontal-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-more-horizontal-symbolic.svg');
+}
+
+.icon-view-more-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-more-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-more-symbolic.svg');
+}
+
+.icon-view-paged-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-paged-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-paged-rtl-symbolic.svg');
+}
+
+.icon-view-paged-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-paged-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-paged-symbolic-rtl.svg');
+}
+
+.icon-view-paged-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-paged-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-paged-symbolic.svg');
+}
+
+.icon-view-pin-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-pin-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-pin-symbolic.svg');
+}
+
+.icon-view-refresh-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-refresh-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-refresh-symbolic.svg');
+}
+
+.icon-view-restore-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-restore-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-restore-symbolic.svg');
+}
+
+.icon-view-reveal-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-reveal-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-reveal-symbolic.svg');
+}
+
+.icon-view-sort-ascending-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-sort-ascending-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-sort-ascending-rtl-symbolic.svg');
+}
+
+.icon-view-sort-ascending-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-sort-ascending-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-sort-ascending-symbolic-rtl.svg');
+}
+
+.icon-view-sort-ascending-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-sort-ascending-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-sort-ascending-symbolic.svg');
+}
+
+.icon-view-sort-descending-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-sort-descending-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-sort-descending-rtl-symbolic.svg');
+}
+
+.icon-view-sort-descending-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-sort-descending-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-sort-descending-symbolic-rtl.svg');
+}
+
+.icon-view-sort-descending-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-sort-descending-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-sort-descending-symbolic.svg');
+}
+
+.icon-view-wrapped-rtl-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-wrapped-rtl-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-wrapped-rtl-symbolic.svg');
+}
+
+.icon-view-wrapped-symbolic-rtl {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-wrapped-symbolic-rtl.svg');
+  mask-image: url($icon-base-path + 'view-wrapped-symbolic-rtl.svg');
+}
+
+.icon-view-wrapped-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'view-wrapped-symbolic.svg');
+  mask-image: url($icon-base-path + 'view-wrapped-symbolic.svg');
+}
+
+.icon-weather-clear-night-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-clear-night-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-clear-night-symbolic.svg');
+}
+
+.icon-weather-clear-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-clear-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-clear-symbolic.svg');
+}
+
+.icon-weather-few-clouds-night-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-few-clouds-night-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-few-clouds-night-symbolic.svg');
+}
+
+.icon-weather-few-clouds-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-few-clouds-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-few-clouds-symbolic.svg');
+}
+
+.icon-weather-fog-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-fog-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-fog-symbolic.svg');
+}
+
+.icon-weather-overcast-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-overcast-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-overcast-symbolic.svg');
+}
+
+.icon-weather-severe-alert-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-severe-alert-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-severe-alert-symbolic.svg');
+}
+
+.icon-weather-showers-scattered-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-showers-scattered-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-showers-scattered-symbolic.svg');
+}
+
+.icon-weather-showers-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-showers-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-showers-symbolic.svg');
+}
+
+.icon-weather-snow-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-snow-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-snow-symbolic.svg');
+}
+
+.icon-weather-storm-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-storm-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-storm-symbolic.svg');
+}
+
+.icon-weather-tornado-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-tornado-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-tornado-symbolic.svg');
+}
+
+.icon-weather-windy-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'weather-windy-symbolic.svg');
+  mask-image: url($icon-base-path + 'weather-windy-symbolic.svg');
+}
+
+.icon-web-browser-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'web-browser-symbolic.svg');
+  mask-image: url($icon-base-path + 'web-browser-symbolic.svg');
+}
+
+.icon-window-close-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'window-close-symbolic.svg');
+  mask-image: url($icon-base-path + 'window-close-symbolic.svg');
+}
+
+.icon-window-maximize-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'window-maximize-symbolic.svg');
+  mask-image: url($icon-base-path + 'window-maximize-symbolic.svg');
+}
+
+.icon-window-minimize-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'window-minimize-symbolic.svg');
+  mask-image: url($icon-base-path + 'window-minimize-symbolic.svg');
+}
+
+.icon-window-new-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'window-new-symbolic.svg');
+  mask-image: url($icon-base-path + 'window-new-symbolic.svg');
+}
+
+.icon-window-restore-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'window-restore-symbolic.svg');
+  mask-image: url($icon-base-path + 'window-restore-symbolic.svg');
+}
+
+.icon-x-office-address-book-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-address-book-symbolic.svg');
+  mask-image: url($icon-base-path + 'x-office-address-book-symbolic.svg');
+}
+
+.icon-x-office-addressbook {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-addressbook.svg');
+  mask-image: url($icon-base-path + 'x-office-addressbook.svg');
+}
+
+.icon-x-office-calendar-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-calendar-symbolic.svg');
+  mask-image: url($icon-base-path + 'x-office-calendar-symbolic.svg');
+}
+
+.icon-x-office-document-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-document-symbolic.svg');
+  mask-image: url($icon-base-path + 'x-office-document-symbolic.svg');
+}
+
+.icon-x-office-document-template {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-document-template.svg');
+  mask-image: url($icon-base-path + 'x-office-document-template.svg');
+}
+
+.icon-x-office-document {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-document.svg');
+  mask-image: url($icon-base-path + 'x-office-document.svg');
+}
+
+.icon-x-office-drawing-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-drawing-symbolic.svg');
+  mask-image: url($icon-base-path + 'x-office-drawing-symbolic.svg');
+}
+
+.icon-x-office-drawing {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-drawing.svg');
+  mask-image: url($icon-base-path + 'x-office-drawing.svg');
+}
+
+.icon-x-office-presentation-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-presentation-symbolic.svg');
+  mask-image: url($icon-base-path + 'x-office-presentation-symbolic.svg');
+}
+
+.icon-x-office-presentation-template {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-presentation-template.svg');
+  mask-image: url($icon-base-path + 'x-office-presentation-template.svg');
+}
+
+.icon-x-office-presentation {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-presentation.svg');
+  mask-image: url($icon-base-path + 'x-office-presentation.svg');
+}
+
+.icon-x-office-spreadsheet-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-spreadsheet-symbolic.svg');
+  mask-image: url($icon-base-path + 'x-office-spreadsheet-symbolic.svg');
+}
+
+.icon-x-office-spreadsheet-template {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-spreadsheet-template.svg');
+  mask-image: url($icon-base-path + 'x-office-spreadsheet-template.svg');
+}
+
+.icon-x-office-spreadsheet {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-office-spreadsheet.svg');
+  mask-image: url($icon-base-path + 'x-office-spreadsheet.svg');
+}
+
+.icon-x-package-repository {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'x-package-repository.svg');
+  mask-image: url($icon-base-path + 'x-package-repository.svg');
+}
+
+.icon-zoom-fit-best-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'zoom-fit-best-symbolic.svg');
+  mask-image: url($icon-base-path + 'zoom-fit-best-symbolic.svg');
+}
+
+.icon-zoom-in-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'zoom-in-symbolic.svg');
+  mask-image: url($icon-base-path + 'zoom-in-symbolic.svg');
+}
+
+.icon-zoom-original-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'zoom-original-symbolic.svg');
+  mask-image: url($icon-base-path + 'zoom-original-symbolic.svg');
+}
+
+.icon-zoom-out-symbolic {
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'zoom-out-symbolic.svg');
+  mask-image: url($icon-base-path + 'zoom-out-symbolic.svg');
+}


### PR DESCRIPTION
Identified 701 SVG icons in data/icons/symbolic/ that were not defined in _symbolic_icons.scss.

This commit adds the corresponding SCSS class definitions for these icons, ensuring they are available for use in the UI.