### PR TITLE
Feat: Improve photo display and avatar in feed

### DIFF
--- a/adwaita-web/scss/_card.scss
+++ b/adwaita-web/scss/_card.scss
@@ -89,3 +89,88 @@
     padding: var(--spacing-m);
   }
 }
+
+// Styles for photo thumbnails within cards in the feed
+.photo-item-card { // Specific to the photo cards in the feed
+  .photo-card-clickable-content {
+    display: block; // Make the anchor fill the content area
+    padding: var(--spacing-m); // Standard card padding
+    &:hover {
+      background-color: rgba(var(--card-fg-color-rgb), 0.02); // Very subtle hover for the content area
+    }
+  }
+
+  .photo-thumbnails-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); // Responsive grid for multiple thumbnails
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-s); // Space before caption if any
+
+    // If only one item, we might want it to be larger or centered.
+    // The template handles single item by not being in the loop,
+    // but this can style the container if it has few items.
+    &:has(.photo-thumbnail-link:nth-child(1):last-child) { // If only one photo
+      grid-template-columns: minmax(150px, 250px); // Single photo can be larger
+      justify-content: center; // Center the single photo if grid takes full width
+    }
+     &:has(.photo-thumbnail-link:nth-child(2):last-child) { // If two photos
+      grid-template-columns: repeat(2, minmax(100px, 1fr));
+    }
+    &:has(.photo-thumbnail-link:nth-child(3):last-child) { // If three photos
+      grid-template-columns: repeat(3, minmax(80px, 1fr));
+    }
+  }
+
+  .photo-thumbnail-link {
+    display: block;
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--border-radius-medium);
+    aspect-ratio: 1 / 1; // Square thumbnails
+    background-color: var(--shade-color); // Placeholder background
+
+    &:hover {
+      box-shadow: 0 0 0 2px var(--accent-color); // Highlight on hover
+    }
+  }
+
+  .photo-thumbnail-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover; // Cover the area, cropping if necessary
+    transition: transform 0.2s ease-out;
+
+    .photo-thumbnail-link:hover & {
+      transform: scale(1.05); // Slight zoom on hover
+    }
+  }
+
+  // For a card that is explicitly showing a single, larger thumbnail (not in a grid)
+  .single-photo-link { // Applied to the link around a single photo
+    display: block;
+    text-align: center; // Center the image if it's not full width
+    margin-bottom: var(--spacing-s);
+  }
+  .single-photo-thumbnail-img { // Applied to the image itself for single display
+    max-width: 100%;
+    max-height: 400px; // Limit height for single preview
+    width: auto; // Maintain aspect ratio
+    height: auto; // Maintain aspect ratio
+    object-fit: contain;
+    border-radius: var(--border-radius-medium);
+  }
+
+  .photo-caption-text {
+    color: var(--secondary-fg-color); // Use secondary text color for caption
+    font-size: var(--font-size-small);
+    text-align: left; // Align caption to the left under the grid/image
+    // padding was moved to the template for better control
+  }
+
+  // Ensure footer is below the clickable content if caption is part of it
+  .blog-post-card__footer {
+    margin-top: var(--spacing-s);
+    padding-top: 0; // Removed default top padding from footer if content above has its own.
+                    // The template now adds its own padding to the footer.
+  }
+}

--- a/app-demo/templates/feed.html
+++ b/app-demo/templates/feed.html
@@ -29,8 +29,8 @@
                                 <div class="adw-box adw-box-vertical">
                                     <a href="{{ url_for('profile.view_profile', user_id=item.author.id) }}" class="adw-link">
                                         <strong class="adw-label body-1">{{ item.author.full_name }}</strong>
-                                    </a>
-                                     <span class="adw-label caption">@{{ item.author.full_name }}</span>
+
+                                     <span class="adw-label caption">@{{ item.author.username }}</span></a>
                                 </div>
                             </div>
                             <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
@@ -84,26 +84,46 @@
                                 <div class="adw-box adw-box-vertical">
                                     <a href="{{ url_for('profile.view_profile', user_id=item.author.id) }}" class="adw-link">
                                         <strong class="adw-label body-1">{{ item.author.full_name }}</strong>
