### PR TITLE
Fix: Consistent display name usage and avatar styling

### DIFF
--- a/adwaita-web/scss/_avatar.scss
+++ b/adwaita-web/scss/_avatar.scss
@@ -27,6 +27,7 @@
     height: 100%;
     object-fit: cover; // Ensure image covers the avatar area nicely
     display: block;    // Remove extra space below image
+    border-radius: inherit; // Ensure the image itself is also rounded, helps with potential clipping issues
   }
 
   .adw-avatar-text {

--- a/app-demo/templates/gallery_full.html
+++ b/app-demo/templates/gallery_full.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{% block title %}{{ user_profile.username }}'s Photo Gallery{% endblock %}
+{% block title %}{{ user_profile.full_name or user_profile.username }}'s Photo Gallery{% endblock %}
 
-{% block header_title %}{{ user_profile.username }}'s Photo Gallery{% endblock %}
+{% block header_title %}{{ user_profile.full_name or user_profile.username }}'s Photo Gallery{% endblock %}
 
 {% block header_actions_start %}
     <a href="{{ url_for('profile.view_profile', user_id=user_profile.id) }}" class="adw-button">

--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -13,7 +13,7 @@
             <header class="blog-post-card__header">
                 {# Post title removed #}
                 <div class="blog-post-card__meta adw-label caption">
-                    By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
+                    By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.full_name or post.author.username if post.author else 'Unknown Author' }}</a>
                     on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else 'Unknown date' }}</time> {# Show time as well #}
                 </div>
             </header>

--- a/app-demo/templates/posts_by_category.html
+++ b/app-demo/templates/posts_by_category.html
@@ -23,11 +23,10 @@
                 <article class="adw-card blog-post-item-card">
                     <header class="blog-post-card__header">
                         <h2 class="adw-title-2 blog-post-card__title">
-                            <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.title }}</a>
+                            <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">Post by {{ post.author.full_name or post.author.username if post.author else 'Unknown Author' }}</a>
                         </h2>
                         <div class="blog-post-card__meta adw-label caption">
-                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
-                            on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
+                            On <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         </div>
                     </header>
                     {% if post.content %}

--- a/app-demo/templates/posts_by_tag.html
+++ b/app-demo/templates/posts_by_tag.html
@@ -23,11 +23,10 @@
                 <article class="adw-card blog-post-item-card">
                     <header class="blog-post-card__header">
                         <h2 class="adw-title-2 blog-post-card__title">
-                            <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.title }}</a>
+                            <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">Post by {{ post.author.full_name or post.author.username if post.author else 'Unknown Author' }}</a>
                         </h2>
                         <div class="blog-post-card__meta adw-label caption">
-                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
-                            on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
+                            On <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         </div>
                     </header>
                     {% if post.content %}


### PR DESCRIPTION
This commit addresses issues with user name display and avatar styling:

- Gallery Title: Corrected the Photo Gallery page title and header in `gallery_full.html` to use the user's full name instead of their username (which might be an email).

- Stretched Avatars: Added `border-radius: inherit;` to the `img` tag within the `.adw-avatar` SCSS rule. This acts as a safeguard to ensure the image itself is rounded, complementing the parent's `overflow: hidden` and `border-radius: 50%` to prevent stretched or non-circular avatars, particularly noted on Home page cards.

- Display Name Consistency:
    - Reviewed all user-facing templates to ensure `full_name` is used for displaying user names (e.g., in page titles, headers, bylines), reserving `username` for explicit handles like `@username` or login forms.
    - Updated author bylines in `index.html` to use `full_name`.
    - Corrected post listings in `posts_by_category.html` and `posts_by_tag.html`. Since posts do not have a `title` attribute, the main link for each post in these lists is now "Post by [Author's Full Name]", and the byline is simplified.