### PR TITLE
Fix: Address photo comment table, dialog UI, and spinner icon

### DIFF
--- a/adwaita-web/js/components/dialog.js
+++ b/adwaita-web/js/components/dialog.js
@@ -55,7 +55,8 @@ class AdwDialogElement extends HTMLElement {
             closeButton.type = 'button'; // CRITICAL: Prevent form submission
             closeButton.classList.add('adw-button', 'circular', 'flat', 'adw-dialog-close-button');
             closeButton.setAttribute('aria-label', 'Close dialog');
-            closeButton.innerHTML = '<span class="adw-icon icon-actions-close-symbolic"></span>'; // Make sure this icon class exists
+            // Use a more standard Adwaita icon name for 'close window'
+            closeButton.innerHTML = '<span class="adw-icon icon-actions-window-close-symbolic"></span>';
             closeButton.addEventListener('click', () => this.close());
             header.appendChild(closeButton);
         }

--- a/adwaita-web/scss/_spinner.scss
+++ b/adwaita-web/scss/_spinner.scss
@@ -6,8 +6,8 @@
   height: 24px; // Default size
   vertical-align: middle;
   background-color: var(--spinner-color, var(--accent-color)); // Color for the SVG icon
-  -webkit-mask-image: url('../data/icons/symbolic/process-working-symbolic.svg');
-  mask-image: url('../data/icons/symbolic/process-working-symbolic.svg');
+  -webkit-mask-image: url('../data/icons/symbolic/view-refresh-symbolic.svg');
+  mask-image: url('../data/icons/symbolic/view-refresh-symbolic.svg');
   -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
   -webkit-mask-position: center;

--- a/app-demo/templates/profile.html
+++ b/app-demo/templates/profile.html
@@ -933,5 +933,9 @@ document.addEventListener('DOMContentLoaded', function () {
         opacity: 0.3; /* Make image semi-transparent while its replacement loads */
     }
 
+    .form-actions-end {
+        text-align: right; /* Aligns inline-block or inline children to the right */
+        margin-top: var(--spacing-m); /* Add some default margin if needed */
+    }
 </style>
 {% endblock %}


### PR DESCRIPTION
- Database: Confirmed `PhotoComment` model and `setup_db.py` are correct. The `photo_comment` table should be created when `setup_db.py` is run by the user, resolving the UndefinedTable error.
- Dialog UI:
    - Changed the default close button icon in `adw-dialog` component (dialog.js) to `icon-actions-window-close-symbolic` for better standard icon display.
    - Added CSS to `profile.html` to ensure `.form-actions-end` (used for 'Post Comment' button) aligns content to the right.
- Icons: Fixed 404 error for spinner icon by updating `adwaita-web/scss/_spinner.scss` to use `view-refresh-symbolic.svg` instead of the missing `process-working-symbolic.svg`. User needs to run `build-adwaita-web.sh` for this to take effect.