### PR TITLE
Feat: Revamp AdwAboutDialogElement and fix menu positioning

### DIFF
--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -22,7 +22,16 @@ class AdwAboutDialogElement extends HTMLElement {
 
     static get observedAttributes() {
         console.log('AdwAboutDialogElement: observedAttributes getter called.');
-        return ['open', 'app-name', 'version', 'copyright', 'logo', 'comments', 'website', 'website-label', 'license-type'];
+        return [
+            'open', 'app-name', 'application-name', 'version', 'copyright', 'logo', 'application-icon',
+            'comments', 'website', 'website-label', 'license-type', 'license',
+            'developer-name', // Keep for potential single developer case
+            'developers', 'designers', 'artists', 'documenters', 'translator-credits',
+            'issue-url', 'support-url',
+            'release-notes', 'release-notes-version',
+            'system-information'
+            // Note: 'logo-icon-name' is less direct for web, prefer 'logo' (URL) or 'application-icon' (CSS class/SVG name)
+        ];
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
@@ -36,8 +45,9 @@ class AdwAboutDialogElement extends HTMLElement {
                 this._doClose();
             }
         } else {
-            if (this.isConnected && this._initialized) { // Only re-render if connected and initialized
-                console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} attribute ${name} changed, calling _render.`);
+            // Re-render if the attribute is not 'open' and the component is connected and initialized.
+            if (this.isConnected && this._initialized) {
+                console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} attribute '${name}' changed from '${oldValue}' to '${newValue}', calling _render.`);
                 this._render();
             }
         }
@@ -71,74 +81,257 @@ class AdwAboutDialogElement extends HTMLElement {
         }
     }
 
+    _parseStringArray(attributeValue) {
+        if (!attributeValue) return [];
+        return attributeValue.split(',').map(item => item.trim()).filter(item => item);
+    }
+
     _render() {
         console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} _render called.`);
         this.innerHTML = ''; // Clear existing content
 
-        const appName = this.getAttribute('app-name') || 'Application';
-        // ... (rest of the attribute fetching remains the same)
+        // Get all attributes
+        const appName = this.getAttribute('application-name') || this.getAttribute('app-name') || 'Application';
         const version = this.getAttribute('version');
         const copyright = this.getAttribute('copyright');
-        const logoSrc = this.getAttribute('logo');
+        const logoSrc = this.getAttribute('logo') || this.getAttribute('application-icon'); // application-icon could be a path too
         const commentsText = this.getAttribute('comments');
         const websiteUrl = this.getAttribute('website');
         const websiteLabel = this.getAttribute('website-label') || websiteUrl;
+        const issueUrl = this.getAttribute('issue-url');
+        const supportUrl = this.getAttribute('support-url');
+        const licenseType = this.getAttribute('license-type');
+        const licenseText = this.getAttribute('license'); // Full license text
+
+        const developers = this._parseStringArray(this.getAttribute('developers'));
+        const developerName = this.getAttribute('developer-name'); // Fallback if developers is empty
+        const designers = this._parseStringArray(this.getAttribute('designers'));
+        const artists = this._parseStringArray(this.getAttribute('artists'));
+        const documenters = this._parseStringArray(this.getAttribute('documenters'));
+        const translatorCredits = this.getAttribute('translator-credits'); // Often a block of text
+
+        const releaseNotes = this.getAttribute('release-notes');
+        const releaseNotesVersion = this.getAttribute('release-notes-version');
+        const systemInformation = this.getAttribute('system-information');
 
         console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} rendering with appName: ${appName}`);
 
+        // 1. Header (standard dialog header)
         const header = document.createElement('header');
         header.classList.add('adw-header-bar', 'adw-dialog__header');
         const titleEl = document.createElement('h2');
         titleEl.classList.add('adw-header-bar__title');
-        titleEl.id = 'about-dialog-title-' + (this.id || Math.random().toString(36).substring(2,7));
+        titleEl.id = `about-dialog-title-${this.id || Math.random().toString(36).substring(2, 9)}`;
         titleEl.textContent = `About ${appName}`;
         this.setAttribute('aria-labelledby', titleEl.id);
         header.appendChild(titleEl);
+
         const closeButton = document.createElement('button');
         closeButton.classList.add('adw-button', 'circular', 'flat', 'adw-dialog-close-button');
         closeButton.setAttribute('aria-label', 'Close dialog');
         const closeIcon = document.createElement('span');
