### PR TITLE
Fix dialog manager loading and Adwaita Sans font error

### DIFF
--- a/adwaita-web/scss/_fonts.scss
+++ b/adwaita-web/scss/_fonts.scss
@@ -2,14 +2,14 @@
 
 // AdwaitaSans (Cantarell equivalent for web)
 @font-face {
-  font-family: 'AdwaitaSansWeb'; // Using a distinct name for the web font
+  font-family: 'Adwaita Sans'; // Using a distinct name for the web font
   src: url('../fonts/sans/AdwaitaSans-Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'AdwaitaSansWeb';
+  font-family: 'Adwaita Sans';
   src: url('../fonts/sans/AdwaitaSans-Italic.ttf') format('truetype');
   font-weight: normal;
   font-style: italic;
@@ -17,13 +17,13 @@
 
 // Add Bold and BoldItalic if they exist and are needed, for example:
 // @font-face {
-//   font-family: 'AdwaitaSansWeb';
+//   font-family: 'Adwaita Sans';
 //   src: url('../fonts/sans/AdwaitaSans-Bold.ttf') format('truetype');
 //   font-weight: bold;
 //   font-style: normal;
 // }
 // @font-face {
-//   font-family: 'AdwaitaSansWeb';
+//   font-family: 'Adwaita Sans';
 //   src: url('../fonts/sans/AdwaitaSans-BoldItalic.ttf') format('truetype');
 //   font-weight: bold;
 //   font-style: italic;
@@ -32,28 +32,28 @@
 
 // AdwaitaMono
 @font-face {
-  font-family: 'AdwaitaMonoWeb'; // Distinct name
+  font-family: 'Adwaita Mono'; // Distinct name
   src: url('../fonts/mono/AdwaitaMono-Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'AdwaitaMonoWeb';
+  font-family: 'Adwaita Mono';
   src: url('../fonts/mono/AdwaitaMono-Italic.ttf') format('truetype');
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
-  font-family: 'AdwaitaMonoWeb';
+  font-family: 'Adwaita Mono';
   src: url('../fonts/mono/AdwaitaMono-Bold.ttf') format('truetype');
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'AdwaitaMonoWeb';
+  font-family: 'Adwaita Mono';
   src: url('../fonts/mono/AdwaitaMono-BoldItalic.ttf') format('truetype');
   font-weight: bold;
   font-style: italic;

--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -198,9 +198,9 @@ $accent-definitions: (
   --list-separator-color: #{rgba($adw-dark-5, 0.1)};
 
   // Fonts (Libadwaita names)
-  --document-font-family: 'AdwaitaSansWeb', 'Cantarell', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --document-font-family: 'Adwaita Sans', 'Cantarell', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --document-font-size: #{$font-size-base-val};
-  --monospace-font-family: 'AdwaitaMonoWeb', 'Monaco', 'Menlo', 'Courier New', monospace;
+  --monospace-font-family: 'Adwaita Mono', 'Monaco', 'Menlo', 'Courier New', monospace;
   --monospace-font-size: #{$font-size-base-val};
 
   // Helper Variables

--- a/build-adwaita-web.sh
+++ b/build-adwaita-web.sh
@@ -142,6 +142,21 @@ else
     echo "WARNING: JS components directory ${JS_COMPONENTS_SOURCE_DIR} not found."
 fi
 
+JS_UTILS_SOURCE_DIR="${JS_INPUT_DIR}/utils"
+JS_UTILS_DEST_DIR_BUILD="${BUILD_JS_DIR}/utils"
+JS_UTILS_DEST_DIR_APP_DEMO="${APP_DEMO_JS_DIR}/utils"
+if [ -d "${JS_UTILS_SOURCE_DIR}" ]; then
+    mkdir -p "${JS_UTILS_DEST_DIR_BUILD}"
+    cp -r "${JS_UTILS_SOURCE_DIR}/." "${JS_UTILS_DEST_DIR_BUILD}/"
+    echo "Copied JS utils from ${JS_UTILS_SOURCE_DIR} to ${JS_UTILS_DEST_DIR_BUILD}"
+
+    mkdir -p "${JS_UTILS_DEST_DIR_APP_DEMO}"
+    cp -r "${JS_UTILS_SOURCE_DIR}/." "${JS_UTILS_DEST_DIR_APP_DEMO}/"
+    echo "Copied JS utils from ${JS_UTILS_SOURCE_DIR} to ${JS_UTILS_DEST_DIR_APP_DEMO}"
+else
+    echo "WARNING: JS utils directory ${JS_UTILS_SOURCE_DIR} not found."
+fi
+
 # Copy data files (e.g., icons) to BUILD directory
 # This section remains as is, assuming data and fonts don't have the same issue.
 echo "--- Copying Data Files to ${BUILD_DATA_DIR} ---"


### PR DESCRIPTION
- Modified build-adwaita-web.sh to correctly copy the js/utils directory, which contains dialog-manager.js, to the app-demo/static/js/utils directory. This resolves the MIME type error caused by the file not being found.
- Updated font-family names in adwaita-web/scss/_fonts.scss and adwaita-web/scss/_variables.scss from 'AdwaitaSansWeb' to 'Adwaita Sans' and 'AdwaitaMonoWeb' to 'Adwaita Mono'. This aligns the CSS font definition with the name apparently expected by the browser, resolving the font loading visibility error.