### PR TITLE
Fix: Critical errors, banner dismiss, home feed, and About dialog

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -82,8 +82,43 @@
         {% else %}
             <a href="{{ url_for('auth.login') }}" class="adw-button">Login</a>
         {% endif %}
+
+        {# Main App Menu Button - Placed at the very end of header actions #}
+        <div class="main-app-menu-container" style="position: relative;">
+            <button id="main-app-menu-button" class="adw-button circular flat" aria-label="Main menu" aria-haspopup="true" aria-expanded="false">
+                <span class="adw-icon icon-view-more-symbolic"></span>
+            </button>
+            <div class="adw-popover menu-popover" id="main-app-popover" role="menu" hidden>
+                <div class="adw-list-box flat popover-list-box">
+                    <button class="adw-action-row activatable" id="about-dialog-trigger" role="menuitem">
+                        <span class="adw-action-row-title">About</span>
+                    </button>
+                    {# Add other menu items here if needed in the future #}
+                </div>
+            </div>
+        </div>
     </div>
 </header>
+
+{# Adwaita About Dialog HTML Structure #}
+<div class="adw-dialog adw-about-dialog" id="app-about-dialog" role="dialog" aria-labelledby="about-dialog-title" aria-modal="true" hidden>
+    <header class="adw-header-bar adw-dialog__header">
+        <h2 class="adw-header-bar__title" id="about-dialog-title">About {{ site_settings.get('site_title', 'Adwaita Social Demo') }}</h2>
+        <button id="close-about-dialog-btn" class="adw-button circular flat adw-dialog-close-button" aria-label="Close dialog">
+            <span class="adw-icon icon-window-close-symbolic"></span>
+        </button>
+    </header>
+    <div class="adw-dialog__content">
+        {# Basic content for an AboutDialog #}
+        <p class="adw-label application-name">{{ site_settings.get('site_title', 'Adwaita Social Demo') }}</p>
+        <p class="adw-label version">Version 1.0.0 (Demo)</p>
+        <p class="adw-label copyright">© {{ current_year }} Your Name/Organization</p>
+        <p class="adw-label comments">This is a demonstration application using the Adwaita-Web UI library.</p>
+        {# <a href="YOUR_WEBSITE_URL_HERE" class="adw-link website-link" target="_blank" rel="noopener noreferrer">Visit Website</a> #}
+    </div>
+    {# AboutDialogs typically don't have a separate action footer unless for credits button etc. #}
+</div>
+
 
 <div class="app-body-container"> {# NEW: Main container for sidebar + content #}
     <aside class="app-sidebar" id="app-sidebar"> {# Added id for ARIA #}
@@ -152,19 +187,7 @@
             {% endif %}
             {% endblock sidebar_nav %}
         </nav>
-
-        {# Secondary navigation for About, Contact, etc. #}
-        <div class="sidebar-section-header adw-label caption" style="padding: var(--spacing-s) var(--spacing-m); margin-top: var(--spacing-xs); text-transform: uppercase; font-weight: bold;">More</div>
-        <nav class="adw-list-box flat sidebar-nav" aria-label="Secondary Navigation">
-            <a href="{{ url_for('general.about_page') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.about_page' }}">
-                <span class="adw-action-row-icon icon-actions-help-about-symbolic"></span>
-                <span class="adw-action-row-title">About</span>
-            </a>
-            <a href="{{ url_for('general.contact_page') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.contact_page' }}">
-                <span class="adw-action-row-icon icon-content-mail-symbolic"></span>
-                <span class="adw-action-row-title">Contact</span>
-            </a>
-        </nav>
+        {# "More" section with About/Contact removed from sidebar #}
     </aside>
 
     <div class="app-content-area"> {# NEW: Wrapper for main content + its own potential footer #}
@@ -198,9 +221,7 @@
                         {% endif %}
                         <div class="{{ banner_class }} visible" role="alert" style="position: relative; top: auto; left: auto; right: auto; transform: none; opacity: 1; margin-top: var(--spacing-s);">
                             <span class="adw-banner-title">{{ message }}</span>
-                            <button class="adw-button circular flat adw-banner-dismiss-button" aria-label="Close notification">
-                                <span class="adw-icon icon-window-close-symbolic"></span> {# Corrected icon class #}
-                            </button>
+                            <button class="adw-button flat adw-banner-dismiss-button">Dismiss</button>
                         </div>
                     {% endif %}
                 {% endfor %}
@@ -231,6 +252,70 @@
     <script src="{{ url_for('static', filename='js/app-layout.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/banner.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/toast.js') }}" defer></script> {# Ensure toast.js is loaded #}
+    <script nonce="{{ csp_nonce() if csp_nonce else '' }}">
+        document.addEventListener('DOMContentLoaded', () => {
+            // Main App Menu Popover
+            const menuButton = document.getElementById('main-app-menu-button');
+            const menuPopover = document.getElementById('main-app-popover');
+            if (menuButton && menuPopover) {
+                menuButton.addEventListener('click', (event) => {
+                    event.stopPropagation(); // Prevent click from immediately closing via document listener
+                    const isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+                    if (isExpanded) {
+                        menuPopover.setAttribute('hidden', '');
+                        menuButton.setAttribute('aria-expanded', 'false');
+                    } else {
+                        menuPopover.removeAttribute('hidden');
+                        menuButton.setAttribute('aria-expanded', 'true');
+                        // Optional: focus first item in popover
+                        const firstFocusable = menuPopover.querySelector('[role="menuitem"]');
+                        if (firstFocusable) firstFocusable.focus();
+                    }
+                });
+                // Close popover if clicking outside
+                document.addEventListener('click', (event) => {
+                    if (!menuPopover.hidden && !menuButton.contains(event.target) && !menuPopover.contains(event.target)) {
+                        menuPopover.setAttribute('hidden', '');
+                        menuButton.setAttribute('aria-expanded', 'false');
+                    }
+                });
+                // Close popover on ESC key
+                menuPopover.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        menuPopover.setAttribute('hidden', '');
+                        menuButton.setAttribute('aria-expanded', 'false');
+                        menuButton.focus();
+                    }
+                });
+            }
+
+            // About Dialog
+            const aboutDialog = document.getElementById('app-about-dialog');
+            const openAboutDialogBtn = document.getElementById('about-dialog-trigger');
+            const closeAboutDialogBtn = document.getElementById('close-about-dialog-btn');
+
+            if (aboutDialog && openAboutDialogBtn && closeAboutDialogBtn) {
+                openAboutDialogBtn.addEventListener('click', () => {
+                    aboutDialog.removeAttribute('hidden');
+                    // Close popover if open
+                    if(menuPopover && !menuPopover.hidden) {
+                        menuPopover.setAttribute('hidden', '');
+                        menuButton.setAttribute('aria-expanded', 'false');
+                    }
+                    const firstFocusable = aboutDialog.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+                    if (firstFocusable) firstFocusable.focus();
+                });
+                closeAboutDialogBtn.addEventListener('click', () => {
+                    aboutDialog.setAttribute('hidden', 'true');
+                });
+                aboutDialog.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        aboutDialog.setAttribute('hidden', 'true');
+                    }
+                });
+            }
+        });
+    </script>
     {% endblock %}
 
     <div id="adw-toast-overlay" class="adw-toast-overlay">

--- a/app-demo/templates/feed.html
+++ b/app-demo/templates/feed.html
@@ -1,117 +1,78 @@
 {% extends "base.html" %}
 
-{% block title %}My Feed{% endblock %}
+{% block title %}Home Feed{% endblock %}
 
-{% block header_title %}Activity Feed{% endblock %}
+{% block header_title %}Home{% endblock %}
 
 {% block content %}
 <div class="adw-clamp adw-clamp-xl">
-    {# Import the macro for like buttons, as it's used for 'created_post' activity type #}
     {% from "_macros.html" import like_button_and_count %}
 
-    {% if activities_list and activities_list|length > 0 %}
-        <div class="feed-activities-container adw-list-box"> {# Using adw-list-box for simpler activity items, can be changed #}
-            {% for activity in activities_list %}
-                {% if activity.type == 'created_post' and activity.target_post %}
-                    {# Render 'created_post' as a full post card. is_published check removed as posts are now always published. #}
-                    <article class="adw-card blog-post-item-card feed-activity-item">
-                        <header class="blog-post-card__header">
-                            <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">
-                                <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">
-                                    <span class="adw-avatar size-m">
-                                        {% if activity.actor.profile_photo_url %}
-                                        <img src="{{ url_for('static', filename=activity.actor.profile_photo_url) }}" alt="{{ activity.actor.username }} avatar">
-                                        {% else %}
-                                        <img src="{{ default_avatar_url }}" alt="{{ activity.actor.username }} default avatar">
-                                        {% endif %}
-                                    </span>
-                                </a>
-                                <div class="adw-box adw-box-vertical">
-                                    <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">
-                                        <strong class="adw-label body-1">{{ activity.actor.full_name or activity.actor.username }}</strong>
-                                    </a>
-                                     <span class="adw-label caption">@{{ activity.actor.username }}</span>
-                                     <span class="adw-label caption feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
-                                </div>
-                            </div>
-                            {# Post title h2 removed #}
-                             {# Meta for publish date of post, not activity timestamp here, is part of the post card content #}
-                            <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
-                                {% if activity.target_post.published_at %}
-                                    Published: <time datetime="{{ activity.target_post.published_at.isoformat() }}">{{ activity.target_post.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% else %}
-                                    Created: <time datetime="{{ activity.target_post.created_at.isoformat() }}">{{ activity.target_post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                                {% endif %}
-                            </div>
-                        </header>
-                        <div class="adw-card__content styled-text-content">
-                            {{ activity.target_post.content | truncate(300, True, '...') | markdown }}
-                        </div>
-                        <footer class="blog-post-card__footer">
-                             <div class="blog-post-card__terms">
-                                {% if activity.target_post.categories %}
-                                    {# Categories display #}
-                                {% endif %}
-                                {% if activity.target_post.tags %}
-                                    {# Tags display #}
-                                {% endif %}
-                            </div>
-                            <a href="{{ url_for('post.view_post', post_id=activity.target_post.id) }}" class="adw-button flat read-more-link">
-                                View Post & Comments <span class="adw-icon icon-actions-go-next-symbolic"></span>
+    {% if posts and posts|length > 0 %}
+        <div class="blog-posts-container" style="margin-top: var(--spacing-l);"> {# Using grid like index.html #}
+            {% for post_item in posts %}
+                <article class="adw-card blog-post-item-card">
+                    <header class="blog-post-card__header">
+                        <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">
+                            <a href="{{ url_for('profile.view_profile', username=post_item.author.username) }}" class="adw-link">
+                                <span class="adw-avatar size-m">
+                                    {% if post_item.author.profile_photo_url %}
+                                    <img src="{{ url_for('static', filename=post_item.author.profile_photo_url) }}" alt="{{ post_item.author.username }} avatar">
+                                    {% else %}
+                                    <img src="{{ default_avatar_url }}" alt="{{ post_item.author.username }} default avatar">
+                                    {% endif %}
+                                </span>
                             </a>
-                        </footer>
-                        <div class="adw-card__actions card-secondary-actions">
-                            {{ like_button_and_count(activity.target_post, current_user, csrf_token()) }}
+                            <div class="adw-box adw-box-vertical">
+                                <a href="{{ url_for('profile.view_profile', username=post_item.author.username) }}" class="adw-link">
+                                    <strong class="adw-label body-1">{{ post_item.author.full_name or post_item.author.username }}</strong>
+                                </a>
+                                 <span class="adw-label caption">@{{ post_item.author.username }}</span>
+                            </div>
                         </div>
-                    </article>
-                {% elif activity.type == 'started_following' and activity.actor and activity.target_user %}
-                    <div class="adw-action-row feed-activity-item feed-activity-follow">
-                        <div class="adw-action-row-start-content">
-                            <span class="adw-icon icon-status-user-available-symbolic feed-activity-icon"></span>
+                        <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
+                            {% if post_item.published_at %}
+                                Published: <time datetime="{{ post_item.published_at.isoformat() }}">{{ post_item.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                            {% else %}
+                                Created: <time datetime="{{ post_item.created_at.isoformat() }}">{{ post_item.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                            {% endif %}
                         </div>
-                        <div class="adw-action-row-text-content">
-                            <span class="adw-action-row-title">
-                                <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">{{ activity.actor.full_name or activity.actor.username }}</a>
-                                started following
-                                <a href="{{ url_for('profile.view_profile', username=activity.target_user.username) }}" class="adw-link">{{ activity.target_user.full_name or activity.target_user.username }}</a>.
-                            </span>
-                            <span class="adw-action-row-subtitle feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
-                        </div>
+                    </header>
+                    <div class="adw-card__content styled-text-content">
+                        {{ post_item.content | truncate(300, True, '...') | markdown }}
                     </div>
-                {% elif activity.type == 'liked_post' and activity.actor and activity.target_post %}
-                     <div class="adw-action-row feed-activity-item feed-activity-like">
-                        <div class="adw-action-row-start-content">
-                            <span class="adw-icon icon-actions-star-symbolic feed-activity-icon"></span>
+                    <footer class="blog-post-card__footer">
+                         <div class="blog-post-card__terms">
+                            {% if post_item.categories %}
+                            <div class="meta-section">
+                                <strong class="adw-label caption meta-label-strong">Categories:</strong>
+                                {% for category in post_item.categories %}
+                                    <a href="{{ url_for('post.posts_by_category', category_slug=category.slug) }}" class="adw-button flat compact tag-pill">{{ category.name }}</a>
+                                {% endfor %}
+                            </div>
+                            {% endif %}
+                            {% if post_item.tags %}
+                            <div class="meta-section">
+                                <strong class="adw-label caption meta-label-strong">Tags:</strong>
+                                {% for tag in post_item.tags %}
+                                    <a href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug) }}" class="adw-button flat compact tag-pill">{{ tag.name }}</a>
+                                {% endfor %}
+                            </div>
+                            {% endif %}
                         </div>
-                        <div class="adw-action-row-text-content">
-                            <span class="adw-action-row-title">
-                                <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">{{ activity.actor.full_name or activity.actor.username }}</a>
-                                liked a <a href="{{ url_for('post.view_post', post_id=activity.target_post.id) }}" class="adw-link">post by {{ activity.target_post.author.full_name or activity.target_post.author.username }}</a>.
-                            </span>
-                             <span class="adw-action-row-subtitle feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
-                        </div>
+                        <a href="{{ url_for('post.view_post', post_id=post_item.id) }}" class="adw-button flat read-more-link">
+                            View Post & Comments <span class="adw-icon icon-actions-go-next-symbolic"></span>
+                        </a>
+                    </footer>
+                    <div class="adw-card__actions card-secondary-actions">
+                        {{ like_button_and_count(post_item, current_user, csrf_token) }} {# Use csrf_token from context #}
                     </div>
-                {% elif activity.type == 'commented_on_post' and activity.actor and activity.target_post %}
-                    <div class="adw-action-row feed-activity-item feed-activity-comment">
-                        <div class="adw-action-row-start-content">
-                             <span class="adw-icon icon-content-message-symbolic feed-activity-icon"></span>
-                        </div>
-                        <div class="adw-action-row-text-content">
-                            <span class="adw-action-row-title">
-                                <a href="{{ url_for('profile.view_profile', username=activity.actor.username) }}" class="adw-link">{{ activity.actor.full_name or activity.actor.username }}</a>
-                                commented on a <a href="{{ url_for('post.view_post', post_id=activity.target_post.id, _anchor='comment-' ~ activity.target_comment_id if activity.target_comment_id else 'post-comments-area') }}" class="adw-link">post by {{ activity.target_post.author.full_name or activity.target_post.author.username }}</a>.
-                            </span>
-                            {# Optionally, show comment snippet here if available on activity model or fetched #}
-                            <span class="adw-action-row-subtitle feed-activity-timestamp"><time datetime="{{ activity.timestamp.isoformat() }}">{{ activity.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time></span>
-                        </div>
-                    </div>
-                {% endif %}
+                </article>
             {% endfor %}
         </div>
 
-        {# Pagination Controls - Check if pagination object is for activities now #}
         {% if pagination and pagination.pages > 1 %}
-        <div class="adw-box adw-box-horizontal justify-center profile-pagination-box"> {# Re-use class for styling if applicable #}
+        <div class="adw-box adw-box-horizontal justify-center profile-pagination-box">
             <div class="adw-toggle-group">
                 {% if pagination.has_prev %}
                     <a href="{{ url_for('general.activity_feed', page=pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
@@ -131,7 +92,6 @@
                             <a href="{{ url_for('general.activity_feed', page=page_num) }}" class="adw-button">{{ page_num }}</a>
                         {% endif %}
                     {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
-                        {# Placeholder for ellipsis if pages are skipped #}
                         <button class="adw-button flat" disabled>…</button>
                     {% endif %}
                 {% endfor %}
@@ -149,22 +109,12 @@
         </div>
         {% endif %}
 
-    {% elif followed_users_count == 0 %}
-        <div class="adw-status-page">
-            <span class="adw-icon icon-status-user-available-symbolic adw-status-page-icon app-status-page-icon"></span>
-            <h3 class="adw-status-page-title">Your Feed is Empty</h3>
-            <p class="adw-status-page-description">You are not following anyone yet.</p>
-            <p class="adw-status-page-description">Find people to follow to see their posts here.</p>
-            {# Optional: Add a button to explore users or go to a search page #}
-            <a href="{{ url_for('general.index') }}" class="adw-button suggested-action" style="margin-top: var(--spacing-m);">Explore Posts</a>
-        </div>
     {% else %}
         <div class="adw-status-page">
             <span class="adw-icon icon-content-document-multiple-symbolic adw-status-page-icon app-status-page-icon"></span>
-            <h3 class="adw-status-page-title">No Posts in Your Feed Yet</h3>
-            <p class="adw-status-page-description">The users you follow haven't posted anything yet, or there are no new posts.</p>
-            <p class="adw-status-page-description">Check back later or find more people to follow!</p>
-            <a href="{{ url_for('general.index') }}" class="adw-button" style="margin-top: var(--spacing-m);">Explore More Posts</a>
+            <h3 class="adw-status-page-title">No Posts Yet</h3>
+            <p class="adw-status-page-description">There are no posts to display. Why not create one?</p>
+            <a href="{{ url_for('post.create_post') }}" class="adw-button suggested-action" style="margin-top: var(--spacing-m);">Create Post</a>
         </div>
     {% endif %}
 </div>

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -218,7 +218,7 @@
     </section>
     {% else %}
     <div class="login-prompt-comment">
-        <p class="adw-label body"><a href="{{ url_for('login', next=request.url) }}" class="adw-link">Login</a> to leave a comment.</p>
+        <p class="adw-label body"><a href="{{ url_for('auth.login', next=request.url) }}" class="adw-link">Login</a> to leave a comment.</p>
     </div>
     {% endif %}
 
@@ -280,7 +280,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (firstFocusable) firstFocusable.focus();
         });
     }
-    if (cancelBtn && deleteDialogEl) {
+    // Corrected conditional: uses cancelPostDeleteBtn and deletePostDialogEl
+    if (cancelPostDeleteBtn && deletePostDialogEl) {
         cancelPostDeleteBtn.addEventListener('click', () => deletePostDialogEl.setAttribute('hidden', 'true'));
     }
     if (deletePostDialogEl) { // ESC key for post delete dialog


### PR DESCRIPTION
- Fixed Jinja2 BuildError for url_for('login') in post.html.
- Fixed JavaScript ReferenceError for post deletion dialog in post.html.
- Changed banner dismiss button to a text button "Dismiss" in base.html.
- Updated home page (general.activity_feed route and feed.html template) for logged-in users to display a feed of posts instead of activities.
- Removed About/Contact links from sidebar.
- Added a main app menu to the header bar with an 'About' item that triggers an Adwaita-styled About dialog.
- Updated static assets via build script.