### PR TITLE
Fix: Correct toast/banner icons, implement Adwaita dialog for comment…

### DIFF
--- a/adwaita-web/js/toast.js
+++ b/adwaita-web/js/toast.js
@@ -76,7 +76,7 @@ window.Adw = window.Adw || {};
         closeButton.setAttribute('aria-label', 'Close notification');
 
         const icon = document.createElement('span');
-        icon.classList.add('adw-icon', 'icon-actions-close-symbolic');
+        icon.classList.add('adw-icon', 'icon-window-close-symbolic'); // Corrected class
         // icon.innerHTML = '&times;'; // Fallback if icon class not present or SVG not used
         closeButton.appendChild(icon);
 

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -199,7 +199,7 @@
                         <div class="{{ banner_class }} visible" role="alert" style="position: relative; top: auto; left: auto; right: auto; transform: none; opacity: 1; margin-top: var(--spacing-s);">
                             <span class="adw-banner-title">{{ message }}</span>
                             <button class="adw-button circular flat adw-banner-dismiss-button" aria-label="Close notification">
-                                <span class="adw-icon icon-actions-close-symbolic"></span>
+                                <span class="adw-icon icon-window-close-symbolic"></span> {# Corrected icon class #}
                             </button>
                         </div>
                     {% endif %}

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -156,9 +156,10 @@
                 {% endif %}
             {% endif %}
             {% if current_user.is_authenticated and (comment.author == current_user or post.author == current_user or current_user.is_admin) %}
-            <form method="POST" action="{{ url_for('post.delete_comment', comment_id=comment.id) }}" onsubmit="return confirm('Are you sure you want to delete this comment?');" style="display: inline;">
+            {# Modified for Adwaita dialog: button type is 'button', not 'submit'. JS will handle form submission. #}
+            <form method="POST" action="{{ url_for('post.delete_comment', comment_id=comment.id) }}" style="display: inline;" class="comment-delete-form" id="delete-comment-form-{{ comment.id }}">
                 {{ delete_comment_form.hidden_tag() }}
-                <button type="submit" class="adw-button destructive-action compact">Delete</button>
+                <button type="button" class="adw-button destructive-action compact comment-delete-button" data-form-id="delete-comment-form-{{ comment.id }}" data-comment-id="{{ comment.id }}">Delete</button>
             </form>
             {% endif %}
         </div>
@@ -243,57 +244,80 @@
     <div class="adw-box adw-box-spacing-s back-to-posts-container">
          <a href="{{ url_for('general.index') }}" class="adw-button"><span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Posts</a>
     </div>
+
+    {# Dialog for confirming comment deletion #}
+    <div class="adw-dialog" id="delete-comment-confirm-dialog" role="alertdialog" aria-labelledby="delete-comment-dialog-title" aria-modal="true" hidden>
+        <header class="adw-header-bar adw-dialog__header">
+             <h2 class="adw-header-bar__title" id="delete-comment-dialog-title">Confirm Comment Deletion</h2>
+        </header>
+        <div class="adw-dialog__content">
+            <p class="adw-label body">Are you sure you want to delete this comment? This action cannot be undone.</p>
+        </div>
+        <footer class="adw-dialog__actions">
+            <button id="cancel-comment-delete-btn" class="adw-button flat">Cancel</button>
+            {# This form will be submitted by JS after setting its action #}
+            <form method="POST" action="" id="confirm-delete-comment-form-actual" style="display: inline;">
+                 {{ delete_comment_form.hidden_tag() }} {# Re-use one of the delete_comment_form instances for CSRF token #}
+                <button id="confirm-comment-delete-btn" type="submit" class="adw-button destructive-action">Delete Comment</button>
+            </form>
+        </footer>
+    </div>
 </div>
 
 <script>
 // Delete post dialog script
 document.addEventListener('DOMContentLoaded', () => {
-    const deleteDialogEl = document.getElementById('delete-confirm-dialog');
-    const openDialogBtn = document.getElementById('open-delete-dialog-btn');
-    const cancelBtn = document.getElementById('cancel-delete-btn');
-    const confirmBtn = document.getElementById('confirm-delete-btn'); // Get the confirm button
+    // Post Deletion Dialog
+    const deletePostDialogEl = document.getElementById('delete-confirm-dialog');
+    const openPostDeleteDialogBtn = document.getElementById('open-delete-dialog-btn');
+    const cancelPostDeleteBtn = document.getElementById('cancel-delete-btn');
 
-    if (openDialogBtn && deleteDialogEl) {
-        openDialogBtn.addEventListener('click', (event) => {
+    if (openPostDeleteDialogBtn && deletePostDialogEl) {
+        openPostDeleteDialogBtn.addEventListener('click', (event) => {
             event.preventDefault();
-            deleteDialogEl.removeAttribute('hidden'); // Show dialog using 'hidden' attribute
-            if (typeof deleteDialogEl.showModal === "function") { // Use <dialog>.showModal() if available
-                // deleteDialogEl.showModal(); // This would be ideal but might not be polyfilled/styled for all browsers without more work
-            }
-            // Basic focus management: focus the first focusable element in the dialog
-            const firstFocusable = deleteDialogEl.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-            if (firstFocusable) {
-                firstFocusable.focus();
-            }
+            deletePostDialogEl.removeAttribute('hidden');
+            const firstFocusable = deletePostDialogEl.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+            if (firstFocusable) firstFocusable.focus();
         });
     }
-
     if (cancelBtn && deleteDialogEl) {
-        cancelBtn.addEventListener('click', () => {
-            deleteDialogEl.setAttribute('hidden', 'true'); // Hide dialog
-            // if (typeof deleteDialogEl.close === "function") { // For native <dialog>
-            //     deleteDialogEl.close();
-            // }
+        cancelPostDeleteBtn.addEventListener('click', () => deletePostDialogEl.setAttribute('hidden', 'true'));
+    }
+    if (deletePostDialogEl) { // ESC key for post delete dialog
+        deletePostDialogEl.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') deletePostDialogEl.setAttribute('hidden', 'true');
         });
     }
 
-    if (confirmBtn && deleteDialogEl) { // Add event listener for confirm button
-        confirmBtn.addEventListener('click', () => {
-            // This will submit the form. The dialog will disappear on page reload.
-            // If it were an AJAX delete, we'd definitely hide it here:
-            // deleteDialogEl.setAttribute('hidden', 'true');
-        });
-    }
+    // Comment Deletion Dialog
+    const deleteCommentDialogEl = document.getElementById('delete-comment-confirm-dialog');
+    const cancelCommentDeleteBtn = document.getElementById('cancel-comment-delete-btn');
+    const confirmDeleteCommentFormActual = document.getElementById('confirm-delete-comment-form-actual');
 
-    // Optional: Close dialog on ESC key
-    if (deleteDialogEl) {
-        deleteDialogEl.addEventListener('keydown', (event) => {
-            if (event.key === 'Escape') {
-                deleteDialogEl.setAttribute('hidden', 'true');
-                // if (typeof deleteDialogEl.close === "function") { // For native <dialog>
-                //    deleteDialogEl.close();
-                // }
+    document.querySelectorAll('.comment-delete-button').forEach(button => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            const formId = button.dataset.formId;
+            const originalForm = document.getElementById(formId);
+            if (originalForm && confirmDeleteCommentFormActual) {
+                // Set the action for the dialog's form
+                confirmDeleteCommentFormActual.action = originalForm.action;
+                // Show the dialog
+                deleteCommentDialogEl.removeAttribute('hidden');
+                const firstFocusable = deleteCommentDialogEl.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+                if (firstFocusable) firstFocusable.focus();
             }
+        });
+    });
+
+    if (cancelCommentDeleteBtn && deleteCommentDialogEl) {
+        cancelCommentDeleteBtn.addEventListener('click', () => deleteCommentDialogEl.setAttribute('hidden', 'true'));
+    }
+    // Confirm button for comment deletion is type="submit" on its own form, so no specific JS listener needed for submission itself.
+    // ESC key for comment delete dialog
+    if (deleteCommentDialogEl) {
+        deleteCommentDialogEl.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') deleteCommentDialogEl.setAttribute('hidden', 'true');
         });
     }
 });


### PR DESCRIPTION
… deletion

- Toast: Corrected close button icon class in toast.js to `icon-window-close-symbolic` to ensure visibility.
- Banner: Corrected dismiss button icon class in base.html to `icon-window-close-symbolic`. Re-verified JS logic for dismiss functionality.
- Dialogs: Replaced native JavaScript `confirm()` for comment deletion with an Adwaita-styled dialog in post.html, including necessary HTML and JavaScript for handling.
- Assets: Rebuilt static assets to include the updated toast.js.