### PR TITLE
Fix AboutDialog close icon path and update header menu UI

### DIFF
--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -396,9 +396,8 @@ $accent-definitions: (
   --pill-button-border-radius: 100px;
 
   // Icon URLs (as CSS Custom Properties)
-  // Base path for icons, relative to the final CSS file (app-demo/static/css/)
-  $_icon-base-path-for-vars: '../data/icons/symbolic/';
-  --icon-window-close-symbolic-url: url(#{$_icon-base-path-for-vars}window-close-symbolic.svg);
+  // Path must be root-relative for use in JS component Shadow DOM styles if var is passed through.
+  --icon-window-close-symbolic-url: url('/static/data/icons/symbolic/window-close-symbolic.svg');
   // Add other frequently used icon URLs here if components need them directly via CSS vars
 
 


### PR DESCRIPTION
- Corrected the path in the CSS custom property `--icon-window-close-symbolic-url` in `_variables.scss` to use a root-relative path (`/static/data/...`) This ensures the AdwaitaAboutDialog's 'X' close icon, which uses this variable, loads correctly from within its Shadow DOM.
- Changed the icon for the main app menu button in `base.html` (triggering the 'About' popover) from `icon-view-more-symbolic` to `icon-actions-open-menu-symbolic`.
- Moved this main app menu button in `base.html` to be positioned between the search form and the 'Settings' link in the header bar.