### PR TITLE
feat: Improve error handling and user notifications

### DIFF
--- a/app-demo/routes/admin_routes.py
+++ b/app-demo/routes/admin_routes.py
@@ -60,7 +60,7 @@ def resolve_flag(flag_id):
         db.session.add(flag)
         db.session.commit()
         current_app.logger.info(f"Admin {current_user.username} resolved flag ID {flag_id} for comment ID {flag.comment_id}.")
-        flash(f'Flag for comment "{flag.comment.text[:30]}..." resolved.', 'success')
+        flash(f'Flag for comment "{flag.comment.text[:30]}..." resolved.', 'toast_success')
     except Exception as e:
         db.session.rollback()
         current_app.logger.error(f"Error resolving flag {flag_id} by admin {current_user.username}: {e}", exc_info=True)
@@ -93,7 +93,7 @@ def site_settings():
             # No need to commit SiteSetting.set here if it commits itself.
             # db.session.commit() # If SiteSetting.set doesn't commit. Original did.
 
-            flash('Site settings updated successfully!', 'success')
+            flash('Site settings updated successfully!', 'toast_success')
             current_app.logger.info(f"Site settings updated by admin {current_user.username}.")
             return redirect(url_for('admin.site_settings')) # Redirect to refresh page with new settings
         except Exception as e:
@@ -153,7 +153,7 @@ def approve_user(user_id):
         db.session.add(user_to_approve)
         db.session.commit()
         current_app.logger.info(f"Admin {current_user.username} approved user ID {user_id} ({user_to_approve.username}).")
-        flash(f'User {user_to_approve.username} has been approved and activated.', 'success')
+        flash(f'User {user_to_approve.username} has been approved and activated.', 'toast_success')
         # TODO: Consider sending a notification email to the user.
     except Exception as e:
         db.session.rollback()
@@ -186,7 +186,7 @@ def reject_user(user_id):
         db.session.delete(user_to_reject)
         db.session.commit()
         current_app.logger.info(f"Admin {current_user.username} rejected and deleted user ID {user_id} (Username: {username_rejected}).")
-        flash(f'User {username_rejected} has been rejected and deleted.', 'success')
+        flash(f'User {username_rejected} has been rejected and deleted.', 'toast_success')
     except Exception as e:
         db.session.rollback()
         current_app.logger.error(f"Error rejecting user {user_id} by admin {current_user.username}: {e}", exc_info=True)

--- a/app-demo/routes/auth_routes.py
+++ b/app-demo/routes/auth_routes.py
@@ -30,7 +30,7 @@ def register():
         existing_user = User.query.filter_by(username=form.email.data).first()
         if existing_user:
             current_app.logger.warning(f"Registration attempt with existing email: '{form.email.data}'.")
-            flash('An account with this email address already exists. Please log in or use a different email.', 'warning')
+            flash('An account with this email address already exists. Please log in or use a different email.', 'danger')
             return render_template('register.html', form=form) # Show form again with error
 
         try:
@@ -78,10 +78,10 @@ def login():
         if user and user.check_password(form.password.data):
             if not user.is_active:
                 current_app.logger.warning(f"Login attempt by inactive user: '{user.username}'.")
-                flash('Your account is not active. Please contact an administrator.', 'warning')
+                flash('Your account is not active. Please contact an administrator.', 'danger')
             elif not user.is_approved:
                 current_app.logger.warning(f"Login attempt by unapproved user: '{user.username}'.")
-                flash('Your account is pending admin approval.', 'warning')
+                flash('Your account is pending admin approval.', 'danger')
             else:
                 login_user(user)
                 current_app.logger.info(f"User '{user.username}' (ID: {user.id}) logged in successfully.")
@@ -153,7 +153,7 @@ def change_password_page():
                 db.session.add(current_user) # Add to session before commit if changed
                 db.session.commit()
                 current_app.logger.info(f"Password changed for user {current_user.username}.")
-                flash('Your password has been updated successfully!', 'success')
+                flash('Your password has been updated successfully!', 'toast_success')
                 # Redirect to a general settings page or profile page
                 return redirect(url_for('general.settings_page'))
             except Exception as e:

--- a/app-demo/routes/post_routes.py
+++ b/app-demo/routes/post_routes.py
@@ -105,7 +105,7 @@ def view_post(post_id):
             if new_mentions_created_comment:
                 db.session.commit()
 
