### PR TITLE
Fix dialog constructor error and AboutDialog close icon

### DIFF
--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -35,6 +35,28 @@
         /* Example if more specific styling needed and global doesn't fully apply in shadow */
         /* padding: var(--spacing-xxs); */
       }
+
+      /* Ensure .adw-icon and specific icon classes apply within Shadow DOM */
+      .adw-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: var(--icon-size-base, 16px);
+        height: var(--icon-size-base, 16px);
+        background-color: currentColor;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        vertical-align: middle;
+      }
+      .icon-window-close-symbolic {
+        -webkit-mask-image: url(../data/icons/symbolic/window-close-symbolic.svg);
+        mask-image: url(../data/icons/symbolic/window-close-symbolic.svg);
+      }
+
       .adw-dialog__content {
          padding: 0; /* Remove padding if content-wrapper handles it */
          line-height: 1.6;

--- a/adwaita-web/js/components/dialog.js
+++ b/adwaita-web/js/components/dialog.js
@@ -7,7 +7,7 @@ if (!window.Adw) {
 class AdwDialogElement extends HTMLElement {
   constructor() {
     super();
-    this._boundOnBackdropClick = this._onBackdropClick.bind(this);
+    // this._boundOnBackdropClick = this._onBackdropClick.bind(this); // Removed, DialogManager handles backdrop clicks
     this._boundOnKeydown = this._onKeydown.bind(this); // For Escape key
     this._boundHandleFocusTrap = this._handleFocusTrap.bind(this); // For focus trapping
     this.classList.add('adw-dialog'); // The host itself is the .adw-dialog


### PR DESCRIPTION
- Removed binding of undefined `_onBackdropClick` in `AdwDialogElement` constructor.
- Added inline styles for `.adw-icon` and `.icon-window-close-symbolic` to `AdwAboutDialogElement`'s Shadow DOM to ensure the close icon is displayed correctly.