### PR TITLE
Fix multiple UI issues and update Adwaita color variables

### DIFF
--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -269,20 +269,24 @@ $accent-definitions: (
   $_card_fg_color_dark-sass: $_window_fg_color_dark_sass;
   $_sidebar_fg_color_light-sass: $_window_fg_color_light_sass;
   $_sidebar_fg_color_dark-sass: $_window_fg_color_dark_sass;
+  // Ensure $_toast_fg_color_sass is defined before use if not already
+  $_toast_fg_color_sass: $adw-light-1; // Assuming this is the intended base for toast text
 
 
-  --accent-fg-color-rgb: #{color.red($_accent-fg-color-sass)}, #{color.green($_accent-fg-color-sass)}, #{color.blue($_accent-fg-color-sass)};
-  --error-fg-color-rgb: #{color.red($_error_fg_color_sass)}, #{color.green($_error_fg_color_sass)}, #{color.blue($_error_fg_color_sass)};
-  --warning-fg-color-rgb: #{color.red($_warning_fg_color_sass)}, #{color.green($_warning_fg_color_sass)}, #{color.blue($_warning_fg_color_sass)};
-  --success-fg-color-rgb: #{color.red($_success_fg_color_sass)}, #{color.green($_success_fg_color_sass)}, #{color.blue($_success_fg_color_sass)};
-  --destructive-color-rgb: #{color.red($_destructive_color_light-sass)}, #{color.green($_destructive_color_light-sass)}, #{color.blue($_destructive_color_light-sass)};
-  --window-fg-color-rgb: #{color.red($_window_fg_color_light-sass)}, #{color.green($_window_fg_color_light-sass)}, #{color.blue($_window_fg_color_light-sass)};
-  --headerbar-fg-color-rgb: #{color.red($_headerbar_fg_color_light-sass)}, #{color.green($_headerbar_fg_color_light-sass)}, #{color.blue($_headerbar_fg_color_light-sass)};
-  --headerbar-fg-color-alpha: #{color.alpha($_headerbar_fg_color_light-sass)}; // Will be 0.8 for light
-  --card-fg-color-rgb: #{color.red($_card_fg_color_light-sass)}, #{color.green($_card_fg_color_light-sass)}, #{color.blue($_card_fg_color_light-sass)};
-  --card-fg-color-alpha: #{color.alpha($_card_fg_color_light-sass)}; // Will be 0.8 for light
-  --sidebar-fg-color-rgb: #{color.red($_sidebar_fg_color_light-sass)}, #{color.green($_sidebar_fg_color_light-sass)}, #{color.blue($_sidebar_fg_color_light-sass)};
-  --sidebar-fg-color-alpha: #{color.alpha($_sidebar_fg_color_light-sass)}; // Will be 0.8 for light
+  --accent-fg-color-rgb: #{color.channel($_accent-fg-color-sass, "red")}, #{color.channel($_accent-fg-color-sass, "green")}, #{color.channel($_accent-fg-color-sass, "blue")};
+  --error-fg-color-rgb: #{color.channel($_error_fg_color_sass, "red")}, #{color.channel($_error_fg_color_sass, "green")}, #{color.channel($_error_fg_color_sass, "blue")};
+  --warning-fg-color-rgb: #{color.channel($_warning_fg_color_sass, "red")}, #{color.channel($_warning_fg_color_sass, "green")}, #{color.channel($_warning_fg_color_sass, "blue")};
+  --success-fg-color-rgb: #{color.channel($_success_fg_color_sass, "red")}, #{color.channel($_success_fg_color_sass, "green")}, #{color.channel($_success_fg_color_sass, "blue")};
+  --destructive-color-rgb: #{color.channel($_destructive_color_light-sass, "red")}, #{color.channel($_destructive_color_light-sass, "green")}, #{color.channel($_destructive_color_light-sass, "blue")};
+  --window-fg-color-rgb: #{color.channel($_window_fg_color_light-sass, "red")}, #{color.channel($_window_fg_color_light-sass, "green")}, #{color.channel($_window_fg_color_light-sass, "blue")};
+  --headerbar-fg-color-rgb: #{color.channel($_headerbar_fg_color_light-sass, "red")}, #{color.channel($_headerbar_fg_color_light-sass, "green")}, #{color.channel($_headerbar_fg_color_light-sass, "blue")};
+  --headerbar-fg-color-alpha: #{color.alpha($_headerbar_fg_color_light-sass)};
+  --card-fg-color-rgb: #{color.channel($_card_fg_color_light-sass, "red")}, #{color.channel($_card_fg_color_light-sass, "green")}, #{color.channel($_card_fg_color_light-sass, "blue")};
+  --card-fg-color-alpha: #{color.alpha($_card_fg_color_light-sass)};
+  --sidebar-fg-color-rgb: #{color.channel($_sidebar_fg_color_light-sass, "red")}, #{color.channel($_sidebar_fg_color_light-sass, "green")}, #{color.channel($_sidebar_fg_color_light-sass, "blue")};
+  --sidebar-fg-color-alpha: #{color.alpha($_sidebar_fg_color_light-sass)};
+  --toast-fg-color-rgb: #{color.channel($color: $_toast_fg_color_sass, $channel: "red")}, #{color.channel($color: $_toast_fg_color_sass, $channel: "green")}, #{color.channel($color: $_toast_fg_color_sass, $channel: "blue")};
+
 
   // Button State Variables - fine
   --button-bg-color: var(--window-bg-color);
@@ -512,17 +516,17 @@ $accent-definitions: (
 
     // RGB versions for dark theme
     // These use the SASS variables which have been updated or confirmed.
-    --accent-fg-color-rgb: #{color.red($_accent-fg-color-sass)}, #{color.green($_accent-fg-color-sass)}, #{color.blue($_accent-fg-color-sass)};
-    --error-fg-color-rgb: #{color.red($_error_fg_color_sass)}, #{color.green($_error_fg_color_sass)}, #{color.blue($_error_fg_color_sass)};
-    --warning-fg-color-rgb: #{color.red($_warning_fg_color_sass)}, #{color.green($_warning_fg_color_sass)}, #{color.blue($_warning_fg_color_sass)};
-    --success-fg-color-rgb: #{color.red($_success_fg_color_sass)}, #{color.green($_success_fg_color_sass)}, #{color.blue($_success_fg_color_sass)};
-    --destructive-color-rgb: #{color.red($_destructive_color_dark-sass)}, #{color.green($_destructive_color_dark-sass)}, #{color.blue($_destructive_color_dark-sass)};
-    --window-fg-color-rgb: #{color.red($_window_fg_color_dark-sass)}, #{color.green($_window_fg_color_dark-sass)}, #{color.blue($_window_fg_color_dark-sass)};
-    --headerbar-fg-color-rgb: #{color.red($_headerbar_fg_color_dark-sass)}, #{color.green($_headerbar_fg_color_dark-sass)}, #{color.blue($_headerbar_fg_color_dark-sass)};
+    --accent-fg-color-rgb: #{color.channel($_accent-fg-color-sass, "red")}, #{color.channel($_accent-fg-color-sass, "green")}, #{color.channel($_accent-fg-color-sass, "blue")};
+    --error-fg-color-rgb: #{color.channel($_error_fg_color_sass, "red")}, #{color.channel($_error_fg_color_sass, "green")}, #{color.channel($_error_fg_color_sass, "blue")};
+    --warning-fg-color-rgb: #{color.channel($_warning_fg_color_sass, "red")}, #{color.channel($_warning_fg_color_sass, "green")}, #{color.channel($_warning_fg_color_sass, "blue")};
+    --success-fg-color-rgb: #{color.channel($_success_fg_color_sass, "red")}, #{color.channel($_success_fg_color_sass, "green")}, #{color.channel($_success_fg_color_sass, "blue")};
+    --destructive-color-rgb: #{color.channel($_destructive_color_dark-sass, "red")}, #{color.channel($_destructive_color_dark-sass, "green")}, #{color.channel($_destructive_color_dark-sass, "blue")};
+    --window-fg-color-rgb: #{color.channel($_window_fg_color_dark-sass, "red")}, #{color.channel($_window_fg_color_dark-sass, "green")}, #{color.channel($_window_fg_color_dark-sass, "blue")};
+    --headerbar-fg-color-rgb: #{color.channel($_headerbar_fg_color_dark-sass, "red")}, #{color.channel($_headerbar_fg_color_dark-sass, "green")}, #{color.channel($_headerbar_fg_color_dark-sass, "blue")};
     --headerbar-fg-color-alpha: #{color.alpha($_headerbar_fg_color_dark-sass)}; // Will be 1 for dark
-    --card-fg-color-rgb: #{color.red($_card_fg_color_dark-sass)}, #{color.green($_card_fg_color_dark-sass)}, #{color.blue($_card_fg_color_dark-sass)};
+    --card-fg-color-rgb: #{color.channel($_card_fg_color_dark-sass, "red")}, #{color.channel($_card_fg_color_dark-sass, "green")}, #{color.channel($_card_fg_color_dark-sass, "blue")};
     --card-fg-color-alpha: #{color.alpha($_card_fg_color_dark-sass)}; // Will be 1 for dark
-    --sidebar-fg-color-rgb: #{color.red($_sidebar_fg_color_dark-sass)}, #{color.green($_sidebar_fg_color_dark-sass)}, #{color.blue($_sidebar_fg_color_dark-sass)};
+    --sidebar-fg-color-rgb: #{color.channel($_sidebar_fg_color_dark-sass, "red")}, #{color.channel($_sidebar_fg_color_dark-sass, "green")}, #{color.channel($_sidebar_fg_color_dark-sass, "blue")};
     --sidebar-fg-color-alpha: #{color.alpha($_sidebar_fg_color_dark-sass)}; // Will be 1 for dark
 
     // Row specific for dark theme - fine

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -167,10 +167,7 @@
                     <span class="adw-action-row-icon icon-status-flag-symbolic"></span>
                     <span class="adw-action-row-title">Review Flags</span>
                 </a>
-                <a href="{{ url_for('admin.site_settings') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'admin.site_settings' }}">
-                    <span class="adw-action-row-icon icon-actions-document-properties-symbolic"></span>
-                    <span class="adw-action-row-title">Site Settings</span>
-                </a>
+                {# Site Settings link removed as it's now part of the main Settings page for admins #}
                 <a href="{{ url_for('admin.pending_users') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'admin.pending_users' }}">
                     <span class="adw-action-row-icon icon-community-users-symbolic"></span> {# Or similar relevant icon #}
                     <span class="adw-action-row-title">Pending Users</span>


### PR DESCRIPTION
- Fix 'Updated at' timestamp display to compare formatted dates.
- Fix expander row in user profile to display content correctly.
- Correct Adwaita native color variables to align with Libadwaita 1.5 docs.
- Widen article cards on Home Page for better space utilization.
- Merge Site Settings into User Settings for admin users.
- Improve menu appearance to be solid and Adwaita-like.
- Install SASS and ensure build script runs successfully.
- Remove 'Site Settings' link from sidebar for admins.

Note: SASS deprecation warnings for color functions persist for `--toast-fg-color-rgb` but do not break the build.