### PR TITLE
Debug: Add counters to app-layout.js for diagnosing multiple event fi…

### DIFF
--- a/adwaita-web/js/app-layout.js
+++ b/adwaita-web/js/app-layout.js
@@ -1,5 +1,9 @@
+let appLayoutDOMContentLoadedCount = 0;
+let appLayoutWhenDefinedResolvedCount = 0;
+
 document.addEventListener('DOMContentLoaded', function () {
-    console.log('app-layout.js: DOMContentLoaded');
+    appLayoutDOMContentLoadedCount++;
+    console.log(`app-layout.js: DOMContentLoaded event #${appLayoutDOMContentLoadedCount}`);
 
     const sidebarToggle = document.querySelector('.app-sidebar-toggle');
     const sidebar = document.getElementById('app-sidebar');
@@ -57,7 +61,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     console.log('app-layout.js: Waiting for adw-dialog custom element to be defined...');
     customElements.whenDefined('adw-dialog').then(() => {
-        console.log('app-layout.js: adw-dialog is defined. Initializing dialog handlers.');
+        appLayoutWhenDefinedResolvedCount++;
+        console.log(`app-layout.js: adw-dialog is defined. Initializing dialog handlers (call #${appLayoutWhenDefinedResolvedCount}).`);
 
         // Post Deletion Dialog (from post.html)
         const deletePostDialogEl = document.getElementById('delete-confirm-dialog');


### PR DESCRIPTION
…rings

Adds counters for:
- DOMContentLoaded event listener invocations.
- customElements.whenDefined('adw-dialog').then() callback invocations.

This will help determine if the script or the whenDefined callback is executing multiple times, leading to repeated event listener attachments for dialog trigger buttons.