### PR TITLE
Fix: Correct AboutDialog implementation, menu positioning, and SCSS s…

### DIFF
--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -131,7 +131,7 @@
          }
     }
   }
-}
+
   // --- AdwAboutDialog Specific Styles ---
   // Targets .adw-dialog.adw-about-dialog
   &.adw-about-dialog {


### PR DESCRIPTION
…yntax

- SCSS: Fixed a syntax error in _dialog.scss by correctly nesting the &.adw-about-dialog styles within the .adw-dialog rule.

- AdwAboutDialogElement:
  - Updated observedAttributes and _render() in aboutdialog.js to align with Libadwaita Adw.AboutDialog properties and structure. Includes support for application icon/name, version, comments, copyright, website, issue/support URLs, license type/text, developer/designer/artist/documenter lists, translator credits, release notes, and system information.
  - Added extensive SCSS to _dialog.scss for styling the new detailed structure of the About Dialog, aiming for an appearance consistent with Libadwaita.

- Main Menu Popover:
  - Updated JavaScript in base.html to dynamically calculate and adjust the position of the #main-app-popover.
  - The popover should now avoid rendering off-screen by considering viewport boundaries and flipping its position relative to the trigger button if necessary.