### PR TITLE
feat: Implement user registration with admin approval (v3)

### DIFF
--- a/app-demo/setup_db.py
+++ b/app-demo/setup_db.py
@@ -221,8 +221,23 @@ if __name__ == "__main__":
         print("DEBUG: db.create_all() returned.")
     print("DEBUG: Exited app_context for db.create_all()")
 
+    # Initialize default site settings if they don't exist
+    with app.app_context():
+        print("DEBUG: Checking/Initializing default site settings...")
+        if SiteSetting.query.filter_by(key='allow_registrations').first() is None:
+            SiteSetting.set('allow_registrations', True, 'bool')
+            print("DEBUG: Default 'allow_registrations' set to True as it was missing.")
+        if SiteSetting.query.filter_by(key='site_title').first() is None:
+            SiteSetting.set('site_title', 'Adwaita Social Demo', 'string')
+        if SiteSetting.query.filter_by(key='posts_per_page').first() is None:
+            SiteSetting.set('posts_per_page', 10, 'int')
+        # Ensure commit if SiteSetting.set doesn't commit itself (original did, current one in models.py does)
+        # db.session.commit() # Not needed if SiteSetting.set commits
+
     if not args.skipuser:
         print("DEBUG: --skipuser is false. Calling create_initial_user()")
+        # The create_initial_user function might also set allow_registrations True
+        # for non-interactive, which is fine (idempotent or last-write wins).
         create_initial_user(app) # This function handles its own app context and gets args from app.config
         print("DEBUG: create_initial_user() returned")
     else:


### PR DESCRIPTION
Adds a user registration system where new users (using email as username) must be approved by an administrator before they can log in.

Key changes:
- User model: Added `is_approved` and `is_active` fields.
- Forms: Created `RegistrationForm`.
- Auth Routes:
    - Added `/register` route.
    - Updated `/login` route to check approval/active status.
- Admin Routes:
    - Added `/admin/pending_users` to list users awaiting approval.
    - Added `/admin/users/<id>/approve` and `/admin/users/<id>/reject` routes.
- Templates:
    - Created `register.html` for registration.
    - Created `admin_pending_users.html` for the moderation interface.
    - Updated `base.html` sidebar with a link to pending users.
    - `login.html` structure for register link confirmed; visibility depends on `allow_registrations` site setting.
- `build-adwaita-web.sh`: Ensured SASS is compiled (requires `sass` to be installed).
- `setup_db.py`:
    - Modified to support non-interactive admin user creation.
    - **Crucially, now ensures 'allow_registrations' site setting defaults to True if not already set during database initialization, making the registration link visible by default for new setups.**
    - Imported `SiteSetting` model.
- `app-demo/__init__.py`: Removed redundant `db.create_all()` call.

Note: Testing in the sandbox remains hindered by persistent Python execution timeouts, preventing server startup and automated checks. Local testing by the user is recommended to confirm all flows.