-        closeIcon.classList.add('adw-icon', 'icon-window-close-symbolic'); // Ensure this class provides the icon
+        closeIcon.classList.add('adw-icon', 'icon-window-close-symbolic');
         closeButton.appendChild(closeIcon);
         closeButton.addEventListener('click', this._boundCloseButtonClick);
         header.appendChild(closeButton);
         this.appendChild(header);
 
+        // 2. Main Content Area
         const contentArea = document.createElement('div');
-        contentArea.classList.add('adw-dialog__content');
-        // ... (rest of contentArea population is the same as original)
+        contentArea.classList.add('adw-dialog__content', 'adw-about-dialog__content-wrapper'); // Specific wrapper for about dialog styling
+
+        // Application Info Section
+        const appInfoSection = document.createElement('section');
+        appInfoSection.classList.add('adw-about-dialog__app-info');
         if (logoSrc) {
             const logoImg = document.createElement('img');
-            logoImg.src = logoSrc; logoImg.alt = `${appName} Logo`; logoImg.classList.add('adw-about-dialog-logo');
-            contentArea.appendChild(logoImg);
+            logoImg.src = logoSrc;
+            logoImg.alt = `${appName} Logo`;
+            logoImg.classList.add('adw-about-dialog-logo');
+            appInfoSection.appendChild(logoImg);
         }
-        const appNameEl = document.createElement('p');
-        appNameEl.classList.add('adw-label', 'application-name', 'title-1'); appNameEl.textContent = appName;
-        contentArea.appendChild(appNameEl);
+        const appNameEl = document.createElement('h3'); // Was p, h3 more semantic for app name here
+        appNameEl.classList.add('adw-about-dialog-application-name'); // Use more specific class
+        appNameEl.textContent = appName;
+        appInfoSection.appendChild(appNameEl);
+
         if (version) {
             const versionEl = document.createElement('p');
-            versionEl.classList.add('adw-label', 'version', 'body-2'); versionEl.textContent = `Version ${version}`;
-            contentArea.appendChild(versionEl);
+            versionEl.classList.add('adw-about-dialog-version');
+            versionEl.textContent = `Version ${version}`;
+            appInfoSection.appendChild(versionEl);
         }
         if (commentsText) {
             const commentsEl = document.createElement('p');
-            commentsEl.classList.add('adw-label', 'comments'); commentsEl.textContent = commentsText;
-            contentArea.appendChild(commentsEl);
+            commentsEl.classList.add('adw-about-dialog-comments');
+            commentsEl.innerHTML = commentsText.replace(/\n/g, '<br>'); // Support multi-line comments
+            appInfoSection.appendChild(commentsEl);
         }
+        contentArea.appendChild(appInfoSection);
+
+        // Links Section (Website, Support, Issues)
+        const linksSection = document.createElement('section');
+        linksSection.classList.add('adw-about-dialog__links');
         if (websiteUrl) {
             const websiteLink = document.createElement('a');
-            websiteLink.href = websiteUrl; websiteLink.textContent = websiteLabel || websiteUrl;
-            websiteLink.classList.add('adw-link'); websiteLink.target = '_blank'; websiteLink.rel = 'noopener noreferrer';
-            const websiteP = document.createElement('p'); websiteP.appendChild(websiteLink);
-            contentArea.appendChild(websiteP);
+            websiteLink.href = websiteUrl;
+            websiteLink.textContent = websiteLabel || 'Visit Website';
+            websiteLink.classList.add('adw-button', 'pill'); // Style as a pill button
+            websiteLink.target = '_blank';
+            websiteLink.rel = 'noopener noreferrer';
+            linksSection.appendChild(websiteLink);
         }
