### PR TITLE
Refactor: Simplify adw-dialog header structure

### DIFF
--- a/adwaita-web/js/components/dialog.js
+++ b/adwaita-web/js/components/dialog.js
@@ -35,37 +35,35 @@ class AdwDialogElement extends HTMLElement {
 
   connectedCallback() {
     // Ensure basic header structure if not already present declaratively
-    if (!this.querySelector('.adw-dialog__header')) {
-        const header = document.createElement('header');
-        header.classList.add('adw-header-bar', 'adw-dialog__header');
+    // The new structure will not use adw-header-bar for a simpler look.
+    if (!this.querySelector('.adw-dialog__header')) { // Keep .adw-dialog__header as a general container name for styling
+        const headerContainer = document.createElement('div'); // Use a div instead of header to avoid adw-header-bar implications
+        headerContainer.classList.add('adw-dialog__header'); // This class will be styled in SCSS
 
         const titleEl = document.createElement('h2');
-        titleEl.classList.add('adw-header-bar__title');
+        titleEl.classList.add('adw-dialog__title'); // New class for specific title styling if needed
         // Ensure titleEl has an ID for aria-labelledby
         titleEl.id = `dialog-title-${this.id || Math.random().toString(36).substring(2, 9)}`;
         this.setAttribute('aria-labelledby', titleEl.id);
 
-        header.appendChild(titleEl);
+        headerContainer.appendChild(titleEl);
 
         // Check for a close button, add if not present by default
-        // Adwaita dialogs typically have a close button in the header.
-        // Users can override this by providing their own header slot.
-        if (!header.querySelector('.adw-dialog-close-button')) {
+        if (!headerContainer.querySelector('.adw-dialog-close-button')) {
             const closeButton = document.createElement('button');
             closeButton.type = 'button'; // CRITICAL: Prevent form submission
             closeButton.classList.add('adw-button', 'circular', 'flat', 'adw-dialog-close-button');
             closeButton.setAttribute('aria-label', 'Close dialog');
-            // Use a more standard Adwaita icon name for 'close window'
             closeButton.innerHTML = '<span class="adw-icon icon-actions-window-close-symbolic"></span>';
             closeButton.addEventListener('click', () => this.close());
-            header.appendChild(closeButton);
+            headerContainer.appendChild(closeButton);
         }
 
-        this.prepend(header);
+        this.prepend(headerContainer);
     }
 
     if (this.title) {
-        this._updateTitle(this.title);
+        this._updateTitle(this.title); // This will target .adw-dialog__title or similar
     }
 
     // Ensure initial state is hidden if not 'open'
@@ -94,7 +92,8 @@ class AdwDialogElement extends HTMLElement {
 
   _updateTitle(newTitle) {
     if (this.isConnected) {
-      let titleEl = this.querySelector('.adw-dialog__header .adw-header-bar__title');
+      // Adjusted selector to match the new title element's class
+      let titleEl = this.querySelector('.adw-dialog__header .adw-dialog__title');
       if (titleEl) {
         titleEl.textContent = newTitle || '';
       }

--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -39,24 +39,30 @@ adw-about-dialog {
 
 // Specific styles for the generic <adw-dialog> (Light DOM content)
 adw-dialog {
-  > .adw-dialog-header {
+  // Styles for the new .adw-dialog__header (which is now a div)
+  > .adw-dialog__header {
     display: flex;
-    justify-content: space-between;
+    justify-content: space-between; // Title on left, close button on right
     align-items: center;
-    padding: var(--spacing-m);
-    border-bottom: 1px solid var(--border-color);
+    padding: var(--spacing-m); // Standard padding
+    border-bottom: 1px solid var(--border-color); // Separator line
 
-    .adw-header-bar__title {
-      font-size: var(--title-3-font-size);
+    .adw-dialog__title { // Styling for the new H2 title class
+      font-size: var(--title-3-font-size, 1.25em); // Use Adwaita title size or fallback
       font-weight: var(--font-weight-bold);
+      margin: 0; // Remove default H2 margin
+      flex-grow: 1; // Allow title to take available space
     }
-    // Styling for the close button in generic dialog header (if needed beyond .adw-button classes)
-    .adw-dialog-close-button.adw-button .adw-icon {
-        // Basic icon mask if not provided by global .adw-icon or button styles
-        // background-color: currentColor;
-        // -webkit-mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
-        // mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
-        // width: var(--icon-size-base); height: var(--icon-size-base);
+
+    .adw-dialog-close-button {
+      // Basic styling for the close button itself if needed beyond .adw-button
+      // For example, ensure it's not too large or small.
+      // Adwaita 'circular' and 'flat' styles should handle most of it.
+      // Ensure the icon inside is visible.
+      .adw-icon {
+        // Icon color should be inherited or set by button styles.
+        // Size is usually 16px for symbolic icons.
+      }
     }
   }
 


### PR DESCRIPTION
- Modified `adwaita-web/js/components/dialog.js` to remove the use of `adw-header-bar` for the default programmatically created dialog header.
- The new default header is a `div.adw-dialog__header` containing an `h2.adw-dialog__title` and the close button.
- Updated `adwaita-web/scss/_dialog.scss` to style this new simpler header structure, ensuring correct title and close button appearance and positioning.
- Existing dialogs in `app-demo` that rely on the default header will now use this simpler style.