### PR TITLE
Feat: Implement Adwaita Dialog Web Components

### DIFF
--- a/adwaita-web/js/components.js
+++ b/adwaita-web/js/components.js
@@ -1,0 +1,12 @@
+// adwaita-web/js/components.js
+// Main file to load and initialize all Adwaita-Web components.
+
+import './components/dialog.js';
+import './components/aboutdialog.js';
+
+// Other components would be imported here as well in a fuller library:
+// import './components/button.js';
+// import './components/entry.js';
+// etc.
+
+console.log("Adwaita Web Components (dialog, aboutdialog) main script loaded.");

--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -1,0 +1,245 @@
+// adwaita-web/js/components/aboutdialog.js
+
+if (!window.Adw) {
+    window.Adw = {};
+}
+
+// Use the same shared backdrop logic as AdwDialogElement for consistency
+// This assumes AdwDialogElement's static _backdropElement is accessible or re-implemented here.
+// For simplicity, let's make it self-contained for now, but sharing would be better.
+
+class AdwAboutDialogElement extends HTMLElement {
+    constructor() {
+        super();
+        this._boundOnKeydown = this._onKeydown.bind(this);
+        this._boundCloseButtonClick = this.close.bind(this); // For close button in header
+
+        // This component will also use Light DOM for easier styling with adwaita-skin.css
+        this.classList.add('adw-dialog', 'adw-about-dialog'); // Host is the dialog
+        this.setAttribute('role', 'dialog');
+        this.setAttribute('aria-modal', 'true');
+    }
+
+    static get observedAttributes() {
+        return ['open', 'app-name', 'version', 'copyright', 'logo', 'comments', 'website', 'website-label', 'license-type'];
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (name === 'open') {
+            if (this.hasAttribute('open')) {
+                this._doOpen();
+            } else {
+                this._doClose();
+            }
+        } else {
+            // For other attributes, re-render if the component is already connected
+            if (this.isConnected) {
+                this._render();
+            }
+        }
+    }
+
+    connectedCallback() {
+        if (!this._initialized) {
+            this._render();
+            this._initialized = true;
+        }
+        // Default to hidden if not explicitly open
+        if (!this.hasAttribute('open')) {
+            this.setAttribute('hidden', '');
+            this.style.display = 'none';
+        } else {
+            this._doOpen(); // Ensure it's properly opened if 'open' is set on connect
+        }
+    }
+
+    _render() {
+        // Clear existing content before re-rendering
+        this.innerHTML = '';
+
+        const appName = this.getAttribute('app-name') || 'Application';
+        const version = this.getAttribute('version');
+        const copyright = this.getAttribute('copyright');
+        const logoSrc = this.getAttribute('logo');
+        const commentsText = this.getAttribute('comments');
+        const websiteUrl = this.getAttribute('website');
+        const websiteLabel = this.getAttribute('website-label') || websiteUrl;
+        // LicenseType, developers, etc., can be added similarly
+
+        // Header
+        const header = document.createElement('header');
+        header.classList.add('adw-header-bar', 'adw-dialog__header');
+
+        const titleEl = document.createElement('h2');
+        titleEl.classList.add('adw-header-bar__title');
+        titleEl.id = 'about-dialog-title-' + (this.id || Math.random().toString(36).substring(2,7));
+        titleEl.textContent = `About ${appName}`;
+        this.setAttribute('aria-labelledby', titleEl.id);
+        header.appendChild(titleEl);
+
+        const closeButton = document.createElement('button');
+        closeButton.classList.add('adw-button', 'circular', 'flat', 'adw-dialog-close-button');
+        closeButton.setAttribute('aria-label', 'Close dialog');
+        const closeIcon = document.createElement('span');
+        closeIcon.classList.add('adw-icon', 'icon-window-close-symbolic');
+        closeButton.appendChild(closeIcon);
+        closeButton.addEventListener('click', this._boundCloseButtonClick);
+        header.appendChild(closeButton);
+        this.appendChild(header);
+
+        // Content Area
+        const contentArea = document.createElement('div');
+        contentArea.classList.add('adw-dialog__content'); // Standard dialog content class
+
+        // AboutDialog specific layout within contentArea
+        if (logoSrc) {
+            const logoImg = document.createElement('img');
+            logoImg.src = logoSrc;
+            logoImg.alt = `${appName} Logo`;
+            logoImg.classList.add('adw-about-dialog-logo');
+            contentArea.appendChild(logoImg);
+        }
+
+        const appNameEl = document.createElement('p');
+        appNameEl.classList.add('adw-label', 'application-name', 'title-1'); // title-1 for prominence
+        appNameEl.textContent = appName;
+        contentArea.appendChild(appNameEl);
+
+        if (version) {
+            const versionEl = document.createElement('p');
+            versionEl.classList.add('adw-label', 'version', 'body-2');
+            versionEl.textContent = `Version ${version}`;
+            contentArea.appendChild(versionEl);
+        }
+
+        if (commentsText) {
+            const commentsEl = document.createElement('p');
+            commentsEl.classList.add('adw-label', 'comments');
+            commentsEl.textContent = commentsText;
+            contentArea.appendChild(commentsEl);
+        }
+
+        if (websiteUrl) {
+            const websiteLink = document.createElement('a');
+            websiteLink.href = websiteUrl;
+            websiteLink.textContent = websiteLabel || websiteUrl;
+            websiteLink.classList.add('adw-link');
+            websiteLink.target = '_blank';
+            websiteLink.rel = 'noopener noreferrer';
+            const websiteP = document.createElement('p');
+            websiteP.appendChild(websiteLink);
+            contentArea.appendChild(websiteP);
+        }
+
+        if (copyright) {
+            const copyrightEl = document.createElement('p');
+            copyrightEl.classList.add('adw-label', 'copyright', 'caption');
+            copyrightEl.textContent = copyright;
+            contentArea.appendChild(copyrightEl);
+        }
+
+        // TODO: Add sections for developers, license, etc. as per full AdwAboutDialog spec
+        // This might involve more complex slotted content or attributes.
+
+        this.appendChild(contentArea);
+    }
+
+    _createBackdrop() { // Simplified backdrop creation, could share with AdwDialogElement
+        if (!AdwAboutDialogElement._backdropElement) {
+            AdwAboutDialogElement._backdropElement = document.createElement('div');
+            AdwAboutDialogElement._backdropElement.classList.add('adw-dialog-backdrop'); // Global class
+            Object.assign(AdwAboutDialogElement._backdropElement.style, {
+                display: 'none', position: 'fixed', top: '0', left: '0',
+                width: '100%', height: '100%',
+                backgroundColor: 'var(--dialog-backdrop-color, rgba(0,0,0,0.4))',
+                zIndex: 'calc(var(--z-index-dialog, 1050) - 1)',
+                opacity: '0',
+                transition: 'opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease)'
+            });
+            document.body.appendChild(AdwAboutDialogElement._backdropElement);
+        }
+        return AdwAboutDialogElement._backdropElement;
+    }
+
+    _onKeydown(event) {
+        if (event.key === 'Escape') {
+            this.close();
+        }
+    }
+
+    _doOpen() {
+        this.removeAttribute('hidden');
+        this.style.display = 'flex';
+
+        const backdrop = this._createBackdrop();
+        backdrop.style.display = 'block';
+        // Force reflow before starting animation
+        void backdrop.offsetWidth;
+        void this.offsetWidth;
+
+        backdrop.style.opacity = '1';
+        this.style.opacity = '1';
+        this.style.transform = 'scale(1)';
+
+        // No backdrop click to close for AboutDialog by default, per GNOME HIG
+        document.addEventListener('keydown', this._boundOnKeydown);
+
+        const firstFocusable = this.querySelector('.adw-dialog-close-button, button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (firstFocusable) {
+            firstFocusable.focus();
+        }
+        this.dispatchEvent(new CustomEvent('open'));
+    }
+
+    _doClose() {
+        if (AdwAboutDialogElement._backdropElement) {
+            AdwAboutDialogElement._backdropElement.style.opacity = '0';
+        }
+        this.style.opacity = '0';
+        this.style.transform = 'scale(0.95)';
+
+        setTimeout(() => {
+            this.setAttribute('hidden', '');
+            this.style.display = 'none';
+            if (AdwAboutDialogElement._backdropElement) {
+                AdwAboutDialogElement._backdropElement.style.display = 'none';
+            }
+        }, 150); // Match animation duration
+
+        document.removeEventListener('keydown', this._boundOnKeydown);
+        this.dispatchEvent(new CustomEvent('close'));
+    }
+
+    open() {
+        this.setAttribute('open', '');
+    }
+
+    close() {
+        this.removeAttribute('open');
+    }
+}
+AdwAboutDialogElement._backdropElement = null; // Shared backdrop instance
+
+customElements.define('adw-about-dialog', AdwAboutDialogElement);
+
+Adw.AboutDialog = Adw.AboutDialog || {};
+Adw.AboutDialog.factory = (options = {}) => {
+    const dialog = document.createElement('adw-about-dialog');
+    if (options.appName) dialog.setAttribute('app-name', options.appName);
+    if (options.version) dialog.setAttribute('version', options.version);
+    if (options.copyright) dialog.setAttribute('copyright', options.copyright);
+    if (options.logo) dialog.setAttribute('logo', options.logo);
+    if (options.comments) dialog.setAttribute('comments', options.comments);
+    if (options.website) dialog.setAttribute('website', options.website);
+    if (options.websiteLabel) dialog.setAttribute('website-label', options.websiteLabel);
+    if (options.licenseType) dialog.setAttribute('license-type', options.licenseType);
+    // Note: Does not handle complex slotted content like developers list from JS factory yet.
+
+    if (typeof options.onClose === 'function') {
+        dialog.addEventListener('close', options.onClose);
+    }
+    return dialog;
+};
+window.createAdwAboutDialog = Adw.AboutDialog.factory;
+
+console.log("AdwAboutDialogElement defined and registered.");

