### PR TITLE
Integrate SVG icons into core SCSS components

### DIFF
--- a/adwaita-web/examples/listbox.html
+++ b/adwaita-web/examples/listbox.html
@@ -34,14 +34,14 @@
                     <div class="adw-action-row-title">General</div>
                     <div class="adw-action-row-subtitle">Language, Date & Time, Users</div>
                 </div>
-                <div class="adw-action-row-suffix"><span class="adw-icon go-next-symbolic"></span></div>
+                <div class="adw-action-row-suffix"><span class="adw-icon adw-action-row-chevron"></span></div>
             </div>
             <div class="adw-action-row activatable">
                 <div class="adw-action-row-content">
                     <div class="adw-action-row-title">Appearance</div>
                     <div class="adw-action-row-subtitle">Background, Style</div>
                 </div>
-                <div class="adw-action-row-suffix"><span class="adw-icon go-next-symbolic"></span></div>
+                <div class="adw-action-row-suffix"><span class="adw-icon adw-action-row-chevron"></span></div>
             </div>
             <div class="adw-action-row">
                 <div class="adw-action-row-content">
@@ -84,7 +84,7 @@
                 background-color: currentColor; /* Simple way to make them visible */
             }
             .preferences-system-symbolic { mask-image: url(../data/icons/symbolic/preferences-system-symbolic.svg); }
