### PR TITLE
feat: Implement user registration with admin approval (v2)

### DIFF
--- a/app-demo/setup_db.py
+++ b/app-demo/setup_db.py
@@ -26,6 +26,7 @@ app_module = importlib.import_module("app-demo")
 create_app = app_module.create_app
 db = app_module.db
 User = app_module.models.User
+SiteSetting = app_module.models.SiteSetting # Import SiteSetting
 
 
 def create_initial_user(flask_app):
@@ -124,6 +125,15 @@ def create_initial_user(flask_app):
         )
         new_user.set_password(password)
         db.session.add(new_user)
+
+        # Set default site settings on initial user creation if non-interactive
+        if not is_interactive:
+            print(f"DEBUG: Setting initial site settings for non-interactive setup.")
+            SiteSetting.set('site_title', 'Adwaita Social Demo', 'string')
+            SiteSetting.set('posts_per_page', 10, 'int')
+            SiteSetting.set('allow_registrations', True, 'bool')
+            print(f"DEBUG: allow_registrations set to True.")
+
         db.session.commit()
         print(f"User '{username}' created successfully and set as admin, approved, and active.")
 


### PR DESCRIPTION
Adds a user registration system where new users (using email as username) must be approved by an administrator before they can log in.

Key changes:
- User model: Added `is_approved` and `is_active` fields.
- Forms: Created `RegistrationForm`.
- Auth Routes:
    - Added `/register` route.
    - Updated `/login` route to check approval/active status.
- Admin Routes:
    - Added `/admin/pending_users` to list users awaiting approval.
    - Added `/admin/users/<id>/approve` and `/admin/users/<id>/reject` routes.
- Templates:
    - Created `register.html` for registration.
    - Created `admin_pending_users.html` for the moderation interface.
    - Updated `base.html` sidebar with a link to pending users.
    - `login.html` logic for register link confirmed.
- `build-adwaita-web.sh`: Ensured SASS is compiled (requires `sass` to be installed).
- `setup_db.py`:
    - Modified to support non-interactive admin user creation.
    - Sets 'allow_registrations' to True by default during non-interactive admin setup to ensure registration link is visible.
    - Imported `SiteSetting` model.
- `app-demo/__init__.py`: Removed redundant `db.create_all()` call.

Note: Testing in the sandbox was hindered by persistent Python execution timeouts, preventing server startup and automated checks. Local testing by the user is recommended.