### PR TITLE
feat: Implement user registration with admin approval

### DIFF
--- a/app-demo/__init__.py
+++ b/app-demo/__init__.py
@@ -172,16 +172,16 @@ def create_app(config_name=None):
         db.session.rollback() # Rollback in case of DB error leading to 500
         return render_template('500.html'), 500
 
-    with app.app_context():
-        app.logger.info("Application context pushed for initial db.create_all().")
-        try:
-            app.logger.info("Attempting to ensure database tables are created (db.create_all())...")
-            db.create_all()
-            app.logger.info("db.create_all() completed. Tables should exist if they didn't.")
-        except Exception as e: # Catch broad exception, could be OperationalError if DB not ready
-            app.logger.error(f"Error during initial db.create_all(): {e}", exc_info=True)
-            # Depending on the app's needs, this might be a fatal error or something to warn about.
-            # For now, just log it. The app might still run if tables exist or are not immediately needed.
+    # Removed redundant db.create_all() from app initialization.
+    # Database schema should be managed by setup_db.py or migrations.
+    # with app.app_context():
+    #     app.logger.info("Application context pushed for initial db.create_all().")
+    #     try:
+    #         app.logger.info("Attempting to ensure database tables are created (db.create_all())...")
+    #         db.create_all()
+    #         app.logger.info("db.create_all() completed. Tables should exist if they didn't.")
+    #     except Exception as e: # Catch broad exception, could be OperationalError if DB not ready
+    #         app.logger.error(f"Error during initial db.create_all(): {e}", exc_info=True)
 
     app.logger.info("Flask application instance created and configured.")
     return app

--- a/app-demo/forms.py
+++ b/app-demo/forms.py
@@ -10,7 +10,7 @@ from wtforms import (
     IntegerField
 )
 from wtforms.fields import DateField # Changed import for DateField
-from wtforms.validators import DataRequired, EqualTo, Length, Optional, NumberRange
+from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional, NumberRange # Added Email
 from wtforms.widgets import CheckboxInput, ListWidget # Ensure ListWidget is imported if used by QuerySelectMultipleField
 from wtforms_sqlalchemy.fields import QuerySelectMultipleField
 from .models import Category # Import Category from models.py
@@ -21,6 +21,18 @@ class LoginForm(FlaskForm):
     username = StringField('Username', validators=[DataRequired()])
     password = PasswordField('Password', validators=[DataRequired()])
     submit = SubmitField('Login')
+
+class RegistrationForm(FlaskForm):
+    email = StringField('Email (Username)', validators=[DataRequired(), Length(min=6, max=120), Email(message="Please enter a valid email address.")])
+    password = PasswordField('Password', validators=[DataRequired(), Length(min=8, message="Password must be at least 8 characters long.")])
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[
+            DataRequired(),
+            EqualTo('password', message='Passwords must match.')
+        ]
+    )
+    submit = SubmitField('Register')
 
 class ChangePasswordForm(FlaskForm):
     current_password = PasswordField('Current Password', validators=[DataRequired()])

--- a/app-demo/models.py
+++ b/app-demo/models.py
@@ -32,6 +32,8 @@ class User(UserMixin, db.Model):
     theme = db.Column(db.String(80), nullable=True, default='system')
     accent_color = db.Column(db.String(80), nullable=True, default='default')
     is_admin = db.Column(db.Boolean, default=False, nullable=False) # Admin flag
+    is_approved = db.Column(db.Boolean, default=False, nullable=False)
+    is_active = db.Column(db.Boolean, default=False, nullable=False)
     posts = db.relationship(
         'Post', backref='author', lazy=True, order_by=lambda: desc(Post.created_at) # Use lambda for Post ref
     )

