### PR TITLE
Fix: Correct SASS syntax error in _popover.scss

### DIFF
--- a/adwaita-web/scss/_popover.scss
+++ b/adwaita-web/scss/_popover.scss
@@ -64,20 +64,22 @@
       }
     }
   }
-}
+
+  // Styling for the divider within the popover menu's list box
+  &.menu-popover, &.menu {
+    .adw-list-box .popover-divider {
+      border: none;
+      border-top: 1px solid var(--divider-color);
+      margin: var(--spacing-xs) var(--spacing-m); // Align with action-row horizontal padding
+    }
+  }
+} // This is the correct closing brace for .adw-popover
 
 // The .adw-popover-surface class can still be used for popovers that have a distinct
 // surface div inside the .adw-popover container (e.g. for content popovers with arrows).
 // The styles for .adw-popover-surface and .adw-popover-surface.menu can remain.
 // This change primarily ensures that if .adw-popover is used with .menu-popover or .menu,
 // it gets the visual styling of a menu directly.
-
-    .popover-divider {
-      border: none;
-      border-top: 1px solid var(--divider-color);
-      margin: var(--spacing-xs) 0; // Consistent with other popover/menu item spacing
-    }
-}
 
 .adw-popover-surface {
   // These styles are for when there's an explicit surface element


### PR DESCRIPTION
This commit fixes an unmatched curly brace and incorrect nesting for the .popover-divider style within `adwaita-web/scss/_popover.scss`.

The .popover-divider style, intended for <hr> elements within menu popovers, was previously placed outside the main .adw-popover block and an extra closing brace was present, causing SASS compilation errors.

The style is now correctly nested to apply to .popover-divider elements within an .adw-list-box inside an .adw-popover that also has .menu-popover or .menu classes. Horizontal margins were also added to the divider to align with the padding of menu items.