### PR TITLE
Fix AboutDialog close icon path

### DIFF
--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -53,8 +53,8 @@
         vertical-align: middle;
       }
       .icon-window-close-symbolic {
-        -webkit-mask-image: url(../data/icons/symbolic/window-close-symbolic.svg);
-        mask-image: url(../data/icons/symbolic/window-close-symbolic.svg);
+        -webkit-mask-image: url(/static/data/icons/symbolic/window-close-symbolic.svg);
+        mask-image: url(/static/data/icons/symbolic/window-close-symbolic.svg);
       }
 
       .adw-dialog__content {


### PR DESCRIPTION
- Changed the mask-image URL for .icon-window-close-symbolic in AdwAboutDialogElement's inline styles to use an absolute path (/static/data/icons/symbolic/window-close-symbolic.svg).
- This ensures the icon is correctly loaded regardless of the page URL, resolving the 404 error.