### PR TITLE
fix: Add missing Display Name field to registration form

### DIFF
--- a/app-demo/templates/register.html
+++ b/app-demo/templates/register.html
@@ -16,6 +16,21 @@
             {{ form.hidden_tag() }} {# CSRF token #}
 
             <div class="adw-list-box" role="group" aria-labelledby="register-group-title">
+                {# Full Name (Display Name) Field #}
+                <div class="adw-entry-row {{ 'has-error' if form.full_name.errors else '' }}">
+                    <label for="{{ form.full_name.id or 'full_name_input' }}" class="adw-entry-row-title">{{ form.full_name.label.text }}</label>
+                    <input type="text"
+                           name="{{ form.full_name.name }}"
+                           id="{{ form.full_name.id or 'full_name_input' }}"
+                           class="adw-entry adw-entry-row-entry"
+                           required
+                           placeholder="Your preferred display name"
+                           value="{{ form.full_name.data or '' }}">
+                    {% if form.full_name.errors %}
+                        <span class="adw-label caption error-text adw-entry-row-subtitle">{{ form.full_name.errors|join(' ') }}</span>
+                    {% endif %}
+                </div>
+
                 {# Email (Username) Field #}
                 <div class="adw-entry-row {{ 'has-error' if form.email.errors else '' }}">
                     <label for="{{ form.email.id or 'email_input' }}" class="adw-entry-row-title">{{ form.email.label.text }}</label>


### PR DESCRIPTION
The 'Display Name' (full_name) field, despite being required by the RegistrationForm, was missing from the registration.html template.

This commit adds the input field for 'Display Name' to the template, ensuring users can provide this required information during registration. The backend already correctly processes this field.