### PR TITLE
Update main app menu icon and placement in header

### DIFF
--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -68,7 +68,7 @@
     <div class="adw-header-bar__end">
         {% block header_actions_start %}{% endblock %} {# For buttons like "Edit Profile", keep this for contextual actions #}
 
-        {# Search, Settings, Login/Logout remain at the end #}
+        {# Search #}
         <form action="{{ url_for('general.search_results') }}" method="GET" class="header-search-form">
             <input type="search" name="q" placeholder="Search..." value="{{ request.args.get('q', '') }}" class="adw-entry">
             <button type="submit" class="adw-button flat circular" aria-label="Search">
@@ -76,17 +76,10 @@
             </button>
         </form>
 
-        {% if current_user.is_authenticated %}
-            <a href="{{ url_for('general.settings_page') }}" class="adw-button flat" title="Settings">Settings</a>
-            <a href="{{ url_for('auth.logout') }}" class="adw-button flat">Logout</a>
-        {% else %}
-            <a href="{{ url_for('auth.login') }}" class="adw-button">Login</a>
-        {% endif %}
-
-        {# Main App Menu Button - Placed at the very end of header actions #}
+        {# Main App Menu Button (About) - Moved here #}
         <div class="main-app-menu-container" style="position: relative;">
             <button id="main-app-menu-button" class="adw-button circular flat" aria-label="Main menu" aria-haspopup="true" aria-expanded="false">
-                <span class="adw-icon icon-view-more-symbolic"></span>
+                <span class="adw-icon icon-actions-open-menu-symbolic"></span> {# Icon changed #}
             </button>
             <div class="adw-popover menu-popover" id="main-app-popover" role="menu" hidden>
                 <div class="adw-list-box flat popover-list-box">
@@ -97,6 +90,14 @@
                 </div>
             </div>
         </div>
+
+        {# Settings, Login/Logout #}
+        {% if current_user.is_authenticated %}
+            <a href="{{ url_for('general.settings_page') }}" class="adw-button flat" title="Settings">Settings</a>
+            <a href="{{ url_for('auth.logout') }}" class="adw-button flat">Logout</a>
+        {% else %}
+            <a href="{{ url_for('auth.login') }}" class="adw-button">Login</a>
+        {% endif %}
     </div>
 </header>
 


### PR DESCRIPTION
- Changed the icon for the main app menu button in `base.html` (which triggers the 'About' popover) from `icon-view-more-symbolic` to `icon-actions-open-menu-symbolic`.
- Moved this menu button to be positioned between the search form and the 'Settings' link in the header bar for better UI flow.