--- a/app-demo/setup_db.py
+++ b/app-demo/setup_db.py
@@ -34,16 +34,28 @@ def create_initial_user(flask_app):
     Requires an active application context.
     """
     print("\nStarting initial user setup...")
+    script_args = flask_app.config.get('SETUP_DB_SCRIPT_ARGS') # Get args passed to the script
 
-    default_username = "admin"
-    try:
-        username_input = input(
-            f"Enter username for the initial user (default: {default_username}): "
-        )
-        username = username_input if username_input else default_username
-    except EOFError:  # Handle non-interactive environment
-        print(f"No input provided, using default username: {default_username}")
-        username = default_username
+    is_interactive = not (script_args and script_args.admin_user and script_args.admin_pass)
+    username = ""
+    password = ""
+    profile_info = None
+
+    if not is_interactive:
+        username = script_args.admin_user
+        password = script_args.admin_pass
+        profile_info = script_args.admin_bio
+        print(f"Non-interactive mode: Creating/updating admin user '{username}'.")
+    else:
+        default_username = "admin"
+        try:
+            username_input = input(
+                f"Enter username for the initial user (default: {default_username}): "
+            )
+            username = username_input if username_input else default_username
+        except EOFError:  # Handle non-interactive environment
+            print(f"No input provided, using default username: {default_username}")
+            username = default_username
 
     # This function is called with app, and establishes its own context for DB operations
     with flask_app.app_context():
@@ -51,82 +63,103 @@ def create_initial_user(flask_app):
 
         if existing_user:
             print(f"User '{username}' already exists.")
-            try:
-                update_choice = input(
-                    "Do you want to update the password for this user? (y/n): "
-                ).lower()
-                if update_choice == "y":
-                    print(f"Updating password for user '{username}'.")
-                    new_password = getpass.getpass("Enter new password: ")
-                    if not new_password:
-                        print("Password cannot be empty. Aborting password update.")
-                        return
-                    new_password_confirm = getpass.getpass("Confirm new password: ")
-                    if new_password != new_password_confirm:
-                        print("Passwords do not match. Aborting password update.")
-                        return
-                    existing_user.set_password(new_password)
-                    db.session.commit()
-                    print(f"Password for user '{username}' updated successfully.")
-                else:
-                    print(f"Password for user '{username}' not updated.")
-            except EOFError:
-                print("Skipping password update for existing user in non-interactive mode.")
+            if not is_interactive: # Non-interactive: always update password if provided
+                print(f"Updating password for user '{username}'.")
+                existing_user.set_password(password)
+                if profile_info is not None: # Update bio if provided
+                    existing_user.profile_info = profile_info
+                db.session.commit()
+                print(f"User '{username}' updated non-interactively.")
+            else: # Interactive: ask to update
+                try:
+                    update_choice = input(
+                        "Do you want to update the password for this user? (y/n): "
+                    ).lower()
+                    if update_choice == "y":
+                        print(f"Updating password for user '{username}'.")
+                        new_password = getpass.getpass("Enter new password: ")
+                        if not new_password:
+                            print("Password cannot be empty. Aborting password update.")
+                            return
+                        new_password_confirm = getpass.getpass("Confirm new password: ")
+                        if new_password != new_password_confirm:
+                            print("Passwords do not match. Aborting password update.")
+                            return
+                        existing_user.set_password(new_password)
+                        db.session.commit()
+                        print(f"Password for user '{username}' updated successfully.")
+                    else:
+                        print(f"Password for user '{username}' not updated.")
+                except EOFError:
+                    print("Skipping password update for existing user in non-interactive mode.")
             return
 
+        # Create new user
         print(f"Creating new user: '{username}'")
-        try:
-            password = getpass.getpass("Enter password: ")
-            if not password:
-                print("Password cannot be empty. Aborting user creation.")
+        if is_interactive:
+            try:
+                password = getpass.getpass("Enter password: ")
+                if not password:
+                    print("Password cannot be empty. Aborting user creation.")
+                    return
+                password_confirm = getpass.getpass("Confirm password: ")
+                if password != password_confirm:
+                    print("Passwords do not match. Aborting user creation.")
+                    return
+                profile_info_input = input(
+                    f"Enter profile information for '{username}' (optional, press Enter to skip): "
+                )
+                profile_info = profile_info_input if profile_info_input else None
+            except EOFError:
+                print("Cannot create user interactively without password. Please run interactively or use args.")
                 return
-            password_confirm = getpass.getpass("Confirm password: ")
-            if password != password_confirm:
-                print("Passwords do not match. Aborting user creation.")
-                return
 
-            profile_info_input = input(
-                f"Enter profile information for '{username}' (optional, press Enter to skip): "
-            )
-            profile_info = profile_info_input if profile_info_input else None
-
-            # Removed profile_photo_url input as it's not handled robustly here
-            # and can be updated via the profile edit page.
-            # For simplicity, it's not part of initial user creation via CLI.
-
-        except EOFError:
-            print(
-                "Cannot create user in non-interactive mode without password. Please run interactively."
-            )
-            return
-
-        new_user = User(username=username, profile_info=profile_info) # Removed profile_photo_url
+        # For both interactive and non-interactive new user creation
+        new_user = User(
+            username=username,
+            profile_info=profile_info,
+            is_admin=True,  # Initial user is admin
+            is_approved=True, # Admin user is auto-approved
+            is_active=True    # Admin user is auto-active
+        )
         new_user.set_password(password)
         db.session.add(new_user)
         db.session.commit()
-        print(f"User '{username}' created successfully.")
+        print(f"User '{username}' created successfully and set as admin, approved, and active.")
 
 
-def delete_tables_interactive(flask_app):
+def delete_database_tables(flask_app, script_args):
     """