+        if (supportUrl) {
+            const supportLink = document.createElement('a');
+            supportLink.href = supportUrl;
+            supportLink.textContent = 'Get Support';
+            supportLink.classList.add('adw-button', 'pill');
+            supportLink.target = '_blank';
+            supportLink.rel = 'noopener noreferrer';
+            linksSection.appendChild(supportLink);
+        }
+        if (issueUrl) {
+            const issueLink = document.createElement('a');
+            issueLink.href = issueUrl;
+            issueLink.textContent = 'Report an Issue';
+            issueLink.classList.add('adw-button', 'pill');
+            issueLink.target = '_blank';
+            issueLink.rel = 'noopener noreferrer';
+            linksSection.appendChild(issueLink);
+        }
+        if (linksSection.hasChildNodes()) {
+            contentArea.appendChild(linksSection);
+        }
+
+
+        // Credits Section
+        const credits = [];
+        if (developers.length > 0) {
+            credits.push({ title: 'Developed by', names: developers });
+        } else if (developerName) {
+            credits.push({ title: 'Developed by', names: [developerName] });
+        }
+        if (designers.length > 0) credits.push({ title: 'Designed by', names: designers });
+        if (artists.length > 0) credits.push({ title: 'Artwork by', names: artists });
+        if (documenters.length > 0) credits.push({ title: 'Documentation by', names: documenters });
+
+        if (credits.length > 0) {
+            const creditsSection = document.createElement('section');
+            creditsSection.classList.add('adw-about-dialog__credits');
+            credits.forEach(creditGroup => {
+                const groupEl = document.createElement('div');
+                groupEl.classList.add('adw-about-dialog-credit-group');
+                const titleEl = document.createElement('h4');
+                titleEl.classList.add('adw-about-dialog-credit-title');
+                titleEl.textContent = creditGroup.title;
+                groupEl.appendChild(titleEl);
+                const listEl = document.createElement('ul');
+                listEl.classList.add('adw-about-dialog-credit-list');
+                creditGroup.names.forEach(name => {
+                    const listItemEl = document.createElement('li');
+                    listItemEl.textContent = name;
+                    listEl.appendChild(listItemEl);
+                });
+                groupEl.appendChild(listEl);
+                creditsSection.appendChild(groupEl);
+            });
+            contentArea.appendChild(creditsSection);
+        }
+
+        if (translatorCredits) { // Often a single block of text
+            const translatorsSection = document.createElement('section');
+            translatorsSection.classList.add('adw-about-dialog__translators');
+            const titleEl = document.createElement('h4');
+            titleEl.classList.add('adw-about-dialog-credit-title');
+            titleEl.textContent = 'Translated by';
+            translatorsSection.appendChild(titleEl);
+            const textEl = document.createElement('p');
+            textEl.classList.add('adw-about-dialog-translator-text');
+            textEl.innerHTML = translatorCredits.replace(/\n/g, '<br>');
+            translatorsSection.appendChild(textEl);
+            contentArea.appendChild(translatorsSection);
+        }
+
+        // Release Notes Section (optional)
+        if (releaseNotes) {
+            const releaseNotesSection = document.createElement('section');
+            releaseNotesSection.classList.add('adw-about-dialog__release-notes');
+            const rnTitle = document.createElement('h4');
+            rnTitle.classList.add('adw-about-dialog-section-title');
+            rnTitle.textContent = releaseNotesVersion ? `Release Notes: ${releaseNotesVersion}` : 'Release Notes';
+            releaseNotesSection.appendChild(rnTitle);
+            const rnContent = document.createElement('div'); // Use a div for potentially complex HTML
+            rnContent.classList.add('adw-about-dialog-prose');
+            rnContent.innerHTML = releaseNotes; // Assume HTML or Markdown processed to HTML
+            releaseNotesSection.appendChild(rnContent);
+            contentArea.appendChild(releaseNotesSection);
+        }
+
+        // License Section
+        if (licenseType || licenseText) {
+            const licenseSection = document.createElement('section');
+            licenseSection.classList.add('adw-about-dialog__license');
+            const licenseTitle = document.createElement('h4');
+            licenseTitle.classList.add('adw-about-dialog-section-title');
+            licenseTitle.textContent = 'License';
+            licenseSection.appendChild(licenseTitle);
+
+            if (licenseType) {
+                const typeEl = document.createElement('p');
+                typeEl.classList.add('adw-about-dialog-license-type');
+                typeEl.textContent = this._getLicenseDisplayName(licenseType);
+                licenseSection.appendChild(typeEl);
+            }
+            if (licenseText) {
+                const textEl = document.createElement('pre'); // Use <pre> for preformatted license text
+                textEl.classList.add('adw-about-dialog-license-text');
+                textEl.textContent = licenseText;
+                licenseSection.appendChild(textEl);
+            }
+            contentArea.appendChild(licenseSection);
+        }
+
+        // System Information (optional)
+        if (systemInformation) {
+            const sysInfoSection = document.createElement('section');
+            sysInfoSection.classList.add('adw-about-dialog__system-information');
+            const siTitle = document.createElement('h4');
+            siTitle.classList.add('adw-about-dialog-section-title');
+            siTitle.textContent = 'System Information';
+            sysInfoSection.appendChild(siTitle);
+            const siContent = document.createElement('pre');
+            siContent.classList.add('adw-about-dialog-prose');
+            siContent.textContent = systemInformation;
+            sysInfoSection.appendChild(siContent);
+            contentArea.appendChild(sysInfoSection);
+        }
+
+
+        // Copyright (usually last)
         if (copyright) {
             const copyrightEl = document.createElement('p');
-            copyrightEl.classList.add('adw-label', 'copyright', 'caption'); copyrightEl.textContent = copyright;
-            contentArea.appendChild(copyrightEl);
+            copyrightEl.classList.add('adw-about-dialog-copyright');
+            copyrightEl.textContent = copyright;
+            contentArea.appendChild(copyrightEl); // Should be last in contentArea
         }
