### PR TITLE
Refactor: Revert dialog.js internal CSS to template literal

### DIFF
--- a/adwaita-web/js/components/dialog.js
+++ b/adwaita-web/js/components/dialog.js
@@ -19,28 +19,49 @@ class AdwDialogElement extends HTMLElement {
     // For now, let's assume global CSS handles .adw-dialog, .adw-dialog-backdrop etc.
     // For web components, it's better to adopt external stylesheets or define self-contained styles.
     // This is a simplified approach for now.
-    // Populating style tag content line by line to avoid any JS string literal issues.
-    style.appendChild(document.createTextNode(':host {'));
-    style.appendChild(document.createTextNode('  display: none; /* Hidden by default */'));
-    style.appendChild(document.createTextNode('  position: fixed;'));
-    style.appendChild(document.createTextNode('  top: 0; left: 0; width: 100%; height: 100%;'));
-    style.appendChild(document.createTextNode('  z-index: var(--z-index-dialog, 1050);'));
-    style.appendChild(document.createTextNode('  align-items: center; justify-content: center;'));
-    style.appendChild(document.createTextNode('}'));
-    style.appendChild(document.createTextNode(':host([open]) { display: flex; }'));
-    style.appendChild(document.createTextNode('.adw-dialog-backdrop {'));
-    style.appendChild(document.createTextNode('  position: fixed; top: 0; left: 0; width: 100%; height: 100%;'));
-    style.appendChild(document.createTextNode('  background-color: var(--dialog-backdrop-color, rgba(0,0,0,0.4));'));
-    style.appendChild(document.createTextNode('  opacity: 0;'));
-    style.appendChild(document.createTextNode('  transition: opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease);'));
-    style.appendChild(document.createTextNode('}'));
-    style.appendChild(document.createTextNode(':host([open]) .adw-dialog-backdrop { opacity: 1; }'));
-    style.appendChild(document.createTextNode('.adw-dialog-container {'));
-    style.appendChild(document.createTextNode('  position: relative; z-index: 1; opacity: 0; transform: scale(0.95);'));
-    style.appendChild(document.createTextNode('  transition: opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease), transform var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease);'));
-    style.appendChild(document.createTextNode('}'));
-    style.appendChild(document.createTextNode(':host([open]) .adw-dialog-container { opacity: 1; transform: scale(1); }'));
-
+    style.textContent = `
+      :host {
+        display: none; /* Hidden by default */
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: var(--z-index-dialog, 1050);
+        align-items: center;
+        justify-content: center;
+      }
+      :host([open]) {
+        display: flex;
+      }
+      .adw-dialog-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: var(--dialog-backdrop-color, rgba(0,0,0,0.4));
+        opacity: 0;
+        transition: opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease);
+      }
+      :host([open]) .adw-dialog-backdrop {
+        opacity: 1;
+      }
+      .adw-dialog-container {
+        /* Styles for .adw-dialog class from global CSS are expected here */
+        /* This container is what users see as the dialog box */
+        position: relative; /* For z-index stacking if needed within the host */
+        z-index: 1; /* Above backdrop within the host */
+        opacity: 0;
+        transform: scale(0.95);
+        transition: opacity var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease),
+                    transform var(--animation-duration-short, 150ms) var(--animation-ease-out-cubic, ease);
+      }
+      :host([open]) .adw-dialog-container {
+        opacity: 1;
+        transform: scale(1);
+      }
+    `;
     // Shadow DOM approach is complex for modals due to stacking and global styles.
     // Reverting to Light DOM for dialog component for easier styling with global CSS.
     // this.shadowRoot.appendChild(style); // Style would go into shadowRoot if used


### PR DESCRIPTION
Reverted the internal CSS string definition within AdwDialogElement's constructor (in adwaita-web/js/components/dialog.js) back to using a standard JavaScript template literal (backticks).

This change is an attempt to ensure the most standard and typically error-free method for defining this multi-line string, in continued efforts to resolve a persistent 'Uncaught SyntaxError: '' string literal contains an unescaped line break' reported in this file. If the error persists, its origin related to a single-quoted string is not in this specific CSS block when defined via a template literal.