-                                    </a>
-                                     <span class="adw-label caption">@{{ item.author.full_name }}</span>
+
+                                     <span class="adw-label caption">@{{ item.author.username }}</span></a>
                                 </div>
                             </div>
                             <div class="blog-post-card__meta adw-label caption" style="margin-top: var(--spacing-xs);">
                                 Uploaded: <time datetime="{{ item.timestamp.isoformat() }}">{{ item.timestamp.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                             </div>
                         </header>
-                        <div class="adw-card__content photo-display-content" style="text-align: center;">
-                            <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo_item.image_filename) }}"
-                                 alt="{{ photo_item.caption or ('Photo by ' ~ item.author.full_name) }}"
-                                 style="max-width: 100%; max-height: 60vh; border-radius: var(--border-radius-medium); object-fit: contain;">
-                            {% if photo_item.caption %}
-                            <p class="adw-label body-1 photo-caption-text" style="margin-top: var(--spacing-s);">{{ photo_item.caption }}</p>
+                        {# Entire card content is a link to the gallery for the first photo in the set #}
+                        {# If photo_item is a list, use first photo for main card link, else use photo_item directly #}
+                        {% set first_photo = photo_item[0] if photo_item is iterable and not photo_item is string else photo_item %}
+                        {% set gallery_url = url_for('profile.view_gallery', user_id=item.author.id) + '#photo-' + (first_photo.id | string) %}
+
+                        <a href="{{ gallery_url }}" class="adw-card__content photo-display-content photo-card-clickable-content" style="text-decoration: none; color: inherit;">
+                            {# Container for multiple thumbnails if photo_item is a list #}
+                            <div class="photo-thumbnails-grid">
+                                {% if photo_item is iterable and not photo_item is string %}
+                                    {# Multiple photos: display as thumbnails in a grid #}
+                                    {% for photo_thumb in photo_item %}
+                                    <a href="{{ url_for('profile.view_gallery', user_id=item.author.id) }}#photo-{{photo_thumb.id}}" class="photo-thumbnail-link">
+                                        <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo_thumb.image_filename) }}"
+                                             alt="{{ photo_thumb.caption or ('Photo by ' ~ item.author.full_name) }}"
+                                             class="photo-thumbnail-img">
+                                    </a>
+                                    {% endfor %}
+                                {% else %}
+                                    {# Single photo: display as a larger thumbnail #}
+                                    <a href="{{ gallery_url }}" class="photo-thumbnail-link single-photo-link">
+                                        <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo_item.image_filename) }}"
+                                             alt="{{ photo_item.caption or ('Photo by ' ~ item.author.full_name) }}"
+                                             class="photo-thumbnail-img single-photo-thumbnail-img">
+                                    </a>
+                                {% endif %}
+                            </div>
+                            {% if first_photo.caption %} {# Show caption of the first photo or the single photo #}
+                            <p class="adw-label body-1 photo-caption-text" style="margin-top: var(--spacing-s); padding: 0 var(--spacing-m);">{{ first_photo.caption }}</p>
                             {% endif %}
-                        </div>
-                        {# Photos don't have comments or likes directly on them in this feed view for now #}
-                        {# Could add a link to view photo in gallery or on profile if a dedicated photo view page exists #}
-                         <footer class="blog-post-card__footer">
-                            <a href="{{ url_for('profile.view_gallery', user_id=item.author.id) }}#photo-{{photo_item.id}}" class="adw-button flat read-more-link">
+                        </a>
+                        <footer class="blog-post-card__footer" style="padding-top: 0;"> {# Adjust padding if caption is inside the link #}
+                            <a href="{{ gallery_url }}" class="adw-button flat read-more-link">
                                 View in Gallery <span class="adw-icon icon-actions-go-next-symbolic"></span>
                             </a>
                         </footer>

--- a/app-demo/templates/gallery_full.html
+++ b/app-demo/templates/gallery_full.html
@@ -53,7 +53,8 @@
     {% if gallery_photos_page and gallery_photos_page.items %}
         <div class="profile-gallery-grid" style="padding-top: var(--spacing-l); padding-bottom: var(--spacing-l);">
             {% for photo in gallery_photos_page.items %}
-            <div class="adw-card gallery-photo-card">
+            {# Add id attribute for direct linking via hash #}
+            <div class="adw-card gallery-photo-card" id="photo-{{ photo.id }}">
                 <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo.image_filename) }}"
                      alt="{{ photo.caption or ('Gallery image by ' ~ (user_profile.full_name or user_profile.username)) }}"
                      class="gallery-photo-image clickable-gallery-photo" {# Added clickable-gallery-photo class #}
@@ -223,6 +224,40 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                 });
             });
+
+            // --- Start of new code for hash navigation ---
+            function openPhotoFromHash() {
+                if (window.location.hash && window.location.hash.startsWith('#photo-')) {
+                    const targetPhotoId = window.location.hash.substring(1); // e.g., "photo-123"
+                    const targetCard = document.getElementById(targetPhotoId);
+                    if (targetCard) {
+                        const clickableImage = targetCard.querySelector('.clickable-gallery-photo');
+                        if (clickableImage) {
+                            // Scroll to the card first, then click.
+                            // Using setTimeout to ensure other UI updates (like dialog definition) are processed.
+                            setTimeout(() => {
+                                targetCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                                // Brief delay after scroll before click, can help if dialog isn't ready.
+                                setTimeout(() => {
+                                   if (galleryPhotoDialog && typeof galleryPhotoDialog.open === 'function') {
+                                       clickableImage.click();
+                                   } else {
+                                       console.warn("Dialog not ready to open for hash navigation.");
+                                   }
+                                }, 100);
+                            }, 0);
+                        } else {
+                            console.warn(`No clickable image found for ID: ${targetPhotoId}`);
+                        }
+                    } else {
+                        console.warn(`No card found for ID: ${targetPhotoId}`);
+                    }
+                }
+            }
+            // Call it once on load
+            openPhotoFromHash();
+            // --- End of new code for hash navigation ---
+
         }).catch(error => {
             console.error("gallery_full.html: Failed to initialize gallery photo dialog; adw-dialog definition not found.", error);
         });


### PR DESCRIPTION
- Display single image uploads as thumbnails in the home feed.
- Structure feed cards to support multiple thumbnails if photos are grouped.
- Make photo cards and thumbnails link to the gallery, opening the specific photo.
- Correct avatar display to show '@username' instead of duplicating full name.
- Ensure full name and '@username' in avatar block link to user profile.
- Update gallery page to auto-open photo in dialog via URL hash.