### PR TITLE
Fix: Correct icon paths, title styling, and dialog functionality

### DIFF
--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -223,6 +223,13 @@ $accent-definitions: (
   --title-2-font-size: #{math.round($font-size-base-val * 1.5)};   // approx 15pt
   --title-1-font-size: #{math.round($font-size-base-val * 1.8)};   // approx 18pt
 
+  // Variables for h1-h6 tags, mapping to title sizes for consistency
+  --h1-font-size: var(--title-1-font-size);
+  --h2-font-size: var(--title-2-font-size);
+  --h3-font-size: var(--title-3-font-size);
+  --h4-font-size: var(--title-4-font-size);
+  // h5 and h6 are mapped to --font-size-large and --font-size-base in _base.scss respectively
+
   // ProgressBar specific
   --progress-bar-track-color: var(--shade-color); // Default track to general shade color
   --progress-bar-fill-color: var(--accent-bg-color); // Fill uses accent

--- a/index.html
+++ b/index.html
@@ -132,42 +132,48 @@
 
         /* Load all icons used in this demo */
         /* (List of all .icon-*-symbolic classes from previous index.html, plus new ones if needed) */
-        .icon-actions-go-previous-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/go-previous-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/go-previous-symbolic.svg"); }
-        .icon-actions-open-menu-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/open-menu-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/open-menu-symbolic.svg"); }
-        .icon-actions-document-new-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/document-new-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/document-new-symbolic.svg"); }
-        .icon-actions-document-save-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/document-save-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/document-save-symbolic.svg"); }
-        .icon-actions-document-open-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/document-open-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/document-open-symbolic.svg"); }
-        .icon-actions-edit-delete-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/edit-delete-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/edit-delete-symbolic.svg"); }
-        .icon-actions-document-print-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/document-print-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/document-print-symbolic.svg"); }
-        .icon-devices-camera-photo-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/devices/camera-photo-symbolic.svg"); mask-image: url("build/data/icons/symbolic/devices/camera-photo-symbolic.svg"); }
-        .icon-actions-call-start-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/call-start-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/call-start-symbolic.svg"); }
-        .icon-actions-call-stop-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/call-stop-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/call-stop-symbolic.svg"); }
-        .icon-ui-pan-down-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/ui/pan-down-symbolic.svg"); mask-image: url("build/data/icons/symbolic/ui/pan-down-symbolic.svg"); }
-        .icon-actions-application-exit-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/application-exit-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/application-exit-symbolic.svg"); }
-        .icon-status-dialog-error-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/status/dialog-error-symbolic.svg"); mask-image: url("build/data/icons/symbolic/status/dialog-error-symbolic.svg"); }
-        .icon-ui-pan-up-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/ui/pan-up-symbolic.svg"); mask-image: url("build/data/icons/symbolic/ui/pan-up-symbolic.svg"); }
-        .icon-actions-media-playback-start-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/media-playback-start-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/media-playback-start-symbolic.svg"); }
-        .icon-apps-help-contents-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/apps/help-contents-symbolic.svg"); mask-image: url("build/data/icons/symbolic/apps/help-contents-symbolic.svg");}
-        .icon-status-emblem-ok-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/status/emblem-ok-symbolic.svg"); mask-image: url("build/data/icons/symbolic/status/emblem-ok-symbolic.svg");}
-        .icon-actions-go-next-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/go-next-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/go-next-symbolic.svg");}
-        .icon-status-dialog-information-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/status/dialog-information-symbolic.svg"); mask-image: url("build/data/icons/symbolic/status/dialog-information-symbolic.svg");}
-        .icon-status-dialog-warning-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/status/dialog-warning-symbolic.svg"); mask-image: url("build/data/icons/symbolic/status/dialog-warning-symbolic.svg");}
-        .icon-actions-go-up-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/go-up-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/go-up-symbolic.svg");}
-        .icon-actions-go-down-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/go-down-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/go-down-symbolic.svg");}
-        .icon-emoji-face-smile-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/emoji/face-smile-symbolic.svg"); mask-image: url("build/data/icons/symbolic/emoji/face-smile-symbolic.svg");}
-        .icon-actions-edit-select-all-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/edit-select-all-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/edit-select-all-symbolic.svg");}
-        .icon-emoji-face-plain-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/emoji/face-plain-symbolic.svg"); mask-image: url("build/data/icons/symbolic/emoji/face-plain-symbolic.svg");}
-        .icon-categories-applications-graphics-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/categories/applications-graphics-symbolic.svg"); mask-image: url("build/data/icons/symbolic/categories/applications-graphics-symbolic.svg");}
-        .icon-categories-applications-multimedia-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/categories/applications-multimedia-symbolic.svg"); mask-image: url("build/data/icons/symbolic/categories/applications-multimedia-symbolic.svg");}
-        .icon-categories-applications-utilities-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/categories/applications-utilities-symbolic.svg"); mask-image: url("build/data/icons/symbolic/categories/applications-utilities-symbolic.svg");}
-        .icon-actions-send-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/send-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/send-symbolic.svg");}
-        .icon-actions-bookmark-new-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/bookmark-new-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/bookmark-new-symbolic.svg");}
-        .icon-actions-system-search-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/system-search-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/system-search-symbolic.svg");}
-        .icon-actions-view-refresh-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/actions/view-refresh-symbolic.svg"); mask-image: url("build/data/icons/symbolic/actions/view-refresh-symbolic.svg");}
-        .icon-places-user-home-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/places/user-home-symbolic.svg"); mask-image: url("build/data/icons/symbolic/places/user-home-symbolic.svg");}
-        .icon-status-weather-clear-night-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/status/weather-clear-night-symbolic.svg"); mask-image: url("build/data/icons/symbolic/status/weather-clear-night-symbolic.svg");}
-        .icon-status-avatar-default-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/status/avatar-default-symbolic.svg"); mask-image: url("build/data/icons/symbolic/status/avatar-default-symbolic.svg");}
-        .icon-ui-view-more-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/ui/view-more-symbolic.svg"); mask-image: url("build/data/icons/symbolic/ui/view-more-symbolic.svg");}
+        .icon-actions-go-previous-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/go-previous-symbolic.svg"); mask-image: url("build/data/icons/symbolic/go-previous-symbolic.svg"); }
+        .icon-actions-open-menu-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/open-menu-symbolic.svg"); mask-image: url("build/data/icons/symbolic/open-menu-symbolic.svg"); }
+        .icon-actions-document-new-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/document-new-symbolic.svg"); mask-image: url("build/data/icons/symbolic/document-new-symbolic.svg"); }
+        .icon-actions-document-save-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/document-save-symbolic.svg"); mask-image: url("build/data/icons/symbolic/document-save-symbolic.svg"); }
+        .icon-actions-document-open-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/document-open-symbolic.svg"); mask-image: url("build/data/icons/symbolic/document-open-symbolic.svg"); }
+        .icon-actions-edit-delete-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/edit-delete-symbolic.svg"); mask-image: url("build/data/icons/symbolic/edit-delete-symbolic.svg"); }
+        .icon-actions-document-print-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/document-print-symbolic.svg"); mask-image: url("build/data/icons/symbolic/document-print-symbolic.svg"); }
+        .icon-devices-camera-photo-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/camera-photo-symbolic.svg"); mask-image: url("build/data/icons/symbolic/camera-photo-symbolic.svg"); }
+        .icon-actions-call-start-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/call-start-symbolic.svg"); mask-image: url("build/data/icons/symbolic/call-start-symbolic.svg"); }
+        .icon-actions-call-stop-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/call-stop-symbolic.svg"); mask-image: url("build/data/icons/symbolic/call-stop-symbolic.svg"); }
+        .icon-ui-pan-down-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/pan-down-symbolic.svg"); mask-image: url("build/data/icons/symbolic/pan-down-symbolic.svg"); }
+        .icon-actions-application-exit-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/application-exit-symbolic.svg"); mask-image: url("build/data/icons/symbolic/application-exit-symbolic.svg"); }
+        .icon-status-dialog-error-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/dialog-error-symbolic.svg"); mask-image: url("build/data/icons/symbolic/dialog-error-symbolic.svg"); }
+        .icon-ui-pan-up-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/pan-up-symbolic.svg"); mask-image: url("build/data/icons/symbolic/pan-up-symbolic.svg"); }
+        .icon-actions-media-playback-start-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/media-playback-start-symbolic.svg"); mask-image: url("build/data/icons/symbolic/media-playback-start-symbolic.svg"); }
+        .icon-apps-help-contents-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/help-contents-symbolic.svg"); mask-image: url("build/data/icons/symbolic/help-contents-symbolic.svg");}
+        .icon-status-emblem-ok-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/emblem-ok-symbolic.svg"); mask-image: url("build/data/icons/symbolic/emblem-ok-symbolic.svg");}
+        .icon-actions-go-next-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/go-next-symbolic.svg"); mask-image: url("build/data/icons/symbolic/go-next-symbolic.svg");}
+        .icon-status-dialog-information-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/dialog-information-symbolic.svg"); mask-image: url("build/data/icons/symbolic/dialog-information-symbolic.svg");}
+        .icon-status-dialog-warning-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/dialog-warning-symbolic.svg"); mask-image: url("build/data/icons/symbolic/dialog-warning-symbolic.svg");}
+        .icon-actions-go-up-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/go-up-symbolic.svg"); mask-image: url("build/data/icons/symbolic/go-up-symbolic.svg");}
+        .icon-actions-go-down-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/go-down-symbolic.svg"); mask-image: url("build/data/icons/symbolic/go-down-symbolic.svg");}
+        .icon-emoji-face-smile-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/face-smile-symbolic.svg"); mask-image: url("build/data/icons/symbolic/face-smile-symbolic.svg");}
+        .icon-actions-edit-select-all-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/edit-select-all-symbolic.svg"); mask-image: url("build/data/icons/symbolic/edit-select-all-symbolic.svg");}
+        .icon-emoji-face-plain-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/face-plain-symbolic.svg"); mask-image: url("build/data/icons/symbolic/face-plain-symbolic.svg");}
+        .icon-categories-applications-graphics-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/applications-graphics-symbolic.svg"); mask-image: url("build/data/icons/symbolic/applications-graphics-symbolic.svg");}
+        .icon-categories-applications-multimedia-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/applications-multimedia-symbolic.svg"); mask-image: url("build/data/icons/symbolic/applications-multimedia-symbolic.svg");}
+        .icon-categories-applications-utilities-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/applications-utilities-symbolic.svg"); mask-image: url("build/data/icons/symbolic/applications-utilities-symbolic.svg");}
+        .icon-actions-send-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/send-symbolic.svg"); mask-image: url("build/data/icons/symbolic/send-symbolic.svg");}
+        .icon-actions-bookmark-new-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/bookmark-new-symbolic.svg"); mask-image: url("build/data/icons/symbolic/bookmark-new-symbolic.svg");}
+        .icon-actions-system-search-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/system-search-symbolic.svg"); mask-image: url("build/data/icons/symbolic/system-search-symbolic.svg");}
+        .icon-actions-view-refresh-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/view-refresh-symbolic.svg"); mask-image: url("build/data/icons/symbolic/view-refresh-symbolic.svg");}
+        .icon-places-user-home-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/user-home-symbolic.svg"); mask-image: url("build/data/icons/symbolic/user-home-symbolic.svg");}
+        .icon-status-weather-clear-night-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/weather-clear-night-symbolic.svg"); mask-image: url("build/data/icons/symbolic/weather-clear-night-symbolic.svg");}
+        .icon-status-avatar-default-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/avatar-default-symbolic.svg"); mask-image: url("build/data/icons/symbolic/avatar-default-symbolic.svg");}
+        .icon-ui-view-more-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/view-more-symbolic.svg"); mask-image: url("build/data/icons/symbolic/view-more-symbolic.svg");}
+        /* For icons that might be directly in symbolic/ (like pan-up, pan-down, window-close from logs) */
+        .icon-pan-up-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/pan-up-symbolic.svg"); mask-image: url("build/data/icons/symbolic/pan-up-symbolic.svg"); }
+        .icon-pan-down-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/pan-down-symbolic.svg"); mask-image: url("build/data/icons/symbolic/pan-down-symbolic.svg"); }
+        .icon-window-close-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/window-close-symbolic.svg"); mask-image: url("build/data/icons/symbolic/window-close-symbolic.svg"); }
+        .icon-process-working-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/process-working-symbolic.svg"); mask-image: url("build/data/icons/symbolic/process-working-symbolic.svg"); }
+
 
         /* Helper for static popover */
         .static-popover-container {
@@ -222,12 +228,12 @@
         <!-- Labels & Text -->
         <section class="widget-showcase">
             <h2 class="adw-label title-2">Labels & Text Styles</h2>
-            <p><span class="adw-label title-1">Title 1 Label</span></p>
-            <p><span class="adw-label title-2">Title 2 Label</span></p>
-            <p><span class="adw-label title-3">Title 3 Label</span></p>
-            <p><span class="adw-label title-4">Title 4 Label</span> (if defined, otherwise regular)</p>
-            <p><span class="adw-label body">Standard body label. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span></p>
-            <p><span class="adw-label body-large">Large body label (if defined).</span> Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <h1 class="adw-label title-1">Title 1 Label</h1>
+            <h2 class="adw-label title-2">Title 2 Label</h2>
+            <h3 class="adw-label title-3">Title 3 Label</h3>
+            <h4 class="adw-label title-4">Title 4 Label</h4>
+            <p class="adw-label body">Standard body label. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span></p>
+            <p class="adw-label body-large">Large body label (if defined).</span> Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p><span class="adw-label dim-label">Dim label (if utility class exists or applied by context).</span> Ut enim ad minim veniam.</p>
             <p><a href="#" class="adw-label link">Link Label (if specific class exists)</a> or just <a href="#">a standard link</a>.</p>
             <p><label class="adw-label selectable">Selectable text label (if class exists)</label></p>
@@ -1315,7 +1321,7 @@
 
 
         // Function to make closeDialogById globally accessible for inline onclick attributes
-        window.closeDialog = closeDialogById;
+        window.closeDialogById = closeDialogById; // Corrected global exposure
 
         // Toast Demo
         function ensureToastOverlay() {


### PR DESCRIPTION
- Icon Paths: Updated all inline CSS icon `url()` paths in `index.html` to correctly reference `build/data/icons/symbolic/ICON_NAME.svg`, reflecting a flat structure post-build. This addresses 404 errors for icons assuming source SVGs are present in `adwaita-web/data/icons/symbolic/` for the build script to copy.
- Title Styling (H1-H6): Fixed missing CSS variable definitions for `h1-h4` font sizes in `adwaita-web/scss/_variables.scss` by mapping them to existing `--title-X` variables. Updated `index.html` to use semantic heading tags with appropriate Adwaita classes for titles.
- Dialog Functionality: Corrected JavaScript error in global function exposure for `closeDialogById`, enabling dialogs to be closed correctly by their internal buttons and the Escape key. Dialogs are now interactive.
- Build: Ran build script to compile SCSS changes for title styling.

These changes address critical issues related to broken icon links, non-styled H1-H6 titles, and non-functional dialogs in the `index.html` showcase.