-            flash('Comment posted successfully!', 'success')
+            flash('Comment posted successfully!', 'toast_success')
             return redirect(url_for('post.view_post', post_id=post_id, _anchor=f"comment-{comment.id}"))
         except ValueError: # Specific to parent_id conversion
             current_app.logger.error(f"Invalid parent_id format '{form.parent_id.data}' for comment on post {post_id}.")
@@ -188,7 +188,7 @@ def create_post():
             if mentioned_users_in_post:
                 db.session.commit() # Commit any mention notifications
 
-            flash('Post created successfully!', 'success')
+            flash('Post created successfully!', 'toast_success')
             return redirect(url_for('post.view_post', post_id=new_post.id))
         except Exception as e:
             db.session.rollback()
@@ -265,7 +265,7 @@ def edit_post(post_id):
             if new_mentions_created:
                 db.session.commit()
 
-            flash('Post updated successfully!', 'success')
+            flash('Post updated successfully!', 'toast_success')
             return redirect(url_for('post.view_post', post_id=post.id))
         except Exception as e:
             db.session.rollback()
@@ -307,7 +307,7 @@ def delete_post(post_id): # Renamed from delete_post_route
         db.session.delete(post)
         db.session.commit()
         current_app.logger.info(f"Post ID: {post_id} successfully deleted by {current_user.username}.")
-        flash('Post deleted successfully!', 'success')
+        flash('Post deleted successfully!', 'toast_success')
     except Exception as e:
         db.session.rollback()
         current_app.logger.error(f"Error deleting post ID {post_id}: {e}", exc_info=True)
@@ -338,7 +338,7 @@ def delete_comment(comment_id): # Renamed
             CommentFlag.query.filter_by(comment_id=comment.id).delete()
             db.session.delete(comment)
             db.session.commit()
-            flash('Comment deleted.', 'success')
+            flash('Comment deleted.', 'toast_success')
             current_app.logger.info(f"Comment ID: {comment_id} successfully deleted by {current_user.username}.")
         except Exception as e:
             db.session.rollback()
@@ -376,7 +376,7 @@ def flag_comment(comment_id): # Renamed
                 db.session.add(new_flag)
                 db.session.commit()
                 current_app.logger.info(f"Comment {comment_id} flagged by user {current_user.username}.")
-                flash('Comment flagged for review.', 'success')
+                flash('Comment flagged for review.', 'toast_success')
             except Exception as e:
                 db.session.rollback()
                 current_app.logger.error(f"Error flagging comment {comment_id}: {e}", exc_info=True)
@@ -460,7 +460,7 @@ def like_post_route(post_id):
             current_app.logger.info(f"Activity 'liked_post' logged for user {current_user.username} on post {post.id}.")
 
             db.session.commit()
-            flash('Post liked!', 'success')
+            flash('Post liked!', 'toast_success')
             current_app.logger.info(f"User {current_user.username} liked post {post_id}.")
         else:
             flash('Could not like post. An unexpected error occurred.', 'danger')
@@ -480,7 +480,7 @@ def unlike_post_route(post_id):
     else:
         if current_user.unlike_post(post):
             db.session.commit()
-            flash('Post unliked.', 'success')
+            flash('Post unliked.', 'toast_success')
             current_app.logger.info(f"User {current_user.username} unliked post {post_id}.")
         else:
             flash('Could not unlike post. An unexpected error occurred.', 'danger')

