### PR TITLE
Diag: Comment out components.js import for flashing test

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -244,7 +244,7 @@
     <script src="{{ url_for('static', filename='js/app-layout.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/banner.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/toast.js') }}" defer></script>
-    <script type="module" src="{{ url_for('static', filename='js/components.js') }}" defer></script> {# Load Web Components #}
+    {# <script type="module" src="{{ url_for('static', filename='js/components.js') }}" defer></script> <!-- TEMPORARILY COMMENTED OUT FOR FLASHING DIAGNOSIS --> #}
     <script nonce="{{ csp_nonce() if csp_nonce else '' }}">
         document.addEventListener('DOMContentLoaded', () => {
             console.log('base.html script: DOMContentLoaded');


### PR DESCRIPTION
- base.html: Temporarily commented out the import of `components.js` (which loads web components like dialog.js, aboutdialog.js) to diagnose a page flashing/reloading issue.

This commit also includes prior diagnostic states and fixes:
- app-layout.js: Dialog initialization logic remains commented out.
- base.html: Popover JavaScript logic remains commented out.
- Jinja2 Syntax (base.html): Corrected inline conditional syntax.
- AdwDialogElement & AdwAboutDialogElement (JS):
  - Using direct style manipulation for open/close.
  - Adjusted AdwDialogElement._updateTitle logging.
- SCSS (_dialog.scss):
  - Fixed SASS syntax error (nesting).
  - Added SCSS for revamped AdwAboutDialogElement structure.
- App-Demo Dialogs (HTML):
  - Added `class="adw-dialog-content"` to dialog content slots.
- AdwAboutDialogElement Revamp (JS):
  - Includes updated attributes and _render() method in aboutdialog.js.