### PR TITLE
Fix CSRF token for Flag Comment form and audit CSRF practices

### DIFF
--- a/app-demo/routes/post_routes.py
+++ b/app-demo/routes/post_routes.py
@@ -23,11 +23,12 @@ def view_post(post_id):
     else:
         current_app.logger.debug(f"Viewing published post ID: {post_id}.")
 
-    form = CommentForm(request.form)
-    delete_comment_form = DeleteCommentForm() # For each comment, if needed in template loop
-    delete_post_form = DeletePostForm() # For the post itself
+    form = CommentForm(request.form) # This is for new comments
+    delete_comment_form = DeleteCommentForm() # For deleting comments
+    delete_post_form = DeletePostForm() # For deleting the post
+    flag_comment_form = FlagCommentForm() # For flagging comments
 
-    if request.method == 'POST' and form.validate_on_submit(): # Check for comment submission
+    if request.method == 'POST' and form.validate_on_submit(): # Check for new comment submission
         current_app.logger.debug(f"Comment form submitted for post {post_id}. Data: {request.form}")
         if not current_user.is_authenticated:
             current_app.logger.warning(f"Anonymous user tried to comment on post {post_id}.")
@@ -138,6 +139,7 @@ def view_post(post_id):
     return render_template('post.html', post=post, form=form, comments=comments,
                            delete_comment_form=delete_comment_form,
                            delete_post_form=delete_post_form,
+                           flag_comment_form=flag_comment_form, # Pass the flag_comment_form
                            related_posts=related_posts)
 
 @post_bp.route('/create', methods=['GET', 'POST'])

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -153,7 +153,7 @@
                     <button class="adw-button flat compact" disabled title="This comment has been flagged">Flagged</button>
                 {% else %}
                     <form method="POST" action="{{ url_for('post.flag_comment', comment_id=comment.id) }}" style="display: inline;">
-                        {{ form.hidden_tag() }}
+                        {{ flag_comment_form.hidden_tag() }} {# Use the correct form instance #}
                         <button type="submit" class="adw-button flat compact" title="Flag this comment for review">Flag</button>
                     </form>
                 {% endif %}


### PR DESCRIPTION
- Corrected the Flag Comment form in post.html to use the CSRF token from `FlagCommentForm` instead of `CommentForm`.
- Modified `post_routes.py` to pass `FlagCommentForm` to the template.
- Audited general CSRF configuration, form usage, POST routes, and AJAX requests. Other areas appear to use CSRF protection correctly, relying on Flask-WTF's global protection or explicit form validation.