-            .go-next-symbolic { mask-image: url(../data/icons/symbolic/go-next-symbolic.svg); }
+            /* .go-next-symbolic rule is removed as it's now part of .adw-action-row-chevron in main SCSS */
             .help-about-symbolic { mask-image: url(../data/icons/symbolic/help-about-symbolic.svg); }
         `;
         document.head.appendChild(styleSheet);

--- a/adwaita-web/scss/_action_row.scss
+++ b/adwaita-web/scss/_action_row.scss
@@ -85,6 +85,18 @@
     // Specific for chevron, e.g. opacity
     .adw-action-row-chevron.adw-icon {
       opacity: var(--icon-opacity); // Uses variable defined in _variables.scss
+      -webkit-mask-image: url('../data/icons/symbolic/go-next-symbolic.svg');
+      mask-image: url('../data/icons/symbolic/go-next-symbolic.svg');
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+      -webkit-mask-position: center;
+      mask-position: center;
+      -webkit-mask-size: contain;
+      mask-size: contain;
+      background-color: currentColor;
+      // Ensure width/height are set if not already by .adw-icon generic rule
+      width: var(--icon-size-small, 14px); // Or specific size for chevrons
+      height: var(--icon-size-small, 14px);
     }
   }
 

--- a/adwaita-web/scss/_combo_row.scss
+++ b/adwaita-web/scss/_combo_row.scss
@@ -79,11 +79,28 @@
         // If it's just a chevron, it could be similar to adw-action-row__chevron
         flex-shrink: 0;
         margin-left: var(--spacing-s);
-        // Example: using a simple chevron character, can be replaced with SVG icon
-        &::after {
-            content: '▼'; // Simple dropdown indicator
-            font-size: var(--font-size-small);
-            color: var(--icon-color);
+        // Replace text chevron with SVG icon
+        // Assuming the button itself will be the icon, or it contains an .adw-icon span
+        // Let's make the button itself the icon container for simplicity here.
+        // If an <span class="adw-icon"> is preferred inside, adjust selector to &__button .adw-icon
+        display: inline-flex; // To contain the icon properly
+        align-items: center;
+        justify-content: center;
+        width: var(--icon-size-small, 14px); // Size of the icon
+        height: var(--icon-size-small, 14px);
+        background-color: currentColor; // Colors the icon via mask
+        -webkit-mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+        mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        color: var(--icon-color); // Set the color for currentColor to pick up
+
+        &::after { // Remove the text chevron
+            content: none;
         }
     }
 

--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -39,7 +39,35 @@
       font-weight: var(--font-weight-bold);
       color: inherit; // Inherits --dialog-fg-color
     }
-    // Close button would be an .adw-button.circular.flat
+
+    // Styling for a dedicated close button in the header
+    .adw-dialog-close-button.adw-button {
+      // Assuming .adw-button provides base button styling (padding, border, etc.)
+      // And .circular, .flat modify it. We primarily need to set the icon here.
+      // If the button is purely iconic, it might need width/height settings too.
+      // Let's assume it's a circular flat button, so padding might create the size.
+      // The icon itself:
+      .adw-icon { // If an <span class="adw-icon"> is used inside the button
+        background-color: currentColor;
+        -webkit-mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
+        mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        width: var(--icon-size-base); // Standard icon size
+        height: var(--icon-size-base);
+        display: inline-block; // Ensure it takes space
+      }
+      // If the button *is* the icon (no inner .adw-icon span):
+      // background-color: currentColor;
+      // -webkit-mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
+      // mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
+      // width: var(--icon-size-base); height: var(--icon-size-base); etc.
+      // For now, sticking to .adw-icon child pattern.
+    }
   }
 
   // Dialog Content Area

--- a/adwaita-web/scss/_expander_row.scss
+++ b/adwaita-web/scss/_expander_row.scss
@@ -21,10 +21,21 @@
       transition: transform var(--animation-duration-short) var(--animation-ease-out-sine);
       transform: rotate(-90deg); // Point right for LTR when collapsed (assuming pan-down icon)
       opacity: var(--icon-opacity, 0.7); // Use a variable for icon opacity
-      font-size: 0.8em; // Consistent with existing style, can be adjusted
-      // Ensure it's vertically centered if AdwActionRow suffix area doesn't guarantee it.
+      // font-size: 0.8em; // Remove font-size if using direct width/height for SVG mask
       display: flex;
       align-items: center;
+      justify-content: center; // Center the mask content
+      width: var(--icon-size-small, 14px); // Standard icon size, adjust if needed for chevrons
+      height: var(--icon-size-small, 14px);
+      background-color: currentColor; // To color the mask
+      -webkit-mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+      mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+      -webkit-mask-position: center;
+      mask-position: center;
+      -webkit-mask-size: contain; // Or 100% 100%
+      mask-size: contain;
     }
 
     // When the header (and thus the row) is expanded

--- a/adwaita-web/scss/_spin_button.scss
+++ b/adwaita-web/scss/_spin_button.scss
@@ -69,11 +69,37 @@
       align-items: center;
       justify-content: center;
       color: var(--button-fg-color); // Ensure button text/icon color
+      // The .adw-icon class is a good target if an actual <i> or <span> element is used for the icon.
+      // If not, we might need pseudo-elements on the button itself.
+      // Assuming an element with .adw-icon will be used, or this style can be applied to button itself.
+      // For now, let's assume .adw-icon is the target within the button.
+      // If buttons are empty and rely on pseudo-elements, this needs to change.
+      // The HTML structure would be <button class="adw-spin-button-control adw-button adw-spin-button-up"><span class="adw-icon"></span></button>
+      // If the button itself is the icon carrier (no inner span):
+      // Then these mask properties should be directly on .adw-spin-button-control.adw-button
+      // Let's style .adw-icon for now as it's explicitly mentioned.
 
-      .adw-icon {
-        width: var(--icon-size-base); // Use variable for icon size
-        height: var(--icon-size-base);
-        margin: 0; // Reset icon margin
+      .adw-icon { // This will be the container for the mask
+        width: var(--icon-size-small, 14px);  // Spin button icons are typically small
+        height: var(--icon-size-small, 14px);
+        margin: 0;
+        background-color: currentColor; // This will color the icon mask.
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+      }
+
+      &.adw-spin-button-up .adw-icon {
+        -webkit-mask-image: url('../data/icons/symbolic/pan-up-symbolic.svg');
+        mask-image: url('../data/icons/symbolic/pan-up-symbolic.svg');
+      }
+
+      &.adw-spin-button-down .adw-icon {
+        -webkit-mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+        mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
       }
 
       &:hover:not(:disabled) {

--- a/adwaita-web/scss/_spinner.scss
+++ b/adwaita-web/scss/_spinner.scss
@@ -2,42 +2,47 @@
 
 .adw-spinner {
   display: inline-block;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border-width: 3px;
-  border-style: solid;
-  border-color: var(--spinner-track-color);
-  border-top-color: var(--spinner-color);
-  animation: adw-spinner-spin 0.75s linear infinite;
+  width: 24px;  // Default size
+  height: 24px; // Default size
   vertical-align: middle;
+  background-color: var(--spinner-color, var(--accent-color)); // Color for the SVG icon
+  -webkit-mask-image: url('../data/icons/symbolic/process-working-symbolic.svg');
+  mask-image: url('../data/icons/symbolic/process-working-symbolic.svg');
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain; // Ensure the icon fits
+  mask-size: contain;
+  animation: adw-spinner-spin 0.75s linear infinite;
+
+  // Remove border properties as we are using mask-image now
+  // border-radius: 50%;
+  // border-width: 3px;
+  // border-style: solid;
+  // border-color: var(--spinner-track-color);
+  // border-top-color: var(--spinner-color);
+
 
   &.small {
     width: 16px;
     height: 16px;
-    border-width: 2px;
+    // border-width: 2px; // Not needed for mask-based
   }
 
   &.large {
     width: 36px;
     height: 36px;
-    border-width: 4px;
+    // border-width: 4px; // Not needed for mask-based
   }
 
   // Accessibility: Respect prefers-reduced-motion
   @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    // Optionally, provide a static visual cue, though a static colored segment already does this.
-    // border-top-color: var(--spinner-track-color); // Make it a full static circle
-    // &::after { // Or add a static icon/character
-    //   content: '⏳'; // Example: hourglass
-    //   font-size: calc(0.6 * var(--width, 24px)); // Adjust size
-    //   position: absolute;
-    //   top: 50%;
-    //   left: 50%;
-    //   transform: translate(-50%, -50%);
-    //   color: var(--spinner-color);
-    // }
+    animation: none; // Stop spinning
+    // For a static representation with mask, it will just show the static SVG.
+    // If process-working-symbolic.svg is a full circle or a non-animated segment,
+    // it will appear static. If it's an animated SVG itself, this might not stop internal SVG animation.
+    // Assuming process-working-symbolic.svg is a static spinner segment graphic.
   }
 }
 
@@ -48,4 +53,8 @@
   100% {
     transform: rotate(360deg);
   }
+// Ensure --spinner-color is defined in _variables.scss, e.g.
+// :root { --spinner-color: var(--accent-color); }
+// And potentially --spinner-track-color if a background is desired behind the SVG spinner.
+// For a simple SVG spinner, track color is not directly applicable unless layering.
 }

--- a/adwaita-web/scss/_split_button.scss
+++ b/adwaita-web/scss/_split_button.scss
@@ -57,9 +57,20 @@
     border: none;
 
     .adw-icon {
-      width: calc(var(--icon-size-base) * 0.75);
-      height: calc(var(--icon-size-base) * 0.75);
-      fill: currentColor;
+      // width: calc(var(--icon-size-base) * 0.75); // Adjusted to standard small icon size
+      // height: calc(var(--icon-size-base) * 0.75);
+      width: var(--icon-size-small, 14px);
+      height: var(--icon-size-small, 14px);
+      // fill: currentColor; // Not needed for mask-image, use background-color
+      background-color: currentColor;
+      -webkit-mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+      mask-image: url('../data/icons/symbolic/pan-down-symbolic.svg');
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+      -webkit-mask-position: center;
+      mask-position: center;
+      -webkit-mask-size: contain;
+      mask-size: contain;
     }
 
     &:hover {


### PR DESCRIPTION
- Updated AdwActionRow and AdwExpanderRow to use CSS-driven SVG chevrons (go-next-symbolic.svg and pan-down-symbolic.svg respectively) via mask-image.
- Styled AdwSpinButton up/down controls to use pan-up-symbolic.svg and pan-down-symbolic.svg.
- Replaced the CSS border-based AdwSpinner with an SVG version using process-working-symbolic.svg and CSS rotation.
- Added pan-down-symbolic.svg as the dropdown arrow for AdwSplitButton.
- Added window-close-symbolic.svg for Dialog close buttons (styling assumes an .adw-dialog-close-button with an inner .adw-icon element).
- Replaced text-based chevron with pan-down-symbolic.svg for AdwComboRow.
- All icons use mask-image and currentColor for proper theming.
- Refined listbox.html example to use the new CSS-driven chevron for AdwActionRow and removed redundant inline icon styles.