### PR TITLE
Refactor AboutDialog icon to use CSS Custom Property

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,10 @@ This repository contains two main projects:
     *   Styling compositions of `adwaita-web` widgets that are unique to `app-demo`.
     *   Minor, one-off presentational tweaks for `app-demo` that do not represent a change to the core widget's default behavior.
     *   It should **not** be used for globally overriding the base styles of core `adwaita-web` widgets.
+*   **CSS and JavaScript Interaction**:
+    *   Avoid direct manipulation of CSS styles (e.g., `element.style.property = 'value'`) from JavaScript for UI/UX, animations, or core styling.
+    *   All fundamental UI/UX appearances, animations, and styles should be defined in the Adwaita-Web UI SCSS files (`adwaita-web/scss/`).
+    *   JavaScript should primarily interact with styles by toggling classes, setting attributes (which CSS can select on), or using CSS Custom Properties.
+    *   For web components with Shadow DOM, if internal styles need access to asset paths (like icons), prefer using CSS Custom Properties defined in global SCSS to pass these paths rather than hardcoding them in JS or inline styles within the component.
 
 Please consult the respective `AGENTS.md` files in each subdirectory for more detailed, context-specific instructions.

--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -53,8 +53,10 @@
         vertical-align: middle;
       }
       .icon-window-close-symbolic {
-        -webkit-mask-image: url(/static/data/icons/symbolic/window-close-symbolic.svg);
-        mask-image: url(/static/data/icons/symbolic/window-close-symbolic.svg);
+        /* Rely on global CSS to define this or use a CSS custom property if path needs to be dynamic */
+        /* Forcing it here if component needs to be self-contained with its icon path */
+        -webkit-mask-image: var(--icon-window-close-symbolic-url);
+        mask-image: var(--icon-window-close-symbolic-url);
       }
 
       .adw-dialog__content {

--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -395,6 +395,12 @@ $accent-definitions: (
   // Pill button radius (for toggle groups, etc.)
   --pill-button-border-radius: 100px;
 
+  // Icon URLs (as CSS Custom Properties)
+  // Base path for icons, relative to the final CSS file (app-demo/static/css/)
+  $_icon-base-path-for-vars: '../data/icons/symbolic/';
+  --icon-window-close-symbolic-url: url(#{$_icon-base-path-for-vars}window-close-symbolic.svg);
+  // Add other frequently used icon URLs here if components need them directly via CSS vars
+
 
   // --- Dark Theme Overrides ---
   &.theme-dark {


### PR DESCRIPTION
- Defined a new CSS custom property `--icon-window-close-symbolic-url` in `_variables.scss` for the close icon's path.
- Updated `AdwAboutDialogElement`'s internal styles to use this CSS variable for the `mask-image` property.
- This moves the icon path definition from JavaScript component's inline style back to SCSS, making it more maintainable and aligned with the project's styling guidelines.
- Updated AGENTS.md to include guidelines against direct CSS manipulation from JS.