-    Drops all known tables from the database after user confirmation.
+    Drops all known tables from the database.
+    Handles interactive confirmation or non-interactive deletion based on script_args.
     Requires an active application context.
+    Returns True if deletion occurred, False otherwise.
     """
-    with flask_app.app_context():
+    is_non_interactive_delete = script_args.deletedb and script_args.admin_user and script_args.admin_pass
+
+    if is_non_interactive_delete:
+        print("Non-interactive mode: Deleting all database tables as --deletedb is present with admin creation flags.")
+        with flask_app.app_context():
+            db.drop_all()
+        print("All tables deleted non-interactively.")
+        return True
+    elif script_args.deletedb: # Interactive deletion
         try:
             confirm = input("Are you sure you want to delete all database tables? This cannot be undone. (yes/no): ").lower()
+            if confirm == 'yes':
+                print("Deleting database tables...")
+                with flask_app.app_context():
+                    db.drop_all()
+                print("All tables deleted.")
+                return True
+            else:
+                print("Table deletion cancelled.")
+                return False
         except EOFError:
-            print("Non-interactive mode: Cannot confirm table deletion. Aborting.")
-            return False # Indicate deletion was aborted
+            print("Non-interactive mode (--deletedb without admin args): Cannot confirm table deletion. Aborting.")
+            return False
+    return False # No deletion was triggered or completed
 
-        if confirm == 'yes':
-            print("Deleting database tables...")
-            db.drop_all()
-            print("All tables deleted.")
-            return True # Indicate deletion happened
-        else:
-            print("Table deletion cancelled.")
-            return False # Indicate deletion was cancelled
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Manage the application database.")
@@ -140,41 +173,48 @@ if __name__ == "__main__":
         action='store_true',
         help='Skip initial user setup/update.'
     )
+    parser.add_argument('--admin-user', help='Set initial admin username non-interactively.')
+    parser.add_argument('--admin-pass', help='Set initial admin password non-interactively.')
+    parser.add_argument('--admin-bio', help='Set initial admin bio non-interactively (optional).')
+
     # --skiptables is implicitly handled: if --deletedb is not followed by explicit creation, tables remain deleted.
     # The create_all() call below will ensure tables are present unless deleted and not recreated.
 
     args = parser.parse_args()
 
+    # Validate non-interactive admin creation args
+    if (args.admin_user and not args.admin_pass) or (not args.admin_user and args.admin_pass):
+        parser.error("--admin-user and --admin-pass must be used together.")
+
     print("Starting database setup...")
 
     # Instantiate the app using the factory
+    print("DEBUG: About to call create_app()")
     app = create_app()
+    print("DEBUG: create_app() returned")
+    app.config['SETUP_DB_SCRIPT_ARGS'] = args # Pass script args to app config
+    print(f"DEBUG: Script args set in app.config: {args}")
 
-    tables_deleted_and_not_recreated = False
     if args.deletedb:
-        if delete_tables_interactive(app): # This function now returns True if deletion occurred
-            # If tables were deleted, we might not want to immediately recreate them
-            # if the user's intention was purely to delete.
-            # However, for typical setup, recreation is desired.
-            # The example logic implies recreation unless specifically skipped.
-            # For simplicity here, we'll let the subsequent create_all handle it.
-            print("Tables were targeted for deletion.")
-        else:
-            # Deletion was cancelled or failed (e.g. non-interactive)
-            # We should probably not proceed to user creation if DB state is uncertain.
-            print("Table deletion process finished or was aborted. Review messages above.")
+        print("DEBUG: --deletedb flag is present. Calling delete_database_tables()")
+        delete_database_tables(app, args)
+        print("DEBUG: delete_database_tables() returned")
 
 
     # Always ensure tables exist by this point, creating them if necessary.
     # This will create tables if they don't exist, or do nothing if they do.
     # If --deletedb was used and tables were dropped, this will recreate them.
+    print("DEBUG: About to enter app_context for db.create_all()")
     with app.app_context():
-        print("Ensuring database tables exist (creating if necessary)...")
+        print("DEBUG: Entered app_context. Calling db.create_all()...")
         db.create_all()
-        print("Database tables ensured/created.")
+        print("DEBUG: db.create_all() returned.")
+    print("DEBUG: Exited app_context for db.create_all()")
 
     if not args.skipuser:
-        create_initial_user(app) # This function handles its own app context
+        print("DEBUG: --skipuser is false. Calling create_initial_user()")
+        create_initial_user(app) # This function handles its own app context and gets args from app.config
+        print("DEBUG: create_initial_user() returned")
     else:
         print("Skipping initial user setup as per --skipuser flag.")
 

--- a/app-demo/templates/admin_pending_users.html
+++ b/app-demo/templates/admin_pending_users.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Pending User Approvals{% endblock %}
+
+{% block header_title %}Pending User Approvals{% endblock %}
+
+{% block content %}
+<div class="adw-preferences-page"> {# Using preferences-page for consistent admin styling #}
+    <header class="adw-preferences-page__header">
+        <h1 class="adw-preferences-page__title">Manage Pending User Registrations</h1>
+        <p class="adw-preferences-page__description">
+            Review and approve or reject new user registrations.
+        </p>
+    </header>
+
+    {% if pending_users %}
+    <section class="adw-preferences-group" aria-labelledby="pending-users-title">
+        <h2 class="adw-preferences-group__title" id="pending-users-title">Users Awaiting Approval</h2>
+        <div class="adw-list-box">
+            {% for user_account in pending_users %}
+            <div class="adw-action-row">
+                <div class="adw-action-row__text">
+                    <span class="adw-action-row__title">{{ user_account.username }}</span>
+                    {# Could add registration date here if available and desired #}
+                    {# <span class="adw-action-row__subtitle">Registered: {{ user_account.created_at|datetimeformat }}</span> #}
+                </div>
+                <div class="adw-action-row__actions adw-box horizontal spacing-s">
+                    {# Approve Form - Minimal form for CSRF #}
+                    <form method="POST" action="{{ url_for('admin.approve_user', user_id=user_account.id) }}" style="display: inline;">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="adw-button suggested-action">Approve</button>
+                    </form>
+                    {# Reject Form - Minimal form for CSRF #}
+                    <form method="POST" action="{{ url_for('admin.reject_user', user_id=user_account.id) }}" style="display: inline;">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="adw-button destructive-action">Reject</button>
+                    </form>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+
+    {% if user_pagination and (user_pagination.has_prev or user_pagination.has_next) %}
+    <nav aria-label="User pagination" class="pagination-nav adw-box horizontal justify-center" style="margin-top: var(--spacing-l);">
+        {% if user_pagination.has_prev %}
+            <a href="{{ url_for('admin.pending_users', page=user_pagination.prev_num) }}" class="adw-button">
+                <span class="adw-icon icon-actions-go-previous-symbolic"></span> Previous
+            </a>
+        {% endif %}
+        <span class="adw-label" style="margin: 0 var(--spacing-m);">Page {{ user_pagination.page }} of {{ user_pagination.pages }}.</span>
+        {% if user_pagination.has_next %}
+            <a href="{{ url_for('admin.pending_users', page=user_pagination.next_num) }}" class="adw-button">
+                Next <span class="adw-icon icon-actions-go-next-symbolic"></span>
+            </a>
+        {% endif %}
+    </nav>
+    {% endif %}
+
+    {% else %}
+    <div class="adw-status-page">
+      <span class="adw-status-page__icon icon-status-info-symbolic"></span>
+      <h2 class="adw-status-page__title">No Pending Approvals</h2>
+      <p class="adw-status-page__description">There are currently no users awaiting approval.</p>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -143,6 +143,11 @@
                     <span class="adw-action-row-icon icon-actions-document-properties-symbolic"></span>
                     <span class="adw-action-row-title">Site Settings</span>
                 </a>
+                <a href="{{ url_for('admin.pending_users') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'admin.pending_users' }}">
+                    <span class="adw-action-row-icon icon-community-users-symbolic"></span> {# Or similar relevant icon #}
+                    <span class="adw-action-row-title">Pending Users</span>
+                    {# Optionally, add a badge for count of pending users if available in context #}
+                </a>
             {% endif %}
             {% endif %}
             {% endblock sidebar_nav %}

--- a/app-demo/templates/register.html
+++ b/app-demo/templates/register.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% block title %}Register{% endblock %}
+
+{% block header_title %}Create Account{% endblock %}
+
+{% block content %}
+<div class="auth-form-container">
+    <h1 class="adw-title-1 form-page-header">Create a New Account</h1>
+
+    {% if not site_settings.get('allow_registrations', False) %}
+        <div class="adw-banner adw-banner-warning visible" role="alert" style="margin-bottom: var(--spacing-l);">
+            <span class="adw-banner-title">User registration is currently disabled by the site administrator.</span>
+        </div>
+    {% else %}
+        <form method="POST" action="{{ url_for('auth.register') }}" id="register-form" class="stacked-form">
+            {{ form.hidden_tag() }} {# CSRF token #}
+
+            <div class="adw-list-box" role="group" aria-labelledby="register-group-title">
+                {# Email (Username) Field #}
+                <div class="adw-entry-row {{ 'has-error' if form.email.errors else '' }}">
+                    <label for="{{ form.email.id or 'email_input' }}" class="adw-entry-row-title">{{ form.email.label.text }}</label>
+                    <input type="email"
+                           name="{{ form.email.name }}"
+                           id="{{ form.email.id or 'email_input' }}"
+                           class="adw-entry adw-entry-row-entry"
+                           required
+                           placeholder="your.email@example.com"
+                           value="{{ form.email.data or '' }}">
+                    {% if form.email.errors %}
+                        <span class="adw-label caption error-text adw-entry-row-subtitle">{{ form.email.errors|join(' ') }}</span>
+                    {% endif %}
+                </div>
+
+                {# Password Field #}
+                <div class="adw-entry-row {{ 'has-error' if form.password.errors else '' }}">
+                    <label for="{{ form.password.id or 'password_input' }}" class="adw-entry-row-title">{{ form.password.label.text }}</label>
+                    <input type="password"
+                           name="{{ form.password.name }}"
+                           id="{{ form.password.id or 'password_input' }}"
+                           class="adw-entry adw-entry-row-entry"
+                           required
+                           placeholder="Choose a strong password (min. 8 characters)">
+                     {% if form.password.errors %}
+                        <span class="adw-label caption error-text adw-entry-row-subtitle">{{ form.password.errors|join(' ') }}</span>
+                    {% endif %}
+                </div>
+
+                {# Confirm Password Field #}
+                <div class="adw-entry-row {{ 'has-error' if form.confirm_password.errors else '' }}">
+                    <label for="{{ form.confirm_password.id or 'confirm_password_input' }}" class="adw-entry-row-title">{{ form.confirm_password.label.text }}</label>
+                    <input type="password"
+                           name="{{ form.confirm_password.name }}"
+                           id="{{ form.confirm_password.id or 'confirm_password_input' }}"
+                           class="adw-entry adw-entry-row-entry"
+                           required
+                           placeholder="Confirm your password">
+                    {% if form.confirm_password.errors %}
+                        <span class="adw-label caption error-text adw-entry-row-subtitle">{{ form.confirm_password.errors|join(' ') }}</span>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="adw-box horizontal justify-end" style="margin-top: var(--spacing-m);">
+                <button type="submit" class="adw-button suggested-action">{{ form.submit.label.text }}</button>
+            </div>
+        </form>
+
+        <div class="adw-box horizontal justify-center" style="margin-top: var(--spacing-m);">
+            <a href="{{ url_for('auth.login') }}" class="adw-link">Already have an account? Log in</a>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds a user registration system where new users (using email as username) must be approved by an administrator before they can log in.

Key changes:
- User model: Added `is_approved` and `is_active` fields.
- Forms: Created `RegistrationForm`.
- Auth Routes:
    - Added `/register` route.
    - Updated `/login` route to check approval/active status.
- Admin Routes:
    - Added `/admin/pending_users` to list users awaiting approval.
    - Added `/admin/users/<id>/approve` and `/admin/users/<id>/reject` routes.
- Templates:
    - Created `register.html` for registration.
    - Created `admin_pending_users.html` for the moderation interface.
    - Updated `base.html` sidebar with a link to pending users.
    - `login.html` already correctly handles conditional display of register link.
- `build-adwaita-web.sh`: Ensured SASS is compiled (requires `sass` to be installed).
- `setup_db.py`: Modified to support non-interactive admin user creation and to be the primary place for `db.create_all()`.
- `app-demo/__init__.py`: Removed redundant `db.create_all()` call.

Note: Testing in the sandbox was hindered by persistent Python execution timeouts. Further local testing of the database setup and application runtime is recommended.