### PR TITLE
Diag: Comment out dialog init in app-layout.js for flashing test

### DIFF
--- a/adwaita-web/js/app-layout.js
+++ b/adwaita-web/js/app-layout.js
@@ -62,7 +62,10 @@ document.addEventListener('DOMContentLoaded', function () {
     console.log('app-layout.js: Waiting for adw-dialog custom element to be defined...');
     customElements.whenDefined('adw-dialog').then(() => {
         appLayoutWhenDefinedResolvedCount++;
-        console.log(`app-layout.js: adw-dialog is defined. Initializing dialog handlers (call #${appLayoutWhenDefinedResolvedCount}).`);
+        console.log(`app-layout.js: adw-dialog is defined. Call #${appLayoutWhenDefinedResolvedCount}. Dialog init TEMPORARILY COMMENTED OUT for diagnosing flashing.`);
+
+        /*
+        // --- Temporarily Commented Out for Flashing Diagnosis ---
 
         // Post Deletion Dialog (from post.html)
         const deletePostDialogEl = document.getElementById('delete-confirm-dialog');
@@ -148,8 +151,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             });
         }
-        console.log('app-layout.js: All dialog handlers initialized.');
+        console.log('app-layout.js: All dialog handlers initialized (commented out section).');
+
+        // --- End of Temporarily Commented Out Block ---
+        */
+
     }).catch(error => {
-        console.error("app-layout.js: Failed to initialize dialogs; adw-dialog definition not found or other error.", error);
+        console.error("app-layout.js: Failed to initialize dialogs (potentially); adw-dialog definition not found or other error.", error);
     });
 });


### PR DESCRIPTION
- app-layout.js: Temporarily commented out dialog initialization logic to help diagnose page flashing/reloading issue.

This commit also includes prior diagnostic states and fixes:
- base.html: Popover JavaScript logic remains commented out.
- Jinja2 Syntax (base.html): Corrected inline conditional syntax.
- AdwDialogElement & AdwAboutDialogElement (JS):
  - Using direct style manipulation for open/close ('.open' class logic is not active).
  - Adjusted AdwDialogElement._updateTitle logging.
- SCSS (_dialog.scss):
  - Fixed SASS syntax error (nesting).
  - Added SCSS for revamped AdwAboutDialogElement structure.
- App-Demo Dialogs (HTML):
  - Added `class="adw-dialog-content"` to dialog content slots.
- AdwAboutDialogElement Revamp (JS):
  - Includes updated attributes and _render() method in aboutdialog.js.