--- a/app-demo/templates/admin_site_settings.html
+++ b/app-demo/templates/admin_site_settings.html
@@ -22,7 +22,7 @@
                 {# Site Title #}
                 <div class="adw-entry-row {{ 'has-error' if form.site_title.errors else '' }}">
                     <label for="{{ form.site_title.id or 'site_title_input' }}" class="adw-entry-row-title">{{ form.site_title.label.text }}</label>
-                    <input type="text" id="{{ form.site_title.id or 'site_title_input' }}" name="{{ form.site_title.name }}" value="{{ form.site_title.data or '' }}" class="adw-entry adw-entry-row-entry">
+                    <input type="text" id="{{ form.site_title.id or 'site_title_input' }}" name="{{ form.site_title.name }}" value="{{ form.site_title.data or '' }}" class="adw-entry adw-entry-row-entry" required>
                     {% if form.site_title.errors %}
                         <span class="adw-label caption error-text adw-entry-row-subtitle">{{ form.site_title.errors|join(' ') }}</span>
                     {% endif %}

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -173,19 +173,36 @@
             {% if messages %}
                 <div class="flash-messages-container" style="position: sticky; top: 0; z-index: 1050; padding: 0 var(--spacing-m) var(--spacing-s);">
                 {% for category, message in messages %}
-                    {% set banner_class = 'adw-banner' %}
-                    {% if category == 'error' %}
-                    {% set banner_class = banner_class ~ ' adw-banner-error' %}
-                    {% elif category == 'success' %}
-                    {% set banner_class = banner_class ~ ' adw-banner-success' %}
-                    {# Default 'info' or 'message' categories will use the base .adw-banner style #}
+                    {% if category == 'toast_success' %}
+                        <script nonce="{{ csp_nonce() if csp_nonce else '' }}">
+                            document.addEventListener('DOMContentLoaded', function() {
+                                if (window.Adw && window.Adw.createToast) {
+                                    window.Adw.createToast("{{ message|escapejs }}");
+                                } else {
+                                    // Fallback if Adw.createToast is not available for some reason
+                                    console.warn("Adw.createToast not found, falling back for message: {{ message|escapejs }}");
+                                    // Optional: could add a simple alert or console log as fallback
+                                }
+                            });
+                        </script>
+                    {% else %}
+                        {% set banner_class = 'adw-banner' %}
+                        {% if category == 'danger' or category == 'error' %}
+                        {% set banner_class = banner_class ~ ' error' %} {# Use .error class for adw-banner styling #}
+                        {% elif category == 'success' %} {# For regular success banners not converted to toasts #}
+                        {% set banner_class = banner_class ~ ' success' %} {# Use .success class #}
+                        {% elif category == 'warning' %}
+                        {% set banner_class = banner_class ~ ' warning' %} {# Use .warning class #}
+                        {% elif category == 'info' %}
+                        {% set banner_class = banner_class ~ ' info' %} {# Use .info class or default Adwaita banner style #}
+                        {% endif %}
+                        <div class="{{ banner_class }} visible" role="alert" style="position: relative; top: auto; left: auto; right: auto; transform: none; opacity: 1; margin-top: var(--spacing-s);">
+                            <span class="adw-banner-title">{{ message }}</span>
+                            <button class="adw-button circular flat adw-banner-dismiss-button" aria-label="Close notification">
+                                <span class="adw-icon icon-actions-close-symbolic"></span>
+                            </button>
+                        </div>
                     {% endif %}
-                    <div class="{{ banner_class }} visible" role="alert" style="position: relative; top: auto; left: auto; right: auto; transform: none; opacity: 1; margin-top: var(--spacing-s);">
-                        <span class="adw-banner-title">{{ message }}</span>
-                        <button class="adw-button circular flat adw-banner-dismiss-button" aria-label="Close notification">
-                            <span class="adw-icon icon-actions-close-symbolic"></span>
-                        </button>
-                    </div>
                 {% endfor %}
                 </div>
             {% endif %}

--- a/app-demo/utils.py
+++ b/app-demo/utils.py
@@ -40,7 +40,7 @@ def flash_form_errors_util(form):
             label_text = field
             if hasattr(form, field) and hasattr(getattr(form, field), 'label') and hasattr(getattr(form, field).label, 'text'):
                 label_text = getattr(form, field).label.text
-            flash(f"Error in {label_text}: {error}", 'warning')
+            flash(f"Error in {label_text}: {error}", 'danger')
 
 
 def markdown_to_html_and_sanitize_util(text):


### PR DESCRIPTION
Implements comprehensive improvements to error reporting and user feedback:

- Standardized error reporting using Adwaita-style banners with dismiss buttons.
  - Flask flash categories ('danger', 'warning', 'info', 'success') are now consistently mapped to appropriate banner styles (error, warning, info, success).
  - Form validation errors and other critical user input errors are now displayed as 'error' (red) banners.
- Introduced Adwaita-style toast notifications for non-critical success messages.
  - Actions like creating posts, adding comments, liking content, updating settings, etc., now trigger toasts for immediate, less intrusive feedback.
- Reviewed and enhanced input validation feedback:
  - Ensured server-side validation errors are clearly reported via error banners.
  - Added minor client-side HTML5 validation attributes for improved UX.

These changes aim to provide clearer, more consistent, and user-friendly notifications throughout the application, adhering to Adwaita styling guidelines.