### PR TITLE
Fix: Ensure Adwaita toasts appear and banner dismiss buttons function

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -229,8 +229,8 @@
     {% block scripts %}
     {# Theme and accent handling script is above, this is for other scripts #}
     <script src="{{ url_for('static', filename='js/app-layout.js') }}" defer></script>
-     <script src="{{ url_for('static', filename='js/banner.js') }}" defer></script> {# Added banner.js #}
-     {# toast.js is also included by build script, Adw.createToast can be used directly if toast.js is loaded #}
+    <script src="{{ url_for('static', filename='js/banner.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/toast.js') }}" defer></script> {# Ensure toast.js is loaded #}
     {% endblock %}
 
     <div id="adw-toast-overlay" class="adw-toast-overlay">


### PR DESCRIPTION
- Added missing <script> tag for toast.js in base.html. This resolves Adw.createToast being undefined and allows toasts to be created and displayed.
- Toasts generated by toast.js inherently include a close button.
- Verified that banner.js is correctly included and the HTML for banner dismiss buttons uses the expected CSS classes. Banner dismiss functionality should now work as intended.