### PR TITLE
fix(ui): Update Adwaita dialog styling

### DIFF
--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -44,7 +44,7 @@ adw-dialog {
     justify-content: space-between;
     align-items: center;
     padding: var(--spacing-m);
-    border-bottom: 1px solid var(--border-color);
+    // border-bottom: 1px solid var(--border-color); // Removed to avoid line under title
 
     .adw-header-bar__title {
       font-size: var(--title-3-font-size);


### PR DESCRIPTION
Removes the bottom border from the internal header of the generic <adw-dialog> component to prevent a line from appearing under the title. This makes the dialog header area visually blend more seamlessly with the content.

The dialog host component already had a border-radius applied, which ensures all corners, including the top ones, are rounded according to the theme's window radius.