### PR TITLE
Fix: Comprehensive dialog, AboutDialog, menu, and styling corrections…

### DIFF
--- a/adwaita-web/js/components/dialog.js
+++ b/adwaita-web/js/components/dialog.js
@@ -105,12 +105,20 @@ class AdwDialogElement extends HTMLElement {
 
   _updateTitle(newTitle) {
     console.log(`AdwDialogElement: ${this.id || 'N/A'} _updateTitle with: ${newTitle}`);
-    let titleEl = this.querySelector('.adw-dialog__header .adw-header-bar__title');
-    if (titleEl) {
-      titleEl.textContent = newTitle || '';
-      console.log(`AdwDialogElement: ${this.id || 'N/A'} title updated to: ${titleEl.textContent}`);
+    // Only try to update DOM if connected.
+    // The actual title value is stored by setAttribute, and connectedCallback will call _updateTitle again.
+    if (this.isConnected) {
+      let titleEl = this.querySelector('.adw-dialog__header .adw-header-bar__title');
+      if (titleEl) {
+        titleEl.textContent = newTitle || '';
+        console.log(`AdwDialogElement: ${this.id || 'N/A'} title updated to: ${titleEl.textContent}`);
+      } else {
+        // This log can still occur if a user provides a custom header without .adw-header-bar__title,
+        // or if connectedCallback hasn't fully completed its setup of the default header yet.
+        console.log(`AdwDialogElement: ${this.id || 'N/A'} title element (.adw-dialog__header .adw-header-bar__title) not found during _updateTitle. If this is pre-connection or using a custom header, this might be expected. Title will be applied by connectedCallback if default header is used.`);
+      }
     } else {
-      console.warn(`AdwDialogElement: ${this.id || 'N/A'} title element not found in header.`);
+        console.log(`AdwDialogElement: ${this.id || 'N/A'} _updateTitle called but element not connected. Title attribute is set ('${newTitle}'). DOM update will be handled by connectedCallback.`);
     }
   }
 


### PR DESCRIPTION
… (v2.1)

- AdwDialogElement (JS): Adjusted _updateTitle logging to be more informative and less alarming for transient states.

- Jinja2 Syntax (base.html): Corrected inline conditional syntax for theme/accent variables to resolve TemplateSyntaxError.

- AdwDialogElement & AdwAboutDialogElement (JS):
  - Modified components to correctly use the `.open` class for visibility, aligning JS behavior with CSS transitions.

- SCSS (_dialog.scss):
  - Fixed a SASS syntax error by correctly nesting `&.adw-about-dialog`.
  - Added comprehensive SCSS for the revamped `AdwAboutDialogElement` structure, targeting Libadwaita design consistency.

- App-Demo Dialogs (HTML):
  - Ensured general dialogs in `post.html` and `edit_post.html` use `<adw-dialog>` correctly with `class="adw-dialog-content"`.

- AdwAboutDialogElement Revamp (JS):
  - Updated `observedAttributes` and overhauled `_render()` in `aboutdialog.js` to support a wide range of Libadwaita properties (icon, name, version, credits, license, links, etc.) and generate a detailed HTML structure.

- Menu Popover (base.html JS):
  - Implemented dynamic calculation and adjustment of the main menu popover's position to prevent viewport overflow.