### PR TITLE
Fix display issues in profile header and post meta

### DIFF
--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -11,7 +11,7 @@
             {# Title h1 removed #}
             <div class="post-meta-detail">
                 <p class="adw-label body">
-                    By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.full_name or post.author.username if post.author else 'Unknown Author' }}</a>
+                    By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.full_name or post.author.username if post.author else 'Unknown Author' }}</a>&nbsp;
                     {%- if post.published_at -%}
                         on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at | human_readable_date }}</time>
                     {%- else -%} {# Should not happen for new posts, fallback for old data or if published_at was somehow not set #}

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -38,7 +38,7 @@
             <div class="adw-box adw-box-vertical adw-box-spacing-xs">
                 <h1 class="adw-label title-1">{{ user_profile.full_name or user_profile.username }}</h1>
                 {% if user_profile.full_name %}
-                <span class="adw-label adw-caption">@{{ user_profile.username }}</span>
+                <div><span class="adw-label adw-caption">@{{ user_profile.username }}</span></div>
                 {% endif %}
                 <div class="adw-box adw-box-horizontal adw-box-spacing-s profile-follow-stats">
                     <a href="{{ url_for('profile.followers_list', username=user_profile.username) }}" class="adw-link">


### PR DESCRIPTION
- Ensure clearer visual separation for username/email on profile page header by wrapping the @username span in a div.
- Add non-breaking space in post.html meta display to ensure spacing between author name and date information.