+
         this.appendChild(contentArea);
-        console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} _render completed.`);
+        console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} _render completed with new structure.`);
+    }
+
+    _getLicenseDisplayName(licenseTypeAttr) {
+        const types = {
+            'CUSTOM': 'Custom License',
+            'GPL_2_0_ONLY': 'GNU GPL v2.0 only',
+            'GPL_3_0_ONLY': 'GNU GPL v3.0 only',
+            'LGPL_2_1_ONLY': 'GNU LGPL v2.1 only',
+            'LGPL_3_0_ONLY': 'GNU LGPL v3.0 only',
+            'BSD': 'BSD License',
+            'MIT_X11': 'MIT/X11 License',
+            'ARTISTIC': 'Artistic License',
+            'APACHE_2_0': 'Apache License 2.0'
+        };
+        return types[licenseTypeAttr.toUpperCase()] || licenseTypeAttr;
     }
 
     _createBackdrop() {
@@ -178,15 +371,19 @@ class AdwAboutDialogElement extends HTMLElement {
         if (!this._initialized) this._render(); // Ensure rendered if opened programmatically before connect
 
         this.removeAttribute('hidden');
-        this.classList.add('open'); // Add .open class for CSS transitions
-        this.style.display = ''; // Clear direct display style if any was set by hidden logic
+        this.style.display = 'flex'; // Should be handled by CSS for :host([open])
+        this.style.opacity = '0'; // Start transparent for transition
+        this.style.transform = 'scale(0.95)'; // Start small for transition
 
         const backdrop = this._createBackdrop();
-        if (backdrop) { // Backdrop might be null if AdwDialogElement's one isn't ready
-            backdrop.classList.add('open'); // Add .open class for CSS transitions
-            backdrop.style.display = ''; // Clear direct display style
-        }
-        // Style changes for opacity/transform are now handled by CSS via .open class
+        backdrop.style.display = 'block';
+
+        requestAnimationFrame(() => {
+            console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} RAF for open transition.`);
+            backdrop.style.opacity = '1';
+            this.style.opacity = '1';
+            this.style.transform = 'scale(1)';
+        });
 
         document.addEventListener('keydown', this._boundOnKeydown);
 
@@ -204,32 +401,28 @@ class AdwAboutDialogElement extends HTMLElement {
 
     _doClose() {
         console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} _doClose executing.`);
-        this.classList.remove('open'); // Remove .open class for CSS transitions
-        const backdrop = AdwAboutDialogElement._backdropElement; // Use the static ref for this component
+        const backdrop = AdwAboutDialogElement._backdropElement; // Use the static ref
         if (backdrop) {
-            backdrop.classList.remove('open'); // Remove .open class
+            backdrop.style.opacity = '0';
         }
+        this.style.opacity = '0';
+        this.style.transform = 'scale(0.95)';
 
-        // CSS transitions will handle opacity, transform, and visibility.
-        // JS needs to set 'hidden' and 'display:none' after transition.
         setTimeout(() => {
-            console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} timeout for close, setting hidden attribute and display:none if needed.`);
-            if (!this.hasAttribute('open')) { // Ensure it's still meant to be closed
-                this.setAttribute('hidden', '');
-                this.style.display = 'none'; // Fallback
-
-                if (backdrop) {
-                    // Check if other dialogs (adw-dialog or adw-about-dialog) are .open
-                    const anyOtherDialogOpen = document.querySelector('adw-dialog.open, adw-about-dialog.open');
-                    if (!anyOtherDialogOpen) {
-                        console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} No other dialogs .open, setting backdrop display:none.`);
-                        backdrop.style.display = 'none';
-                    } else {
-                        console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} Other dialogs still .open, not changing backdrop display.`);
-                    }
+            console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} timeout for close, setting display:none and hidden attribute.`);
+            this.setAttribute('hidden', '');
+            this.style.display = 'none';
+            if (backdrop) {
+                 // Check if other dialogs (adw-dialog or adw-about-dialog) are open
+                const anyOtherAdwDialogOpen = document.querySelector('adw-dialog[open]:not([hidden]), adw-about-dialog[open]:not([hidden])');
+                if (!anyOtherAdwDialogOpen) { // If this was the last one
+                    console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} No other dialogs open, hiding backdrop.`);
+                    backdrop.style.display = 'none';
+                } else {
+                    console.log(`AdwAboutDialogElement: ${this.id || 'N/A'} Other dialogs may be open, not hiding backdrop globally here.`);
                 }
             }
-        }, 150); // Match CSS transition duration
+        }, 150);
 
         document.removeEventListener('keydown', this._boundOnKeydown);
         this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));

--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -92,17 +92,21 @@
   }
 
   // Dialog Footer / Actions Area
-  // This style applies to .adw-dialog-footer, .adw-dialog-buttons (legacy),
-  // and .adw-dialog__actions-buttons-container (used by JS factory and recommended for slotted buttons)
-  .adw-dialog-footer,
-  .adw-dialog-buttons,
-  .adw-dialog__actions-buttons-container { // Added .adw-dialog__actions-buttons-container
+  .adw-dialog-footer {
     display: flex;
     justify-content: flex-end; // Buttons typically to the right
     align-items: center;
     padding: var(--spacing-m);
     border-top: var(--border-width) solid var(--border-color);
     gap: var(--spacing-s); // Gap between buttons
+
+    // AdwAlertDialog has a specific layout for responses (buttons)
+    // This is a general footer, AlertDialog might have more specific button styling/layout.
+  }
+
+  // Old .adw-dialog-buttons, kept for compatibility, prefer .adw-dialog-footer
+  .adw-dialog-buttons {
+    @extend .adw-dialog-footer; // Inherit footer styles
   }
 
 
@@ -127,66 +131,172 @@
          }
     }
   }
-
+}
   // --- AdwAboutDialog Specific Styles ---
+  // Targets .adw-dialog.adw-about-dialog
   &.adw-about-dialog {
-    .adw-dialog__content {
+    // Overall content wrapper for About Dialog (this is the .adw-dialog__content inside .adw-about-dialog)
+    .adw-about-dialog__content-wrapper {
       display: flex;
       flex-direction: column;
-      align-items: center;
-      text-align: center; // Center text for most elements within
-      padding-top: var(--spacing-xl); // More top padding for About dialog content
-      padding-bottom: var(--spacing-xl); // More bottom padding
+      align-items: center; // Center content like logo, app name, version
+      text-align: center;
+      gap: var(--spacing-m); // Default gap between sections
+      // Padding is on .adw-dialog-content, but we might want more specific for about
+      padding: var(--spacing-l) var(--spacing-xl) var(--spacing-xl) var(--spacing-xl); // Generous padding
+
+      > section { // Direct children sections
+        width: 100%; // Sections take full width of content area
+        margin-bottom: var(--spacing-m); // Space between sections
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    .adw-about-dialog__app-info {
+      margin-bottom: var(--spacing-l); // Larger margin after app info block
     }
 
     .adw-about-dialog-logo {
-      width: 64px; // Standard Adwaita About Dialog logo size
+      width: 64px;
       height: 64px;
-      margin-bottom: var(--spacing-l);
-      border-radius: var(--border-radius-small); // Slight rounding if the logo isn't circular
+      margin-bottom: var(--spacing-m); // Space after logo
+      border-radius: var(--border-radius-medium);
+      object-fit: cover;
     }
 
-    .application-name { // This already has .adw-label and .title-1
-      // .title-1 provides font size and weight. We might want specific margin.
-      margin-bottom: var(--spacing-xxs); // Very small margin below app name
-      color: var(--window-fg-color); // Ensure it uses the main text color
+    .adw-about-dialog-application-name {
+      font-size: var(--title-1-font-size);
+      font-weight: var(--font-weight-bold);
+      margin-bottom: var(--spacing-xxs);
+      color: var(--window-fg-color);
     }
 
-    .version { // This already has .adw-label and .body-2
-      // .body-2 provides font size. Adwaita often uses slightly dimmed for version.
-      opacity: var(--dim-opacity);
+    .adw-about-dialog-version {
+      font-size: var(--font-size-base);
+      color: var(--secondary-fg-color);
       margin-top: 0;
       margin-bottom: var(--spacing-m);
     }
 
-    .comments { // This already has .adw-label
-      font-size: var(--font-size-base); // Ensure base font size
+    .adw-about-dialog-comments {
+      font-size: var(--font-size-base);
       margin-top: 0;
-      margin-bottom: var(--spacing-l);
-      max-width: 90%; // Prevent comments from being too wide
+      margin-bottom: 0;
+      max-width: 100%;
+      line-height: var(--line-height-base);
+      white-space: pre-wrap;
     }
 
-    // Container for the website link
-    p:has(> .adw-link) { // Target the <p> tag containing the website link
-      margin-top: 0;
-      margin-bottom: var(--spacing-l);
-      .adw-link {
-        font-size: var(--font-size-base);
+    .adw-about-dialog__links {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: var(--spacing-s);
+      margin-bottom: var(--spacing-l); // Space after links block
+
+      .adw-button.pill {
+        // Assuming .adw-button.pill is styled elsewhere (e.g. _button.scss)
+        // to have a pill shape (large border-radius)
+        // Example if not defined elsewhere:
+        // border-radius: var(--pill-button-border-radius, 100px);
+        // padding: var(--spacing-xs) var(--spacing-m);
       }
     }
 
-
-    .copyright { // This already has .adw-label and .caption
-      // .caption provides font size and often dimmed color.
-      margin-top: var(--spacing-l); // Space above copyright
-      margin-bottom: 0; // No margin below the last element
-      opacity: var(--dim-opacity);
+    .adw-about-dialog-section-title {
+      font-size: var(--title-4-font-size);
+      font-weight: var(--font-weight-bold);
+      margin-bottom: var(--spacing-s);
+      text-align: left;
+      border-bottom: 1px solid var(--border-color); // Add a separator line
+      padding-bottom: var(--spacing-xs);
+      margin-top: var(--spacing-l); // Space before a new section title
     }
 
-    // No explicit footer/buttons for AboutDialog by default, content flows to bottom.
-    // If a footer were added, it would use .adw-dialog-footer styles.
+    .adw-about-dialog__credits {
+      text-align: left;
+      .adw-about-dialog-credit-group {
+        margin-bottom: var(--spacing-m);
+        &:last-child { margin-bottom: 0; }
+      }
+      .adw-about-dialog-credit-title {
+        font-size: var(--font-size-large);
+        font-weight: var(--font-weight-bold);
+        margin-bottom: var(--spacing-xs);
+      }
+      .adw-about-dialog-credit-list {
+        list-style: none;
+        padding-left: 0;
+        margin: 0;
+        li {
+          font-size: var(--font-size-base);
+          margin-bottom: var(--spacing-xxs);
+          color: var(--secondary-fg-color); // Dim credit names slightly
+        }
+      }
+    }
+
+    .adw-about-dialog__translators {
+      text-align: left;
+      .adw-about-dialog-credit-title { // Reuse credit title style
+         font-size: var(--font-size-large);
+         font-weight: var(--font-weight-bold);
+         margin-bottom: var(--spacing-xs);
+      }
+      .adw-about-dialog-translator-text {
+         font-size: var(--font-size-base);
+         white-space: pre-wrap;
+         color: var(--secondary-fg-color);
+      }
+    }
+
+    .adw-about-dialog__license {
+      text-align: left;
+      .adw-about-dialog-license-type {
+        font-size: var(--font-size-base);
+        font-weight: var(--font-weight-bold);
+        margin-bottom: var(--spacing-xs);
+      }
+      .adw-about-dialog-license-text {
+        font-family: var(--monospace-font-family);
+        font-size: var(--font-size-small);
+        padding: var(--spacing-s);
+        background-color: var(--shade-color);
+        border-radius: var(--border-radius-small);
+        white-space: pre-wrap;
+        overflow-x: auto;
+        max-height: 150px; // Shorter height for license text
+        border: 1px solid var(--border-color);
+        color: var(--secondary-fg-color);
+      }
+    }
+
+    .adw-about-dialog__release-notes,
+    .adw-about-dialog__system-information {
+        text-align: left;
+        .adw-about-dialog-prose {
+            font-size: var(--font-size-base);
+            white-space: pre-wrap;
+            background-color: var(--shade-color);
+            padding: var(--spacing-s);
+            border-radius: var(--border-radius-small);
+            max-height: 150px;
+            overflow-y: auto;
+            border: 1px solid var(--border-color);
+            color: var(--secondary-fg-color);
+        }
+    }
+
+    .adw-about-dialog-copyright {
+      font-size: var(--font-size-small);
+      color: var(--secondary-fg-color);
+      margin-top: var(--spacing-l);
+      text-align: center;
+    }
   }
-}
+} // This closing brace is for .adw-dialog
 
 .adw-dialog-backdrop {
   position: fixed;

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -257,18 +257,60 @@
             if (menuButton && menuPopover) {
                 menuButton.addEventListener('click', (event) => {
                     event.stopPropagation();
-                    const isOpen = menuPopover.classList.contains('open');
-                    console.log('base.html script: menuButton clicked. Was open:', isOpen);
-                    if (isOpen) {
-                        menuPopover.classList.remove('open');
-                        menuPopover.setAttribute('hidden', ''); // Set hidden after animation starts (CSS handles timing)
+                    const isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+                    console.log('base.html script: menuButton clicked. Was expanded:', isExpanded);
+                    if (isExpanded) {
+                        menuPopover.setAttribute('hidden', '');
                         menuButton.setAttribute('aria-expanded', 'false');
-                        console.log('base.html script: Popover closed via class.');
+                        console.log('base.html script: Popover hidden.');
                     } else {
-                        menuPopover.removeAttribute('hidden'); // Remove hidden first to allow CSS to take over
+                        // Position and show popover
+                        menuPopover.classList.remove('open'); // Ensure it's not open for remeasuring if needed
+                        menuPopover.style.visibility = 'hidden'; // Keep hidden for measurement
+                        menuPopover.removeAttribute('hidden'); // Make it part of layout for measurement
+
+                        const buttonRect = menuButton.getBoundingClientRect();
+                        const popoverRect = menuPopover.getBoundingClientRect(); // Get initial dimensions
+
+                        let top = buttonRect.bottom + 2; // Default below button, +2 for small gap
+                        let left = buttonRect.right - popoverRect.width; // Default align right edges
+
+                        // Adjust for right overflow
+                        if (buttonRect.right > window.innerWidth) { // If button itself is partly off-screen
+                            left = window.innerWidth - popoverRect.width - 5; // Position from viewport edge
+                        } else if (left + popoverRect.width > window.innerWidth - 5) { // 5px margin from edge
+                            left = window.innerWidth - popoverRect.width - 5;
+                        }
+
+                        // Adjust for left overflow
+                        if (left < 5) { // 5px margin from edge
+                            left = 5;
+                        }
+
+                        // Adjust for bottom overflow (flip to top)
+                        if (top + popoverRect.height > window.innerHeight - 5) { // 5px margin from bottom
+                            top = buttonRect.top - popoverRect.height - 2; // Position above button
+                            // If it also overflows top, it's a very constrained space.
+                            // A more complex solution would limit height and make it scrollable.
+                            // For now, just ensure it's not less than 0.
+                            if (top < 5) {
+                                top = 5;
+                                // Potentially set max-height and overflow-y: auto here if still too tall
+                                // menuPopover.style.maxHeight = (window.innerHeight - 10) + 'px';
+                                // menuPopover.style.overflowY = 'auto';
+                            }
+                        }
+
+                        menuPopover.style.top = `${top}px`;
+                        menuPopover.style.left = `${left}px`;
+                        menuPopover.style.right = 'auto'; // Ensure right is not conflicting
+                        menuPopover.style.bottom = 'auto'; // Ensure bottom is not conflicting
+
+                        menuPopover.style.visibility = ''; // Make visible again before adding .open for transition
                         menuPopover.classList.add('open');
                         menuButton.setAttribute('aria-expanded', 'true');
-                        console.log('base.html script: Popover opened via class.');
+                        console.log('base.html script: Popover shown and positioned.');
+
                         const firstFocusable = menuPopover.querySelector('[role="menuitem"]');
                         if (firstFocusable) {
                             console.log('base.html script: Focusing first item in popover:', firstFocusable);
@@ -280,19 +322,19 @@
                     if (menuPopover && menuPopover.classList.contains('open') && menuButton && !menuButton.contains(event.target) && !menuPopover.contains(event.target)) {
                         console.log('base.html script: Click outside popover. Closing.');
                         menuPopover.classList.remove('open');
-                        menuPopover.setAttribute('hidden', '');
                         menuButton.setAttribute('aria-expanded', 'false');
+                        // Add hidden after transition (CSS handles this with visibility)
+                        setTimeout(() => { if (!menuPopover.classList.contains('open')) menuPopover.setAttribute('hidden', ''); }, 150);
                     }
                 });
                 menuPopover.addEventListener('keydown', (event) => {
                     if (event.key === 'Escape') {
                         console.log('base.html script: Escape key in popover. Closing.');
                         menuPopover.classList.remove('open');
-                        menuPopover.setAttribute('hidden', '');
-                        if (menuButton) {
-                           menuButton.setAttribute('aria-expanded', 'false');
-                           menuButton.focus();
-                        }
+                        menuButton.setAttribute('aria-expanded', 'false');
+                        if (menuButton) menuButton.focus();
+                         setTimeout(() => { if (!menuPopover.classList.contains('open')) menuPopover.setAttribute('hidden', ''); }, 150);
+                    }
                     }
                 });
             }

--- a/app-demo/templates/edit_post.html
+++ b/app-demo/templates/edit_post.html
@@ -81,7 +81,7 @@
         {{ delete_form.hidden_tag() }}
     </form>
     <adw-dialog id="edit-delete-post-confirm-dialog" title="Confirm Deletion">
-        <div slot="content" class="adw-dialog-content">
+        <div slot="content">
             <p class="adw-label body">Are you sure you want to permanently delete this post titled "<strong>{{ post.title|escape }}</strong>"? This action cannot be undone.</p>
         </div>
         <div slot="buttons" class="adw-dialog__actions-buttons-container">

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -110,10 +110,10 @@
              <h2 class="adw-header-bar__title">Confirm Deletion</h2>
             </header>
         #}
-        <div slot="content" class="adw-dialog-content">
+        <div slot="content">
                 <p class="adw-label body">Are you sure you want to delete this post? This action cannot be undone.</p>
             </div>
-        <div slot="buttons" class="adw-dialog__actions-buttons-container">
+        <div slot="buttons" class="adw-dialog__actions-buttons-container"> {# Added a wrapper for consistent styling if needed #}
                 <button id="cancel-delete-btn" class="adw-button flat">Cancel</button>
                 <form method="POST" action="{{ url_for('post.delete_post', post_id=post.id) }}" id="delete-post-form" class="delete-post-form-inline">
                     {{ delete_post_form.hidden_tag() }} {# Use form instance for CSRF #}
@@ -250,7 +250,7 @@
 
     {# Dialog for confirming comment deletion - now using <adw-dialog> #}
     <adw-dialog id="delete-comment-confirm-dialog" title="Confirm Comment Deletion">
-        <div slot="content" class="adw-dialog-content">
+        <div slot="content">
             <p class="adw-label body">Are you sure you want to delete this comment? This action cannot be undone.</p>
         </div>
         <div slot="buttons" class="adw-dialog__actions-buttons-container">


### PR DESCRIPTION
- AdwAboutDialogElement:
  - Updated observedAttributes and _render() in aboutdialog.js to align with Libadwaita Adw.AboutDialog properties and structure. Includes support for application icon/name, version, comments, copyright, website, issue/support URLs, license type/text, developer/designer/artist/documenter lists, translator credits, release notes, and system information.
  - Added extensive SCSS to _dialog.scss for styling the new detailed structure of the About Dialog, targeting an appearance consistent with Libadwaita.

- Main Menu Popover:
  - Updated JavaScript in base.html to dynamically calculate and adjust the position of the #main-app-popover.
  - The popover should now avoid rendering off-screen by considering viewport boundaries and flipping its position relative to the trigger button if necessary.