### PR TITLE
Further UI and Feed Enhancements

### DIFF
--- a/adwaita-web/scss/_popover.scss
+++ b/adwaita-web/scss/_popover.scss
@@ -72,6 +72,13 @@
 // This change primarily ensures that if .adw-popover is used with .menu-popover or .menu,
 // it gets the visual styling of a menu directly.
 
+    .popover-divider {
+      border: none;
+      border-top: 1px solid var(--divider-color);
+      margin: var(--spacing-xs) 0; // Consistent with other popover/menu item spacing
+    }
+}
+
 .adw-popover-surface {
   // These styles are for when there's an explicit surface element
   // For .adw-popover.menu-popover, the styles above apply directly to .adw-popover

--- a/app-demo/routes/general_routes.py
+++ b/app-demo/routes/general_routes.py
@@ -134,36 +134,139 @@ def contact_page():
 
 @general_bp.route('/feed') # This is the "Home" page for logged-in users
 @login_required
-def activity_feed(): # Rename to home_feed or similar if preferred, but endpoint name stays for now
-    current_app.logger.info(f"Accessing main feed (posts) for user {current_user.username}.")
+def activity_feed():
+    current_app.logger.info(f"Accessing activity feed for user {current_user.username}.")
     page = request.args.get('page', 1, type=int)
-    per_page = current_app.config.get('POSTS_PER_PAGE', 10) # Use POSTS_PER_PAGE
+    per_page = current_app.config.get('POSTS_PER_PAGE', 10)
 
-    posts_list, pagination = [], None
-
-    # For the main feed, show posts from users the current user is following, plus their own posts.
-    # Alternatively, show all public posts if that's the desired global feed behavior.
-    # For now, let's implement a feed of all public posts, similar to the anonymous index.
-    # A more advanced feed would involve `followed_users_posts`.
-
+    feed_items = []
     try:
-        # Fetch all published posts, newest first.
-        posts_query = Post.query.filter(Post.is_published == True)\
-                                .order_by(Post.published_at.desc(), Post.created_at.desc())
+        followed_user_ids = [user.id for user in current_user.followed]
+        user_ids_for_feed = followed_user_ids + [current_user.id]
 
-        pagination = posts_query.paginate(page=page, per_page=per_page, error_out=False)
-        posts_list = pagination.items
-        current_app.logger.debug(f"Found {len(posts_list)} posts for main feed page {page}. Total: {pagination.total}")
+        current_app.logger.debug(f"Fetching feed items for user IDs: {user_ids_for_feed}")
+
+        # Fetch posts
+        posts_query = Post.query.filter(
+            Post.user_id.in_(user_ids_for_feed),
+            Post.is_published == True
+        ).order_by(db.func.coalesce(Post.published_at, Post.created_at).desc())
+
+        # Fetch photos (UserPhoto model from ..models)
+        from ..models import UserPhoto # Ensure UserPhoto is imported
+        photos_query = UserPhoto.query.filter(
+            UserPhoto.user_id.in_(user_ids_for_feed)
+            # Assuming UserPhotos are always "public" if the user is followed or it's self.
+            # Add privacy checks if UserPhoto has its own or inherits from profile.
+        ).order_by(UserPhoto.uploaded_at.desc())
+
+        # Combine and sort
+        # This is a simplified combination. For robust pagination and large datasets,
+        # this approach (fetch all, then sort/paginate in Python) can be inefficient.
+        # A more complex SQL query (UNION ALL) or a different feed generation strategy
+        # might be needed for scale.
+
+        raw_posts = posts_query.all()
+        raw_photos = photos_query.all()
+
+        for post in raw_posts:
+            feed_items.append({
+                'type': 'post',
+                'timestamp': post.published_at or post.created_at,
+                'author': post.author, # Direct User object
+                'data': post, # The Post object itself
+                'id': f'post-{post.id}' # Unique ID for template key
+            })
+
+        for photo in raw_photos:
+            feed_items.append({
+                'type': 'photo',
+                'timestamp': photo.uploaded_at,
+                'author': photo.user, # Direct User object (backref from UserPhoto.user_id)
+                'data': photo, # The UserPhoto object itself
+                'id': f'photo-{photo.id}' # Unique ID for template key
+            })
+
+        # Sort all feed items by timestamp, newest first
+        feed_items.sort(key=lambda x: x['timestamp'], reverse=True)
+
+        # Manual pagination
+        total_items = len(feed_items)
+        start_index = (page - 1) * per_page
+        end_index = start_index + per_page
+        paginated_feed_items = feed_items[start_index:end_index]
+
+        # Create a simple pagination object for the template
+        from flask_sqlalchemy.pagination import Pagination # For object structure
+        # This is a mock pagination object, not a real SQLAlchemy one for this combined list.
+        # For a real solution, a custom pagination class or helper would be better.
+        class ManualPagination:
+            def __init__(self, page, per_page, total_items, items):
+                self.page = page
+                self.per_page = per_page
+                self.total = total_items
+                self.items = items
+
+            @property
+            def pages(self):
+                return (self.total + self.per_page - 1) // self.per_page if self.total > 0 else 0
+
+            @property
+            def has_prev(self):
+                return self.page > 1
+
+            @property
+            def has_next(self):
+                return self.page < self.pages
+
+            @property
+            def prev_num(self):
+                return self.page - 1 if self.has_prev else None
+
+            @property
+            def next_num(self):
+                return self.page + 1 if self.has_next else None
+
+            def iter_pages(self, left_edge=2, right_edge=2, left_current=2, right_current=5):
+                # Simplified iter_pages for manual pagination
+                if self.pages <= (left_edge + left_current + right_edge + right_current + 1):
+                    return range(1, self.pages + 1)
+                pages_iter = []
+                # Left Capped pages
+                for i in range(1, left_edge + 1):
+                    pages_iter.append(i)
+                pages_iter.append(None) # Ellipsis
+                # Middle pages
+                for i in range(self.page - left_current, self.page + right_current +1):
+                    if i > left_edge and i < self.pages - right_edge + 1 :
+                        pages_iter.append(i)
+                # Right Capped pages
+                if self.pages - right_edge > self.page + right_current : # check if ellipsis needed
+                    pages_iter.append(None)
+                for i in range(self.pages - right_edge + 1, self.pages + 1):
+                    if i not in pages_iter: # Avoid duplicates if ranges overlap
+                         pages_iter.append(i)
+                # Remove duplicate Nones if they occur consecutively
+                final_pages_iter = []
+                for i, val in enumerate(pages_iter):
+                    if val is None and (i == 0 or pages_iter[i-1] is None):
+                        continue
+                    final_pages_iter.append(val)
+                return final_pages_iter
+
+
+        pagination_obj = ManualPagination(page, per_page, total_items, paginated_feed_items)
+
+        current_app.logger.debug(f"Processed {len(paginated_feed_items)} items for feed page {page}. Total combined: {total_items}")
+
     except Exception as e:
-        current_app.logger.error(f"Error fetching posts for main feed for user {current_user.username}: {e}", exc_info=True)
+        current_app.logger.error(f"Error fetching or processing feed for user {current_user.username}: {e}", exc_info=True)
         flash("Error loading the feed. Please try again later.", "danger")
-        # posts_list and pagination will remain empty or None
+        paginated_feed_items = []
+        pagination_obj = ManualPagination(page, per_page, 0, [])
 
-    # The template 'feed.html' will need to be adjusted to render posts instead of activities.
-    # Or, we can point to 'index.html' if it's suitable for rendering a list of posts with pagination.
-    # Let's assume 'feed.html' will be adapted.
-    # csrf_token() is globally available in templates if CSRFProtect is setup, no need to pass it explicitly as a string.
-    return render_template('feed.html', posts=posts_list, pagination=pagination, current_user=current_user)
+
+    return render_template('feed.html', feed_items=paginated_feed_items, pagination=pagination_obj)
 
 
 # The '/users/find' route is now removed as search is unified.

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -108,15 +108,17 @@
                         <span class="adw-action-row-title">Pending Users</span>
                     </a>
                     {% endif %}
+                    <hr class="popover-divider">
+                    <a href="{{ url_for('auth.logout') }}" class="adw-action-row activatable" role="menuitem">
+                        <span class="adw-action-row-title">Logout</span>
+                    </a>
                     {% endif %}
                 </div>
             </div>
         </div>
 
-        {# Login/Logout #}
-        {% if current_user.is_authenticated %}
-            <a href="{{ url_for('auth.logout') }}" class="adw-button flat">Logout</a>
-        {% else %}
+        {# Login Button (Logout moved to menu) #}
+        {% if not current_user.is_authenticated %}
             <a href="{{ url_for('auth.login') }}" class="adw-button">Login</a>
         {% endif %}
     </div>
@@ -180,8 +182,8 @@
                     <span class="adw-action-row-title">New Post</span>
                 </a>
                 <a href="{{ url_for('general.dashboard') }}" class="adw-action-row activatable {{ 'selected' if request.endpoint == 'general.dashboard' }}">
-                    <span class="adw-action-row-icon icon-apps-dashboard-symbolic"></span> {# Or a more generic icon #}
-                    <span class="adw-action-row-title">Dashboard</span>
+                    <span class="adw-action-row-icon icon-apps-dashboard-symbolic"></span> {# Or a more generic icon, icon-user-bookmarks-symbolic could fit "My Posts" #}
+                    <span class="adw-action-row-title">My Posts</span>
                 </a>
             {# Admin links moved to dropdown menu #}
             {% endif %}

--- a/app-demo/templates/feed.html
+++ b/app-demo/templates/feed.html
@@ -5,69 +5,110 @@
 {% block header_title %}Home{% endblock %}
 
 {% block content %}
-<div class="adw-clamp adw-clamp-xl">
+<div class="adw-clamp adw-clamp-lg"> {# Changed to adw-clamp-lg for a bit more width for single column #}
     {% from "_macros.html" import like_button_and_count %}
 
-    {% if posts and posts|length > 0 %}
-        <div class="blog-posts-container" style="margin-top: var(--spacing-l);"> {# Using grid like index.html #}
-            {% for post_item in posts %}
-                <article class="adw-card blog-post-item-card">
-                    <header class="blog-post-card__header">
-                        <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">
-                            <a href="{{ url_for('profile.view_profile', user_id=post_item.author.id) }}" class="adw-link">
-                                <span class="adw-avatar size-m">
-                                    {% if post_item.author.profile_photo_url %}
-                                    <img src="{{ url_for('static', filename=post_item.author.profile_photo_url) }}" alt="{{ post_item.author.username }} avatar">
-                                    {% else %}
-                                    <img src="{{ default_avatar_url }}" alt="{{ post_item.author.username }} default avatar">
-                                    {% endif %}
-                                </span>
-                            </a>
-                            <div class="adw-box adw-box-vertical">
-                                <a href="{{ url_for('profile.view_profile', user_id=post_item.author.id) }}" class="adw-link">
-                                    <strong class="adw-label body-1">{{ post_item.author.full_name }}</strong>
+    {% if feed_items and feed_items|length > 0 %}
+        {# Changed from blog-posts-container (grid) to a flex column layout #}
+        <div class="feed-items-container" style="display: flex; flex-direction: column; gap: var(--spacing-l); margin-top: var(--spacing-l);">
+            {% for item in feed_items %}
+                {% if item.type == 'post' %}
+                    {% set post_item = item.data %}
+                    <article class="adw-card blog-post-item-card feed-item-card-post">
+                        <header class="blog-post-card__header">
+                            <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">
+                                <a href="{{ url_for('profile.view_profile', user_id=item.author.id) }}" class="adw-link">
+                                    <span class="adw-avatar size-m">
+                                        {% if item.author.profile_photo_url %}
+                                        <img src="{{ url_for('static', filename=item.author.profile_photo_url) }}" alt="{{ item.author.username }} avatar">
+                                        {% else %}
+                                        <img src="{{ default_avatar_url }}" alt="{{ item.author.username }} default avatar">
+                                        {% endif %}
+                                    </span>
                                 </a>
-                                 <span class="adw-label caption">@{{ post_item.author.full_name }}</span>
+                                <div class="adw-box adw-box-vertical">
+                                    <a href="{{ url_for('profile.view_profile', user_id=item.author.id) }}" class="adw-link">
+                                        <strong class="adw-label body-1">{{ item.author.full_name }}</strong>
+                                    </a>
+                                     <span class="adw-label caption">@{{ item.author.full_name }}</span>
+                                </div>
                             </div>
+                            <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
+                                Posted: <time datetime="{{ item.timestamp.isoformat() }}">{{ item.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                            </div>
+                        </header>
+                        <div class="adw-card__content styled-text-content">
+                            {{ post_item.content | markdown }} {# No truncation for feed, show full content #}
                         </div>
-                        <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
-                            {% if post_item.published_at %}
-                                Published: <time datetime="{{ post_item.published_at.isoformat() }}">{{ post_item.published_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
-                            {% else %}
-                                Created: <time datetime="{{ post_item.created_at.isoformat() }}">{{ post_item.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                        <footer class="blog-post-card__footer">
+                             <div class="blog-post-card__terms">
+                                {% if post_item.categories %}
+                                <div class="meta-section">
+                                    <strong class="adw-label caption meta-label-strong">Categories:</strong>
+                                    {% for category in post_item.categories %}
+                                        <a href="{{ url_for('post.posts_by_category', category_slug=category.slug) }}" class="adw-button flat compact tag-pill">{{ category.name }}</a>
+                                    {% endfor %}
+                                </div>
+                                {% endif %}
+                                {% if post_item.tags %}
+                                <div class="meta-section">
+                                    <strong class="adw-label caption meta-label-strong">Tags:</strong>
+                                    {% for tag in post_item.tags %}
+                                        <a href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug) }}" class="adw-button flat compact tag-pill">{{ tag.name }}</a>
+                                    {% endfor %}
+                                </div>
+                                {% endif %}
+                            </div>
+                            <a href="{{ url_for('post.view_post', post_id=post_item.id) }}" class="adw-button flat read-more-link">
+                                View Post & Comments <span class="adw-icon icon-actions-go-next-symbolic"></span>
+                            </a>
+                        </footer>
+                        <div class="adw-card__actions card-secondary-actions">
+                            {{ like_button_and_count(post_item, current_user, csrf_token()) }}
+                        </div>
+                    </article>
+                {% elif item.type == 'photo' %}
+                    {% set photo_item = item.data %}
+                    <article class="adw-card photo-item-card feed-item-card-photo">
+                         <header class="blog-post-card__header"> {# Re-use similar header structure #}
+                            <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">
+                                <a href="{{ url_for('profile.view_profile', user_id=item.author.id) }}" class="adw-link">
+                                    <span class="adw-avatar size-m">
+                                        {% if item.author.profile_photo_url %}
+                                        <img src="{{ url_for('static', filename=item.author.profile_photo_url) }}" alt="{{ item.author.username }} avatar">
+                                        {% else %}
+                                        <img src="{{ default_avatar_url }}" alt="{{ item.author.username }} default avatar">
+                                        {% endif %}
+                                    </span>
+                                </a>
+                                <div class="adw-box adw-box-vertical">
+                                    <a href="{{ url_for('profile.view_profile', user_id=item.author.id) }}" class="adw-link">
+                                        <strong class="adw-label body-1">{{ item.author.full_name }}</strong>
+                                    </a>
+                                     <span class="adw-label caption">@{{ item.author.full_name }}</span>
+                                </div>
+                            </div>
+                            <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
+                                Uploaded: <time datetime="{{ item.timestamp.isoformat() }}">{{ item.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                            </div>
+                        </header>
+                        <div class="adw-card__content photo-display-content" style="text-align: center;">
+                            <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo_item.image_filename) }}"
+                                 alt="{{ photo_item.caption or ('Photo by ' ~ item.author.full_name) }}"
+                                 style="max-width: 100%; max-height: 60vh; border-radius: var(--border-radius-medium); object-fit: contain;">
+                            {% if photo_item.caption %}
+                            <p class="adw-label body-1 photo-caption-text" style="margin-top: var(--spacing-s);">{{ photo_item.caption }}</p>
                             {% endif %}
                         </div>
-                    </header>
-                    <div class="adw-card__content styled-text-content">
-                        {{ post_item.content | truncate(300, True, '...') | markdown }}
-                    </div>
-                    <footer class="blog-post-card__footer">
-                         <div class="blog-post-card__terms">
-                            {% if post_item.categories %}
-                            <div class="meta-section">
-                                <strong class="adw-label caption meta-label-strong">Categories:</strong>
-                                {% for category in post_item.categories %}
-                                    <a href="{{ url_for('post.posts_by_category', category_slug=category.slug) }}" class="adw-button flat compact tag-pill">{{ category.name }}</a>
-                                {% endfor %}
-                            </div>
-                            {% endif %}
-                            {% if post_item.tags %}
-                            <div class="meta-section">
-                                <strong class="adw-label caption meta-label-strong">Tags:</strong>
-                                {% for tag in post_item.tags %}
-                                    <a href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug) }}" class="adw-button flat compact tag-pill">{{ tag.name }}</a>
-                                {% endfor %}
-                            </div>
-                            {% endif %}
-                        </div>
-                        <a href="{{ url_for('post.view_post', post_id=post_item.id) }}" class="adw-button flat read-more-link">
-                            View Post & Comments <span class="adw-icon icon-actions-go-next-symbolic"></span>
-                        </a>
-                    </footer>
-                    <div class="adw-card__actions card-secondary-actions">
-                        {{ like_button_and_count(post_item, current_user, csrf_token) }} {# Use csrf_token from context #}
-                    </div>
-                </article>
+                        {# Photos don't have comments or likes directly on them in this feed view for now #}
+                        {# Could add a link to view photo in gallery or on profile if a dedicated photo view page exists #}
+                         <footer class="blog-post-card__footer">
+                            <a href="{{ url_for('profile.view_gallery', user_id=item.author.id) }}#photo-{{photo_item.id}}" class="adw-button flat read-more-link">
+                                View in Gallery <span class="adw-icon icon-actions-go-next-symbolic"></span>
+                            </a>
+                        </footer>
+                    </article>
+                {% endif %}
             {% endfor %}
         </div>
 


### PR DESCRIPTION
This commit builds on previous UI improvements with the following changes:

- Logout Button: Moved the "Logout" button from the main header bar into the primary application dropdown menu for a cleaner header. A visual separator (hr.popover-divider) was added to the dropdown.

- Sidebar Navigation: Renamed the "Dashboard" link in the sidebar to "My Posts" to better reflect its content (user's own posts).

- Home Feed Update:
    - Backend: The "Home" feed (formerly activity_feed) now fetches both Posts and UserPhotos from the current user and users they follow. These items are combined, sorted chronologically, and paginated.
    - Frontend: The `feed.html` template now renders this unified list of feed items. The layout has been changed from a grid of cards to a single-column, vertically stacked list of items. Conditional rendering is used for posts and photos.