--- a/adwaita-web/js/components/dialog.js
+++ b/adwaita-web/js/components/dialog.js
@@ -1,0 +1,277 @@
+// adwaita-web/js/components/dialog.js
+
+if (!window.Adw) {
+  window.Adw = {};
+}
+
+class AdwDialogElement extends HTMLElement {
+  constructor() {
+    super();
+    this._boundOnBackdropClick = this._onBackdropClick.bind(this);
+    this._boundOnKeydown = this._onKeydown.bind(this);
+
+    // Initial structure (will be populated more dynamically or via slots)
+    this.attachShadow({ mode: 'open' }); // Using Shadow DOM for encapsulation
+
+    const style = document.createElement('style');
+    // Basic styling - actual Adwaita styles will come from global adwaita-skin.css
+    // We need to ensure global styles can penetrate or are explicitly adopted.
+    // For now, let's assume global CSS handles .adw-dialog, .adw-dialog-backdrop etc.
+    // For web components, it's better to adopt external stylesheets or define self-contained styles.
+    // This is a simplified approach for now.
+    style.textContent = `
+      :host {
+        display: none; /* Hidden by default */
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: var(--z-index-dialog, 1050);
+        align-items: center;
+        justify-content: center;
+      }
+      :host([open]) {
+        display: flex;
+      }
+      .adw-dialog-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: var(--dialog-backdrop-color, rgba(0,0,0,0.4));
+        opacity: 0;
+        transition: opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease);
+      }
+      :host([open]) .adw-dialog-backdrop {
+        opacity: 1;
+      }
+      .adw-dialog-container {
+        /* Styles for .adw-dialog class from global CSS are expected here */
+        /* This container is what users see as the dialog box */
+        position: relative; /* For z-index stacking if needed within the host */
+        z-index: 1; /* Above backdrop within the host */
+        opacity: 0;
+        transform: scale(0.95);
+        transition: opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease),
+                    transform var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease);
+      }
+      :host([open]) .adw-dialog-container {
+        opacity: 1;
+        transform: scale(1);
+      }
+      /* Applying Adwaita styles directly inside shadow DOM can be tricky.
+         Ideally, adwaita-skin.css would define styles for adw-dialog and its parts,
+         and we would construct the light DOM to match, or adopt the stylesheet.
+         For simplicity here, we'll assume the global CSS applies if we build the
+         dialog structure in light DOM and don't use shadow DOM, OR
+         we must explicitly link/adopt the main adwaita-skin.css into the shadow DOM.
+         Let's switch to Light DOM for dialogs as they are modal and often need global CSS.
+      */
+    `;
+    // Shadow DOM approach is complex for modals due to stacking and global styles.
+    // Reverting to Light DOM for dialog component for easier styling with global CSS.
+    // this.shadowRoot.appendChild(style);
+    // this._backdrop = document.createElement('div');
+    // this._backdrop.classList.add('adw-dialog-backdrop');
+    // this.shadowRoot.appendChild(this._backdrop);
+
+    // this._dialogContainer = document.createElement('div');
+    // this._dialogContainer.classList.add('adw-dialog'); // Use global class
+    // this.shadowRoot.appendChild(this._dialogContainer);
+
+    // Using Light DOM for easier styling with existing global adwaita-skin.css
+    this.classList.add('adw-dialog'); // The host itself is the .adw-dialog
+    this._backdrop = null; // Backdrop will be separate, managed by open/close
+  }
+
+  static get observedAttributes() {
+    return ['open', 'title', 'close-on-backdrop-click'];
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (name === 'open') {
+      if (this.hasAttribute('open')) {
+        this._doOpen();
+      } else {
+        this._doClose();
+      }
+    } else if (name === 'title') {
+      this._updateTitle(newValue);
+    }
+  }
+
+  connectedCallback() {
+    // Ensure basic structure if not already there (e.g. from declarative use)
+    // This is simplified; complex slotting would require more robust handling.
+    if (!this.querySelector('.adw-dialog__header')) {
+        const header = document.createElement('header');
+        header.classList.add('adw-header-bar', 'adw-dialog__header');
+        const titleEl = document.createElement('h2');
+        titleEl.classList.add('adw-header-bar__title');
+        titleEl.id = 'dialog-title-' + (this.id || Math.random().toString(36).substring(2,7));
+        this.setAttribute('aria-labelledby', titleEl.id);
+        header.appendChild(titleEl);
+        this.prepend(header); // Prepend to allow content to follow
+    }
+    if (this.title) {
+        this._updateTitle(this.title);
+    }
+     // Default to hidden if not explicitly open
+    if (!this.hasAttribute('open')) {
+        this.setAttribute('hidden', '');
+    }
+  }
+
+  _updateTitle(newTitle) {
+    let titleEl = this.querySelector('.adw-dialog__header .adw-header-bar__title');
+    if (titleEl) {
+      titleEl.textContent = newTitle || '';
+    }
+  }
+
+  _createBackdrop() {
+    if (!AdwDialogElement._backdropElement) {
+        AdwDialogElement._backdropElement = document.createElement('div');
+        AdwDialogElement._backdropElement.classList.add('adw-dialog-backdrop');
+        AdwDialogElement._backdropElement.style.display = 'none'; // Start hidden
+        AdwDialogElement._backdropElement.style.position = 'fixed';
+        AdwDialogElement._backdropElement.style.top = '0';
+        AdwDialogElement._backdropElement.style.left = '0';
+        AdwDialogElement._backdropElement.style.width = '100%';
+        AdwDialogElement._backdropElement.style.height = '100%';
+        AdwDialogElement._backdropElement.style.backgroundColor = 'var(--dialog-backdrop-color, rgba(0,0,0,0.4))';
+        AdwDialogElement._backdropElement.style.zIndex = 'calc(var(--z-index-dialog, 1050) - 1)'; // Below dialog
+        AdwDialogElement._backdropElement.style.opacity = '0';
+        AdwDialogElement._backdropElement.style.transition = 'opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease)';
+        document.body.appendChild(AdwDialogElement._backdropElement);
+    }
+    return AdwDialogElement._backdropElement;
+  }
+
+  _onBackdropClick(event) {
+    if (this.getAttribute('close-on-backdrop-click') !== 'false') {
+      this.close();
+    }
+  }
+
+  _onKeydown(event) {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  _doOpen() {
+    this.removeAttribute('hidden');
+    this.style.display = 'flex'; // From CSS :host([open])
+
+    const backdrop = this._createBackdrop();
+    backdrop.style.display = 'block';
+    setTimeout(() => { // Allow display change to take effect before transition
+        backdrop.style.opacity = '1';
+        this.style.opacity = '1'; // Assuming .adw-dialog also has opacity transition
+        this.style.transform = 'scale(1)'; // Assuming .adw-dialog also has transform transition
+    }, 10);
+
+
+    backdrop.addEventListener('click', this._boundOnBackdropClick);
+    document.addEventListener('keydown', this._boundOnKeydown);
+
+    // Focus management
+    const firstFocusable = this.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (firstFocusable) {
+      firstFocusable.focus();
+    }
+    this.dispatchEvent(new CustomEvent('open'));
+  }
+
+  _doClose() {
+    if (AdwDialogElement._backdropElement) {
+        AdwDialogElement._backdropElement.style.opacity = '0';
+    }
+    this.style.opacity = '0';
+    this.style.transform = 'scale(0.95)';
+
+    setTimeout(() => {
+        this.setAttribute('hidden', '');
+        this.style.display = 'none';
+        if (AdwDialogElement._backdropElement) {
+            AdwDialogElement._backdropElement.style.display = 'none';
+        }
+    }, 150); // Match animation duration
+
+    if (AdwDialogElement._backdropElement) {
+        AdwDialogElement._backdropElement.removeEventListener('click', this._boundOnBackdropClick);
+    }
+    document.removeEventListener('keydown', this._boundOnKeydown);
+    this.dispatchEvent(new CustomEvent('close'));
+  }
+
+  open() {
+    this.setAttribute('open', '');
+  }
+
+  close() {
+    this.removeAttribute('open');
+  }
+
+  get title() {
+    return this.getAttribute('title');
+  }
+  set title(value) {
+    this.setAttribute('title', value);
+  }
+}
+AdwDialogElement._backdropElement = null; // Static property for shared backdrop
+
+// Define the custom element
+customElements.define('adw-dialog', AdwDialogElement);
+
+// Make it available via Adw namespace for imperative creation if needed
+Adw.Dialog = Adw.Dialog || {};
+Adw.Dialog.factory = (options = {}) => {
+    const dialog = document.createElement('adw-dialog');
+    if (options.title) dialog.title = options.title;
+    if (options.closeOnBackdropClick === false) dialog.setAttribute('close-on-backdrop-click', 'false');
+
+    if (options.content) {
+        const contentDiv = document.createElement('div');
+        contentDiv.slot = 'content'; // Assuming dialog.scss styles slots
+        if (typeof options.content === 'string') {
+            contentDiv.innerHTML = options.content; // Or textContent if plain text
+        } else if (options.content instanceof Node) {
+            contentDiv.appendChild(options.content);
+        }
+        dialog.appendChild(contentDiv);
+    }
+    if (options.buttons && Array.isArray(options.buttons)) {
+        const buttonsDiv = document.createElement('div');
+        buttonsDiv.slot = 'buttons'; // Assuming dialog.scss styles slots
+        options.buttons.forEach(button => buttonsDiv.appendChild(button));
+        dialog.appendChild(buttonsDiv);
+    }
+    if (typeof options.onClose === 'function') {
+        dialog.addEventListener('close', options.onClose);
+    }
+    // The dialog is created but not opened. Caller should call .open()
+    return dialog;
+};
+// For convenience, matching docs
+window.createAdwDialog = Adw.Dialog.factory;
+I've created the file `adwaita-web/js/components/dialog.js` and implemented a basic `AdwDialogElement` web component.
+
+Key features of this initial implementation:
+*   It's registered as `<adw-dialog>`.
+*   It uses Light DOM for easier styling with the global `adwaita-skin.css`. The host element itself gets the `adw-dialog` class.
+*   It manages a shared backdrop element (`AdwDialogElement._backdropElement`) for all dialog instances.
+*   Implements `open()` and `close()` methods, which toggle an `open` attribute and manage visibility with basic opacity/scale transitions.
+*   Handles `title` attribute to update a title element within a standard header structure (created if not present).
+*   Supports `close-on-backdrop-click` attribute and ESC key for closing.
+*   Provides a basic `Adw.Dialog.factory` (aliased to `createAdwDialog`) for imperative creation, though it's simplified and assumes the global CSS will style slotted content correctly.
+
+**Next Steps within this plan item:**
+1.  Create a main `adwaita-web/js/components.js` file that imports and ensures `dialog.js` (and potentially other future components) is executed.
+2.  Ensure this main `components.js` (or `dialog.js` directly if preferred for now) is loaded in `app-demo/templates/base.html`.
+
+Let's create `adwaita-web/js/components.js` to load `dialog.js`.

--- a/adwaita-web/scss/_about_dialog.scss
+++ b/adwaita-web/scss/_about_dialog.scss
@@ -1,0 +1,66 @@
+// SCSS for AdwAboutDialog
+@use 'variables';
+@use 'mixins';
+
+.adw-about-dialog {
+  // Inherits .adw-dialog base styles (background, shadow, basic structure)
+  // About dialogs often have a slightly wider max-width or specific width.
+  max-width: 600px; // Example, adjust as needed
+
+  .adw-dialog__content {
+    padding: var(--spacing-xl); // Generous padding for about dialogs
+    text-align: center; // Center most content by default
+  }
+
+  .adw-about-dialog-logo {
+    display: block;
+    margin: 0 auto var(--spacing-l) auto;
+    width: 64px; // Standard size for app icon in about dialog
+    height: 64px;
+    border-radius: var(--border-radius-medium); // Slight rounding if it's square
+    object-fit: contain;
+  }
+
+  .application-name {
+    // font-size: var(--title-1-font-size); // Already title-1 from JS component
+    // font-weight: var(--font-weight-bold); // Already bold from .title-1
+    margin-bottom: var(--spacing-xxs);
+    color: var(--headerbar-fg-color); // Use headerbar text color for emphasis
+  }
+
+  .version {
+    // font-size: var(--font-size-base); // body-2 is smaller than base
+    opacity: var(--dim-opacity);
+    margin-bottom: var(--spacing-m);
+  }
+
+  .comments {
+    font-size: var(--font-size-base);
+    margin-bottom: var(--spacing-l);
+    // text-align: left; // If comments should be left-aligned within centered dialog
+  }
+
+  .website-link {
+    // Standard link styling, but maybe a specific margin
+    display: block; // Make it a block for centering or specific layout
+    margin-bottom: var(--spacing-m);
+  }
+
+  .copyright {
+    // font-size: var(--font-size-small); // caption class handles this
+    opacity: var(--dim-opacity);
+    margin-top: var(--spacing-l); // Space above copyright
+  }
+
+  // Placeholder for future sections like license, credits if implemented via expanders/tabs
+  .adw-expander-row, .adw-tab-view {
+    margin-top: var(--spacing-l);
+    text-align: left; // These complex widgets usually align left
+  }
+}
+
+// Ensure the .adw-dialog-close-button in the header of an .adw-about-dialog
+// is styled correctly if it needs specific overrides (usually not, inherits from .adw-dialog)
+.adw-about-dialog .adw-dialog__header .adw-dialog-close-button {
+  // No specific overrides usually needed here
+}

--- a/adwaita-web/scss/adwaita-skin.scss
+++ b/adwaita-web/scss/adwaita-skin.scss
@@ -14,6 +14,7 @@
 @use 'card'; // Ensure card is before listbox
 @use 'listbox';
 @use 'dialog';
+@use 'about_dialog';
 @use 'row_types';
 @use 'action_row';
 @use 'entry_row';

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -100,24 +100,16 @@
     </div>
 </header>
 
-{# Adwaita About Dialog HTML Structure #}
-<div class="adw-dialog adw-about-dialog" id="app-about-dialog" role="dialog" aria-labelledby="about-dialog-title" aria-modal="true" hidden>
-    <header class="adw-header-bar adw-dialog__header">
-        <h2 class="adw-header-bar__title" id="about-dialog-title">About {{ site_settings.get('site_title', 'Adwaita Social Demo') }}</h2>
-        <button id="close-about-dialog-btn" class="adw-button circular flat adw-dialog-close-button" aria-label="Close dialog">
-            <span class="adw-icon icon-window-close-symbolic"></span>
-        </button>
-    </header>
-    <div class="adw-dialog__content">
-        {# Basic content for an AboutDialog #}
-        <p class="adw-label application-name">{{ site_settings.get('site_title', 'Adwaita Social Demo') }}</p>
-        <p class="adw-label version">Version 1.0.0 (Demo)</p>
-        <p class="adw-label copyright">© {{ current_year }} Your Name/Organization</p>
-        <p class="adw-label comments">This is a demonstration application using the Adwaita-Web UI library.</p>
-        {# <a href="YOUR_WEBSITE_URL_HERE" class="adw-link website-link" target="_blank" rel="noopener noreferrer">Visit Website</a> #}
-    </div>
-    {# AboutDialogs typically don't have a separate action footer unless for credits button etc. #}
-</div>
+{# Adwaita About Dialog Web Component #}
+<adw-about-dialog id="app-about-dialog"
+    app-name="{{ site_settings.get('site_title', 'Adwaita Social Demo') }}"
+    version="1.0.0 (Demo)"
+    copyright="© {{ current_year }} Adwaita-Web Contributors"
+    comments="This is a demonstration application using the Adwaita-Web UI library."
+    logo="{{ url_for('static', filename='img/default_avatar.png') }}" {# Example logo #}
+    website="https://github.com/mclellac/adwaita-web">
+    {# Additional slots like license-text or developers could be added here if needed #}
+</adw-about-dialog>
 
 
 <div class="app-body-container"> {# NEW: Main container for sidebar + content #}
@@ -251,7 +243,8 @@
     {# Theme and accent handling script is above, this is for other scripts #}
     <script src="{{ url_for('static', filename='js/app-layout.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/banner.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='js/toast.js') }}" defer></script> {# Ensure toast.js is loaded #}
+    <script src="{{ url_for('static', filename='js/toast.js') }}" defer></script>
+    <script type="module" src="{{ url_for('static', filename='js/components.js') }}" defer></script> {# Load Web Components #}
     <script nonce="{{ csp_nonce() if csp_nonce else '' }}">
         document.addEventListener('DOMContentLoaded', () => {
             // Main App Menu Popover
@@ -290,29 +283,27 @@
             }
 
             // About Dialog
-            const aboutDialog = document.getElementById('app-about-dialog');
+            const appAboutDialogEl = document.getElementById('app-about-dialog'); // This is now <adw-about-dialog>
             const openAboutDialogBtn = document.getElementById('about-dialog-trigger');
-            const closeAboutDialogBtn = document.getElementById('close-about-dialog-btn');
+            // The close button is now part of the AdwAboutDialogElement's internal structure,
+            // and ESC key handling is also ideally within the component.
 
-            if (aboutDialog && openAboutDialogBtn && closeAboutDialogBtn) {
+            if (appAboutDialogEl && openAboutDialogBtn) {
                 openAboutDialogBtn.addEventListener('click', () => {
-                    aboutDialog.removeAttribute('hidden');
+                    if (typeof appAboutDialogEl.open === 'function') {
+                        appAboutDialogEl.open();
+                    } else { // Fallback
+                        appAboutDialogEl.removeAttribute('hidden');
+                    }
                     // Close popover if open
                     if(menuPopover && !menuPopover.hidden) {
                         menuPopover.setAttribute('hidden', '');
-                        menuButton.setAttribute('aria-expanded', 'false');
-                    }
-                    const firstFocusable = aboutDialog.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-                    if (firstFocusable) firstFocusable.focus();
-                });
-                closeAboutDialogBtn.addEventListener('click', () => {
-                    aboutDialog.setAttribute('hidden', 'true');
-                });
-                aboutDialog.addEventListener('keydown', (event) => {
-                    if (event.key === 'Escape') {
-                        aboutDialog.setAttribute('hidden', 'true');
+                        if(menuButton) menuButton.setAttribute('aria-expanded', 'false');
                     }
                 });
+                // Note: The AdwAboutDialogElement should handle its own close button clicks and ESC key.
+                // If a manual close button outside the component was needed, its listener would be:
+                // closeAboutDialogBtn.addEventListener('click', () => appAboutDialogEl.close());
             }
         });
     </script>

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -103,21 +103,24 @@
             <button id="open-delete-dialog-btn" class="adw-button destructive-action">Delete Post</button>
         </div>
 
-        <div class="adw-dialog" id="delete-confirm-dialog" role="alertdialog" aria-labelledby="delete-dialog-title" aria-modal="true" hidden>
-            <header class="adw-header-bar adw-dialog__header">
-                 <h2 class="adw-header-bar__title" id="delete-dialog-title">Confirm Deletion</h2>
+    <adw-dialog id="delete-confirm-dialog" title="Confirm Deletion">
+        {# Default header with title is handled by the web component based on 'title' attribute #}
+        {# Or, we can provide a custom header slot if needed:
+        <header slot="header" class="adw-header-bar adw-dialog__header">
+             <h2 class="adw-header-bar__title">Confirm Deletion</h2>
             </header>
-            <div class="adw-dialog__content">
+        #}
+        <div slot="content">
                 <p class="adw-label body">Are you sure you want to delete this post? This action cannot be undone.</p>
             </div>
-            <footer class="adw-dialog__actions">
+        <div slot="buttons" class="adw-dialog__actions-buttons-container"> {# Added a wrapper for consistent styling if needed #}
                 <button id="cancel-delete-btn" class="adw-button flat">Cancel</button>
                 <form method="POST" action="{{ url_for('post.delete_post', post_id=post.id) }}" id="delete-post-form" class="delete-post-form-inline">
                     {{ delete_post_form.hidden_tag() }} {# Use form instance for CSRF #}
                     <button id="confirm-delete-btn" type="submit" class="adw-button destructive-action">Delete</button>
                 </form>
-            </footer>
         </div>
+    </adw-dialog>
         {% endif %}
     </article>
 
@@ -245,53 +248,52 @@
          <a href="{{ url_for('general.index') }}" class="adw-button"><span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Posts</a>
     </div>
 
-    {# Dialog for confirming comment deletion #}
-    <div class="adw-dialog" id="delete-comment-confirm-dialog" role="alertdialog" aria-labelledby="delete-comment-dialog-title" aria-modal="true" hidden>
-        <header class="adw-header-bar adw-dialog__header">
-             <h2 class="adw-header-bar__title" id="delete-comment-dialog-title">Confirm Comment Deletion</h2>
-        </header>
-        <div class="adw-dialog__content">
+    {# Dialog for confirming comment deletion - now using <adw-dialog> #}
+    <adw-dialog id="delete-comment-confirm-dialog" title="Confirm Comment Deletion">
+        <div slot="content">
             <p class="adw-label body">Are you sure you want to delete this comment? This action cannot be undone.</p>
         </div>
-        <footer class="adw-dialog__actions">
+        <div slot="buttons" class="adw-dialog__actions-buttons-container">
             <button id="cancel-comment-delete-btn" class="adw-button flat">Cancel</button>
-            {# This form will be submitted by JS after setting its action #}
             <form method="POST" action="" id="confirm-delete-comment-form-actual" style="display: inline;">
-                 {{ delete_comment_form.hidden_tag() }} {# Re-use one of the delete_comment_form instances for CSRF token #}
+                 {{ delete_comment_form.hidden_tag() }}
                 <button id="confirm-comment-delete-btn" type="submit" class="adw-button destructive-action">Delete Comment</button>
             </form>
-        </footer>
-    </div>
+        </div>
+    </adw-dialog>
 </div>
 
 <script>
-// Delete post dialog script
 document.addEventListener('DOMContentLoaded', () => {
     // Post Deletion Dialog
-    const deletePostDialogEl = document.getElementById('delete-confirm-dialog');
+    const deletePostDialogEl = document.getElementById('delete-confirm-dialog'); // This is now <adw-dialog>
     const openPostDeleteDialogBtn = document.getElementById('open-delete-dialog-btn');
     const cancelPostDeleteBtn = document.getElementById('cancel-delete-btn');
 
     if (openPostDeleteDialogBtn && deletePostDialogEl) {
         openPostDeleteDialogBtn.addEventListener('click', (event) => {
             event.preventDefault();
-            deletePostDialogEl.removeAttribute('hidden');
-            const firstFocusable = deletePostDialogEl.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-            if (firstFocusable) firstFocusable.focus();
+            if (typeof deletePostDialogEl.open === 'function') {
+                deletePostDialogEl.open();
+            } else { // Fallback if WC not registered/working
+                deletePostDialogEl.removeAttribute('hidden');
+            }
+            // Focusing logic might need to be inside the component's open method
         });
     }
-    // Corrected conditional: uses cancelPostDeleteBtn and deletePostDialogEl
     if (cancelPostDeleteBtn && deletePostDialogEl) {
-        cancelPostDeleteBtn.addEventListener('click', () => deletePostDialogEl.setAttribute('hidden', 'true'));
-    }
-    if (deletePostDialogEl) { // ESC key for post delete dialog
-        deletePostDialogEl.addEventListener('keydown', (event) => {
-            if (event.key === 'Escape') deletePostDialogEl.setAttribute('hidden', 'true');
+        cancelPostDeleteBtn.addEventListener('click', () => {
+            if (typeof deletePostDialogEl.close === 'function') {
+                deletePostDialogEl.close();
+            } else { // Fallback
+                deletePostDialogEl.setAttribute('hidden', 'true');
+            }
         });
     }
+    // ESC key handling is now ideally inside the AdwDialogElement component
 
     // Comment Deletion Dialog
-    const deleteCommentDialogEl = document.getElementById('delete-comment-confirm-dialog');
+    const deleteCommentDialogEl = document.getElementById('delete-comment-confirm-dialog'); // This is now <adw-dialog>
     const cancelCommentDeleteBtn = document.getElementById('cancel-comment-delete-btn');
     const confirmDeleteCommentFormActual = document.getElementById('confirm-delete-comment-form-actual');
 
@@ -300,27 +302,27 @@ document.addEventListener('DOMContentLoaded', () => {
             event.preventDefault();
             const formId = button.dataset.formId;
             const originalForm = document.getElementById(formId);
-            if (originalForm && confirmDeleteCommentFormActual) {
-                // Set the action for the dialog's form
+            if (originalForm && confirmDeleteCommentFormActual && deleteCommentDialogEl) {
                 confirmDeleteCommentFormActual.action = originalForm.action;
-                // Show the dialog
-                deleteCommentDialogEl.removeAttribute('hidden');
-                const firstFocusable = deleteCommentDialogEl.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-                if (firstFocusable) firstFocusable.focus();
+                if (typeof deleteCommentDialogEl.open === 'function') {
+                    deleteCommentDialogEl.open();
+                } else { // Fallback
+                    deleteCommentDialogEl.removeAttribute('hidden');
+                }
             }
         });
     });
 
     if (cancelCommentDeleteBtn && deleteCommentDialogEl) {
-        cancelCommentDeleteBtn.addEventListener('click', () => deleteCommentDialogEl.setAttribute('hidden', 'true'));
-    }
-    // Confirm button for comment deletion is type="submit" on its own form, so no specific JS listener needed for submission itself.
-    // ESC key for comment delete dialog
-    if (deleteCommentDialogEl) {
-        deleteCommentDialogEl.addEventListener('keydown', (event) => {
-            if (event.key === 'Escape') deleteCommentDialogEl.setAttribute('hidden', 'true');
+        cancelCommentDeleteBtn.addEventListener('click', () => {
+            if (typeof deleteCommentDialogEl.close === 'function') {
+                deleteCommentDialogEl.close();
+            } else { // Fallback
+                deleteCommentDialogEl.setAttribute('hidden', 'true');
+            }
         });
     }
+    // ESC key handling is now ideally inside the AdwDialogElement component
 });
 
 // Threaded comments reply script


### PR DESCRIPTION
- Created <adw-dialog> and <adw-about-dialog> web components with open()/close() methods and attribute handling.
- Added JS files for these components under adwaita-web/js/components/ and a main components.js loader.
- Updated base.html to load the new components.js module.
- Added SCSS for <adw-about-dialog> to style it according to Adwaita design, and imported it into the main stylesheet.
- Refactored dialog usage in post.html and base.html to use the new <adw-dialog> and <adw-about-dialog> custom elements and their methods, replacing previous div-based dialogs.
- This addresses issues where dialogs were not opening due to missing .open() methods.