### PR TITLE
fix: Address email validation, notification types, and AGENTS.md

### DIFF
--- a/adwaita-web/AGENTS.md
+++ b/adwaita-web/AGENTS.md
@@ -73,3 +73,9 @@ Dark mode is typically handled by adding a class (e.g., `theme-dark`) to a high-
 *   **Linting:** Implement SCSS linting to maintain code quality.
 
 By following these guidelines, `adwaita-skin` can be maintained as a robust and easy-to-use pure CSS library for Adwaita styling.
+
+## User Notifications (Banners, Toasts)
+
+*   **Dismiss Mechanisms:** All transient user notifications, such as banners (`.adw-banner`) and toasts (`.adw-toast`), that are implemented or styled by this library (or its associated JavaScript helpers like `banner.js`, `toast.js`) **must** include a clearly visible and user-operable mechanism for dismissal (e.g., a close button with an 'X' icon).
+*   **Functionality:** This dismiss mechanism must be fully functional, allowing the user to remove the notification from view.
+*   **Accessibility:** Ensure these dismiss controls are accessible (e.g., proper ARIA attributes, keyboard focusable).

--- a/app-demo/requirements.txt
+++ b/app-demo/requirements.txt
@@ -17,3 +17,4 @@ typing_extensions==4.14.0
 Werkzeug>=3.1.0
 WTForms==3.2.1
 wtforms-sqlalchemy==0.4.2
+email-validator # For WTForms Email validator

--- a/app-demo/routes/auth_routes.py
+++ b/app-demo/routes/auth_routes.py
@@ -86,7 +86,7 @@ def login():
                 login_user(user)
                 current_app.logger.info(f"User '{user.username}' (ID: {user.id}) logged in successfully.")
                 current_app.logger.debug(f"Session after login for user '{user.username}': {dict(session)}")
-            flash('Logged in successfully.', 'success')
+            flash('Logged in successfully.', 'toast_success') # Changed to toast_success
             next_page = request.args.get('next')
             # More robust security check for next_page
             if next_page:
@@ -133,7 +133,7 @@ def logout():
 
     current_app.logger.info(f"User '{username_before_logout}' (ID: {user_id_before_logout}) logged out successfully.")
     current_app.logger.debug(f"Session after logout: {dict(session)}")
-    flash('Logged out successfully.', 'success')
+    flash('Logged out successfully.', 'toast_success') # Changed to toast_success
     return redirect(url_for('general.index'))
 
 


### PR DESCRIPTION
This commit addresses issues identified in previous feedback:

- Added `email-validator` to `app-demo/requirements.txt` to resolve the `ModuleNotFoundError` for email validation in WTForms.
- Corrected notification types for success messages:
  - "Logged in" and "Logged out" messages are now toasts (`toast_success`) as requested.
  - "Registration successful (pending approval)" remains a banner (`success`) due to its critical status nature.
- Updated `adwaita-web/AGENTS.md` to include an explicit instruction requiring all transient notifications (banners, toasts) to have clearly visible and functional dismiss/close mechanisms.
- Verified that the JavaScript and HTML structures for banner and toast dismiss buttons are correctly implemented in the codebase.

These changes further refine the error handling and user notification system.