### PR TITLE
Update documentation and add tutorial

### DIFF
--- a/adwaita-web/THEMING_REFERENCE.md
+++ b/adwaita-web/THEMING_REFERENCE.md
@@ -240,6 +240,14 @@ These are primarily used by the `row-base` mixin and row components like `AdwAct
 *   `--toast-min-height`: Minimum height of toasts (e.g., `36px`).
 *   `--toast-border-radius`: Border radius for toasts (defaults to `var(--border-radius-large)`).
 
+### Switch Variables
+Used for styling `AdwSwitch` components.
+*   `--switch-knob-bg-color`: Background color of the switch knob in its default state.
+*   `--switch-slider-off-bg-color`: Background color of the switch track when in the "off" state.
+*   `--switch-slider-disabled-off-bg-color`: Background color of the switch track when disabled and "off".
+*   `--switch-knob-disabled-bg-color`: Background color of the switch knob when disabled and "off".
+    *   Note: When a switch is "on" and active, its track uses `var(--accent-bg-color)`. When "on" and disabled, it uses `var(--accent-bg-color)` with `var(--disabled-opacity)`.
+
 ## Fonts
 *   `--document-font-family`: Default sans-serif font stack.
 *   `--document-font-size`: Default base font size (e.g., `10pt`).

--- a/adwaita-web/docs/general/usage-guide.md
+++ b/adwaita-web/docs/general/usage-guide.md
@@ -89,14 +89,15 @@ While Adwaita Skin aims to be flexible, some styles might expect a certain HTML 
 
 Refer to the "Styled Elements (CSS Classes)" section in the main documentation and the examples provided in `adwaita-web/examples/` to see the recommended HTML structures and available classes for different Adwaita patterns.
 
-## Interactivity
+## Interactivity & JavaScript Components
 
-Adwaita Skin is a **pure CSS library**. It **does not provide any JavaScript** for interactivity.
-*   Event handling (e.g., what happens when a button is clicked).
-*   Dynamic updates to the UI (e.g., showing/hiding elements, changing content).
-*   Complex widget behaviors (e.g., opening/closing dialogs, managing tabs).
+The core CSS of Adwaita Skin provides the visual styling for HTML elements. For many components, this styling can be applied to manually structured HTML, and you would implement all interactivity (event handling, dynamic updates) with your own JavaScript.
 
-All such interactivity must be implemented by your application using your own JavaScript code. Adwaita Skin provides the visual styling, and your JavaScript provides the functionality.
+However, the Adwaita Web project also includes:
+*   **JavaScript-powered Web Components** (e.g., `<adw-dialog>`, `<adw-switch>`, `<adw-tab-view>`). These components encapsulate both structure and behavior. Their respective documentation pages detail their usage.
+*   **Helper JavaScript modules** (e.g., for managing toasts, banners, or application layout) located in the `adwaita-web/js/` directory.
+
+When using the pure CSS classes on your own HTML, you are responsible for all interactivity. When using the provided Web Components or JS helpers, they will handle much of their internal behavior.
 
 ## Theming
 

--- a/adwaita-web/docs/tutorial-creating-a-simple-app.md
+++ b/adwaita-web/docs/tutorial-creating-a-simple-app.md
@@ -1,0 +1,306 @@
+# Tutorial: Creating a Simple Application with Adwaita Web
+
+This tutorial will guide you through building a very simple web application interface using the Adwaita Web library. We'll create a basic "Quick Notes" app that allows you to add and display short notes. This will demonstrate how to use several Adwaita Web components and styling conventions.
+
+## 1. Introduction
+
+Adwaita Web provides CSS styles and JavaScript components to build web interfaces that mimic the look and feel of GNOME's Adwaita design language. This tutorial focuses on using the CSS styling aspect with basic HTML, and will touch upon how JavaScript can be used for interactivity.
+
+**What we'll build:**
+*   A header bar with the application title.
+*   An input area to add new notes.
+*   A list to display the added notes.
+
+## 2. Setup
+
+### Basic HTML Page (`quick_notes.html`)
+First, create a basic HTML file. Let's call it `quick_notes.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quick Notes App</title>
+  <link rel="stylesheet" href="path/to/adwaita-web/css/adwaita-skin.css"> <!-- Adjust path as needed -->
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .app-container {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+    }
+    .content-area {
+      padding: var(--spacing-l);
+      flex-grow: 1;
+      overflow-y: auto;
+    }
+    .notes-list {
+      margin-top: var(--spacing-m);
+    }
+  </style>
+</head>
+<body>
+  <div class="app-container">
+    <!-- App content will go here -->
+  </div>
+
+  <script>
+    // Basic JavaScript for interactivity will go here
+  </script>
+</body>
+</html>
+```
+
+### Linking Adwaita Web CSS
+In the `<head>` section, we've linked to `adwaita-skin.css`. You'll need to:
+1.  **Compile the SCSS:** If you're working from the source, use a SASS compiler on `adwaita-web/scss/adwaita-skin.scss` to generate `adwaita-skin.css`. The project includes a `build-adwaita-web.sh` script that can do this and also prepares other assets.
+2.  **Adjust the Path:** Make sure the `href` attribute in the `<link>` tag correctly points to where `adwaita-skin.css` is located relative to your `quick_notes.html` file. For example, if you run the build script, it might place it in a `build/css/` directory.
+
+## 3. Basic Layout with AdwHeaderBar
+
+Let's add a header bar to our application.
+
+Modify the `app-container` div:
+```html
+  <div class="app-container">
+    <header class="adw-header-bar">
+      <div class="adw-header-bar-center-box">
+        <h1 class="adw-header-bar-title">Quick Notes</h1>
+      </div>
+      <div class="adw-header-bar-end">
+        <button class="adw-button flat circular" id="theme-toggle-button" aria-label="Toggle Theme">
+          <span class="adw-icon icon-display-brightness-symbolic"></span> <!-- Placeholder icon -->
+        </button>
+      </div>
+    </header>
+
+    <main class="content-area">
+      <!-- Input and list will go here -->
+    </main>
+  </div>
+```
+*   We use `adw-header-bar` for the main header.
+*   `adw-header-bar-center-box` and `adw-header-bar-title` for the title.
+*   `adw-header-bar-end` for right-aligned actions (like a theme toggle).
+*   You'll need to define `icon-display-brightness-symbolic` or use an actual SVG/image for the icon. For simplicity, we'll assume it's defined elsewhere or you can use text.
+
+## 4. Adding Notes: Input Area
+
+Now, let's add an input field and a button to add new notes within the `content-area`.
+
+```html
+    <main class="content-area">
+      <div class="adw-box horizontal spacing-s" style="align-items: center; margin-bottom: var(--spacing-l);">
+        <input type="text" class="adw-entry" id="new-note-input" placeholder="Enter your note..." style="flex-grow: 1;">
+        <button class="adw-button suggested-action" id="add-note-button">
+          <span class="adw-icon icon-add-symbolic"></span> Add Note
+        </button>
+      </div>
+
+      <div class="adw-list-box notes-list" id="notes-list-container">
+        <!-- Notes will be added here -->
+        <div class="adw-row placeholder-row">
+          <span class="adw-label dim-label">No notes yet.</span>
+        </div>
+      </div>
+    </main>
+```
+*   We use an `adw-box horizontal spacing-s` to layout the input and button side-by-side with small spacing.
+*   `adw-entry` styles the text input.
+*   `adw-button suggested-action` styles the "Add Note" button. (Define `icon-add-symbolic` or use text).
+*   `adw-list-box` will contain our notes. We've added a placeholder row for when it's empty.
+
+## 5. Displaying Notes in a ListBox
+
+Each note in the list can be an `AdwActionRow`.
+
+```html
+<!-- Inside <div class="adw-list-box notes-list" id="notes-list-container"> -->
+<!-- Example of how a note might look (to be added by JavaScript): -->
+<!--
+<div class="adw-action-row">
+  <span class="adw-action-row-title">My first note text</span>
+  <div style="flex-grow: 1;"></div> &lt;!&ndash; Spacer &ndash;&gt;
+  <button class="adw-button flat circular destructive-action" aria-label="Delete note">
+    <span class="adw-icon icon-edit-delete-symbolic"></span>
+  </button>
+</div>
+-->
+```
+We'll add these rows dynamically with JavaScript later. For now, this shows the structure. (Define `icon-edit-delete-symbolic`).
+
+## 6. Styling and Theming
+
+Adwaita Web makes theming easy.
+
+### Light/Dark Mode
+To toggle dark mode, you'll need a bit of JavaScript for the theme toggle button:
+```javascript
+// Inside the <script> tag at the bottom of body
+
+const themeToggleButton = document.getElementById('theme-toggle-button');
+const brightnessIcon = themeToggleButton.querySelector('.adw-icon'); // Assuming it's there
+
+function setTheme(themeName) {
+  if (themeName === 'dark') {
+    document.documentElement.classList.add('theme-dark');
+    // Update icon to sun or similar for dark mode (optional)
+    // brightnessIcon.classList.remove('icon-display-brightness-symbolic');
+    // brightnessIcon.classList.add('icon-weather-sunny-symbolic'); // Define this icon
+  } else {
+    document.documentElement.classList.remove('theme-dark');
+    // Update icon to moon or similar for light mode (optional)
+    // brightnessIcon.classList.remove('icon-weather-sunny-symbolic');
+    // brightnessIcon.classList.add('icon-display-brightness-symbolic');
+  }
+  localStorage.setItem('appTheme', themeName);
+}
+
+themeToggleButton.addEventListener('click', () => {
+  if (document.documentElement.classList.contains('theme-dark')) {
+    setTheme('light');
+  } else {
+    setTheme('dark');
+  }
+});
+
+// Apply saved theme on load
+const savedTheme = localStorage.getItem('appTheme');
+if (savedTheme) {
+  setTheme(savedTheme);
+} else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  setTheme('dark'); // Prefer system dark mode if no saved theme
+}
+```
+*(Remember to define any icons like `icon-weather-sunny-symbolic` if you implement the icon change.)*
+
+### Accent Colors
+You can change the accent color by adding a class to `document.documentElement` (e.g., `accent-green`, `accent-purple`).
+For example, to set it to green:
+```javascript
+document.documentElement.classList.add('accent-green');
+// To remove a previous accent before adding a new one:
+// document.documentElement.classList.remove('accent-blue', 'accent-red', ...);
+```
+This would typically be part of a settings panel in a larger application.
+
+## 7. Interactivity: Adding Notes (JavaScript)
+
+Let's make the "Add Note" button work.
+
+```javascript
+// Inside the <script> tag
+
+const newNoteInput = document.getElementById('new-note-input');
+const addNoteButton = document.getElementById('add-note-button');
+const notesListContainer = document.getElementById('notes-list-container');
+const placeholderRow = notesListContainer.querySelector('.placeholder-row');
+
+addNoteButton.addEventListener('click', () => {
+  const noteText = newNoteInput.value.trim();
+  if (noteText === '') {
+    // Optional: Show an AdwToast or inline message if using Adw.js helpers
+    // Adw.createToast("Note cannot be empty!");
+    alert("Note cannot be empty!"); // Simple alert for now
+    return;
+  }
+
+  if (placeholderRow) {
+    placeholderRow.remove(); // Remove "No notes yet" message
+  }
+
+  const noteRow = document.createElement('div');
+  noteRow.className = 'adw-action-row';
+
+  const titleSpan = document.createElement('span');
+  titleSpan.className = 'adw-action-row-title';
+  titleSpan.textContent = noteText;
+
+  const spacer = document.createElement('div');
+  spacer.style.flexGrow = '1';
+
+  const deleteButton = document.createElement('button');
+  deleteButton.className = 'adw-button flat circular destructive-action';
+  deleteButton.setAttribute('aria-label', 'Delete note');
+  const deleteIcon = document.createElement('span');
+  // Ensure you have 'icon-edit-delete-symbolic' CSS defined for the icon's appearance
+  deleteIcon.className = 'adw-icon icon-edit-delete-symbolic';
+  deleteButton.appendChild(deleteIcon);
+
+  deleteButton.addEventListener('click', () => {
+    noteRow.remove();
+    // If list becomes empty, show placeholder again
+    if (notesListContainer.children.length === 0) {
+        notesListContainer.appendChild(placeholderRow); // Re-add original placeholder or create new
+    }
+  });
+
+  noteRow.appendChild(titleSpan);
+  noteRow.appendChild(spacer);
+  noteRow.appendChild(deleteButton);
+
+  notesListContainer.appendChild(noteRow);
+
+  newNoteInput.value = ''; // Clear input
+  newNoteInput.focus();
+
+  // Optional: Use Adw.Toast for feedback if Adw.js is included
+  // Adw.createToast("Note added!");
+});
+```
+
+This JavaScript provides basic functionality. A real app would use more robust DOM manipulation, potentially Web Components for each note, and save data (e.g., to `localStorage`).
+
+### Using Adw.js Components (Conceptual)
+If you were using the Adwaita Web JavaScript components:
+*   **Dialogs:** For confirmation before deleting a note:
+    ```javascript
+    // Conceptual, assuming Adw.AlertDialog.factory is available
+    // Adw.AlertDialog.factory("Really delete this note?", {
+    //   heading: "Confirm Deletion",
+    //   choices: [ {label: "Cancel", value: "cancel"}, {label: "Delete", value: "delete", style: "destructive"}],
+    //   onResponse: (value) => { if (value === "delete") { /* ... delete logic ... */ } }
+    // }).open();
+    ```
+*   **Toasts:** For notifications:
+    ```javascript
+    // Adw.Toast.show("Note successfully added!"); // If using the Adw.Toast API
+    ```
+
+## 8. Conclusion
+
+This tutorial demonstrated how to set up a simple HTML page with Adwaita Web CSS to create a basic application interface. We covered:
+*   Linking the stylesheet.
+*   Using `AdwHeaderBar`, `AdwBox`, `AdwEntry`, `AdwButton`, and `AdwListBox` with `AdwActionRow`.
+*   Basic theme (dark mode) and accent color application.
+*   Conceptual JavaScript for interactivity.
+
+From here, you can explore more Adwaita Web components and SCSS utilities to build richer interfaces. Refer to the individual widget documentation pages for detailed information on each component's styling options and expected HTML structure.
+
+Remember to consult the `THEMING_REFERENCE.md` for a full list of CSS custom properties to customize the look and feel further.
+You would also need to define the icons used (e.g. `icon-display-brightness-symbolic`, `icon-add-symbolic`, `icon-edit-delete-symbolic`) in your CSS, for example:
+```css
+/* In your main CSS or a separate icon CSS file */
+.adw-icon { /* Basic icon setup */
+  display: inline-block;
+  width: 16px; height: 16px;
+  background-color: currentColor; /* For mask-image icons */
+  -webkit-mask-size: contain; mask-size: contain;
+  -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+  -webkit-mask-position: center; mask-position: center;
+}
+.icon-display-brightness-symbolic { -webkit-mask-image: url(path/to/display-brightness-symbolic.svg); mask-image: url(path/to/display-brightness-symbolic.svg); }
+.icon-add-symbolic { -webkit-mask-image: url(path/to/list-add-symbolic.svg); mask-image: url(path/to/list-add-symbolic.svg); }
+.icon-edit-delete-symbolic { -webkit-mask-image: url(path/to/edit-delete-symbolic.svg); mask-image: url(path/to/edit-delete-symbolic.svg); }
+/* ... add other icons you use ... */
+```
+Adjust the `url()` paths to point to your icon files. The Adwaita Web library provides many symbolic icons in `adwaita-web/data/icons/symbolic/`.
+Happy Hacking!
+```

--- a/adwaita-web/docs/widgets/actionrow.md
+++ b/adwaita-web/docs/widgets/actionrow.md
@@ -137,10 +137,35 @@ A declarative way to define Adwaita action rows.
 
 ## Styling
 
-*   Primary SCSS: `scss/_action_row.scss` (and inherits from `_listbox.scss` / `_row_types.scss`).
-*   The layout uses flexbox to arrange icon, title/subtitle block, suffix, and chevron.
-*   The `disabled` state will typically reduce opacity and disable pointer events.
-*   Interactive states (hover, active) are styled for visual feedback.
+*   **SCSS Source:** `scss/_action_row.scss`. Inherits base row styles through `@include mixins.row-base`.
+*   **Key Visual Aspects:**
+    *   **Layout:** Uses flexbox. Default `gap` is `var(--spacing-m)`.
+    *   **Padding & Height:** Typically `12px` top/bottom padding, aiming for standard Adwaita row heights (e.g., ~54px single line, ~70px with subtitle).
+    *   **Shadow:** Standalone ActionRows or those in flat listboxes have a `var(--subtle-box-shadow)`.
+    *   **Prefix/Suffix Icons:**
+        *   General icons (e.g., in `.adw-action-row-prefix` or as part of a suffix widget) use `var(--secondary-fg-color)` and are typically 16px.
+        *   Chevron icon (`.adw-action-row-chevron` in suffix for navigation) uses `pan-next-symbolic.svg` (or `go-next-symbolic.svg`), `currentColor` (thus `var(--secondary-fg-color)`), and `var(--icon-opacity)`.
+    *   **Title (`.adw-action-row-title`):** Normal weight, `var(--window-fg-color)`, ellipsis for overflow.
+    *   **Subtitle (`.adw-action-row-subtitle`):** Small size, `var(--secondary-fg-color)`, ellipsis for overflow. `margin-top: var(--spacing-xxs)`.
+    *   **Activatable State (`.activatable` class):**
+        *   Cursor becomes `pointer`.
+        *   Hover: `background-color: var(--list-row-hover-bg-color)`.
+        *   Active (pressed): `background-color: var(--list-row-active-bg-color)`.
+        *   Focus: Standard outline `var(--focus-ring-width) solid var(--accent-color)` with `var(--focus-outline-offset)`.
+    *   **Property Variant (`.property` class):**
+        *   Title becomes de-emphasized (normal weight, `var(--secondary-fg-color)`).
+        *   Subtitle becomes emphasized (`var(--primary-fg-color)`, normal weight, full opacity).
+        *   If also `.monospace`, subtitle uses `var(--font-family-monospace)`.
+    *   **Monospace Variant (`.monospace` class, if not also `.property`):**
+        *   Subtitle uses `var(--font-family-monospace)`.
+    *   **Destructive Variant (`.destructive-action` class):**
+        *   Title color becomes `var(--destructive-color)`.
+*   **Theming:**
+    *   Background color from `var(--list-row-bg-color)`.
+    *   Interactive states use variables like `var(--list-row-hover-bg-color)`, `var(--list-row-active-bg-color)`.
+    *   Text colors primarily from `var(--window-fg-color)` and `var(--secondary-fg-color)`.
+
+Refer to `scss/_action_row.scss` and [Theming Reference](../general/theming.md) for full details.
 
 ---
 Next: [EntryRow](./entryrow.md)

--- a/adwaita-web/docs/widgets/alertdialog.md
+++ b/adwaita-web/docs/widgets/alertdialog.md
@@ -143,9 +143,18 @@ A declarative way to define Adwaita alert dialogs. This component internally use
 
 ## Styling
 
-*   Primary SCSS: `scss/_alert_dialog.scss` (which builds upon `scss/_dialog.scss`).
-*   Typically has a more focused layout than a generic `AdwDialog`, with clear visual separation for heading, body, and action buttons.
-*   Buttons are usually arranged in a specific order (e.g., cancel on the left, confirm on the right or destructive actions).
+*   **SCSS Source:** The specific styles for alert dialog content elements (like heading, body) are defined in `scss/_dialog.scss`. The `<adw-alert-dialog>` web component itself relies on the base `adw-dialog` styling for its container, also defined in `scss/_dialog.scss`.
+*   **Key CSS Classes (from `_dialog.scss`):**
+    *   When an `<adw-alert-dialog>` constructs its internal `<adw-dialog>`, its `heading` attribute typically maps to an element styled by `.adw-alert-dialog-heading`.
+    *   The `body` attribute or `body-content` slot maps to content styled by `.adw-alert-dialog-body`.
+    *   Slotted choice buttons are usually wrapped in a container styled by `.adw-alert-dialog-responses`.
+*   **Visual Appearance:**
+    *   The overall dialog frame (background, shadow, border-radius) is styled by the base `adw-dialog` rules.
+    *   Heading is centered and typically uses `var(--title-2-font-size)`.
+    *   Body text is centered and dimmed using `var(--dim-opacity)`.
+    *   Response buttons are arranged in a flex container, which can be vertical (default) or horizontal (if `.adw-alert-dialog-responses.horizontal` is used).
+
+Refer to [Dialog Styling](./dialog.md) for details on the base dialog container and the specific alert content classes.
 
 ---
 Next: [AboutDialog](./aboutdialog.md)

--- a/adwaita-web/docs/widgets/breakpointbin.md
+++ b/adwaita-web/docs/widgets/breakpointbin.md
@@ -144,9 +144,12 @@ A declarative way to use Adwaita breakpoint bins.
 
 ## Styling & Behavior
 
-*   Primary SCSS: `scss/_breakpoint_bin.scss`.
-*   The BreakpointBin itself is usually a simple container (`display: block;`).
-*   It uses a `ResizeObserver` (if available) to monitor its own width and dynamically change the `display` style of its children (setting `display: none` for hidden children and `display: ''` or `display: block` for the visible one).
+*   **Styling:** There is no dedicated SCSS file (`_breakpoint_bin.scss`) for `AdwBreakpointBin` itself in Adwaita Web. The component is primarily JavaScript-driven.
+    *   The `AdwBreakpointBin` container is typically a simple `div` (`display: block;`). Its own styling (borders, padding, etc.) should be applied manually or via utility classes if needed for visual presentation (as seen in the `index.html` showcase).
+    *   The appearance of the children is determined by their own content and styling.
+*   **Behavior:**
+    *   It uses a `ResizeObserver` (if available) to monitor its own width.
+    *   Based on its width, it dynamically changes the `display` style of its direct child elements that have `data-name` and `data-condition` attributes (setting `display: none` for hidden children and restoring the original display style or setting `display: block` for the visible one).
 *   Children are evaluated based on their `condition` (sorted by min-width), and the largest one that matches the current width is displayed.
 
 ---

--- a/adwaita-web/docs/widgets/button.md
+++ b/adwaita-web/docs/widgets/button.md
@@ -54,6 +54,28 @@ Apply these classes in addition to `adw-button`:
     <button class="adw-button disabled">CSS Disabled Button</button>
     ```
     *Note: Using the `disabled` attribute on the `<button>` element is the standard HTML way and is preferred for accessibility and behavior.*
+*   `.osd`: For On-Screen Display contexts, providing a style that contrasts well with varied backgrounds (typically dark and semi-transparent).
+    ```html
+    <button class="adw-button osd">OSD Button</button>
+    <button class="adw-button osd suggested-action">OSD Suggested</button>
+    ```
+*   `.small`: For a smaller version of the button.
+    ```html
+    <button class="adw-button small">Small Button</button>
+    <button class="adw-button small suggested-action icon-only" aria-label="Small Add">
+      <span class="adw-icon adw-icon-plus-symbolic"></span>
+    </button>
+    ```
+
+### Toggle Buttons and `.active` State
+Buttons can also represent a toggle state (on/off) by adding the `.active` class (often managed by JavaScript). `aria-pressed="true"` should be used for accessibility.
+
+```html
+<button class="adw-button active" aria-pressed="true">Active Toggle</button>
+<button class="adw-button flat active" aria-pressed="true">Flat Active Toggle</button>
+<button class="adw-button suggested-action active" aria-pressed="true">Suggested Active Toggle</button>
+```
+The `.active` class has specific styling in combination with `.flat`, `.suggested-action`, and `.destructive-action`.
 
 ### Icons in Buttons
 For icon buttons, include your icon element (e.g., `<span>` with icon font classes, or an inline `<svg>`) inside the button.

--- a/adwaita-web/docs/widgets/card.md
+++ b/adwaita-web/docs/widgets/card.md
@@ -1,0 +1,61 @@
+# Card CSS Styling (Adwaita Skin)
+
+Cards are surfaces that display content and actions on a single topic. They are typically used to group related information in a visually distinct way.
+
+## HTML Structure and CSS Classes
+
+To create a card, apply the `.adw-card` class to a `<div>` or other appropriate block element.
+
+**Basic Card:**
+```html
+<div class="adw-card">
+  <h3 class="adw-label title-3" style="margin-top:0;">Card Title</h3>
+  <p class="adw-label body">This is the content of the card.</p>
+  <div class="adw-button-row" style="justify-content: flex-end; margin-top: var(--spacing-m);">
+    <button class="adw-button flat">Action</button>
+  </div>
+</div>
+```
+
+## Modifier Classes
+
+*   `.activatable`: Apply to `.adw-card` to give it hover and active states, making it suitable for being clickable.
+    ```html
+    <div class="adw-card activatable">
+      <p class="adw-label body">This card is activatable. Click me!</p>
+    </div>
+    ```
+*   `.adw-button.card`: Apply the `.card` class to an `.adw-button` element to make the button itself look and behave like a card.
+    ```html
+    <button class="adw-button card">
+      <h4 class="adw-label title-4">Button as Card</h4>
+      <p class="adw-label body-small">This button takes up the full card space.</p>
+    </button>
+    ```
+
+## Styling & Theming
+
+*   **SCSS Source:** `scss/_card.scss`
+*   **Base Styling (via `mixins.apply-card-style`):**
+    *   Background: `var(--card-bg-color)`
+    *   Text Color: `var(--card-fg-color)`
+    *   Border Radius: `var(--border-radius-large)`
+    *   Padding: `var(--spacing-m)` (default internal padding)
+    *   Box Shadow: A standard card shadow (e.g., `var(--stronger-card-box-shadow)` which is `0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05)` or similar).
+*   **Activatable Cards:**
+    *   Hover: `background-color: rgba(var(--card-fg-color-rgb), 0.05);`
+    *   Active: `background-color: rgba(var(--card-fg-color-rgb), 0.08);`
+    *   Focus: Displays the standard focus ring (`var(--focus-ring-color)`) combined with the card's box shadow.
+*   **Button as Card (`.adw-button.card`):**
+    *   Resets default button appearance and adopts card styling (background, color, border-radius, shadow).
+    *   Its direct children will typically need their own padding if the button's default padding is removed. The SCSS example suggests `> * { padding: var(--spacing-m); }`.
+
+Refer to the [Theming Reference](../general/theming.md) and `scss/_variables.scss` for more details on the CSS variables used.
+
+## Interactivity
+
+*   For `.adw-card.activatable` or `.adw-button.card`, click event handling must be implemented with JavaScript.
+*   Content within a standard `.adw-card` (like buttons) follows normal interactivity rules.
+
+---
+Next: [HeaderBar](./headerbar.md)

--- a/adwaita-web/docs/widgets/comborow.md
+++ b/adwaita-web/docs/widgets/comborow.md
@@ -163,10 +163,33 @@ if(jsComboContainer) {
 
 ## Styling
 
-*   Primary SCSS: `scss/_combo_row.scss` (if exists), `scss/_row_types.scss`, and potentially styles for native `<select>` elements.
-*   The layout aligns the label part to the left and the select dropdown to the right.
-*   The standard Adwaita styling for `<select>` elements (often subtle, matching entry fields) will apply.
-*   Disabled state styles the entire row as inactive.
+*   **SCSS Sources:** `scss/_combo_row.scss` and the `AdwComboRow` section in `scss/_row_types.scss`.
+*   **Key Classes and Structure:**
+    *   The `.adw-combo-row` class is the main container, typically styled like an `AdwActionRow`.
+    *   **Manual HTML Structure (if not using Web Component):**
+        ```html
+        <div class="adw-combo-row">
+          <div class="adw-combo-row__text-content"> <!-- Or adw-action-row-content -->
+            <span class="adw-combo-row__title">Label Title</span>
+            <span class="adw-combo-row__subtitle">Optional Subtitle</span>
+          </div>
+          <select class="adw-combo-row-select">
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+          </select>
+          <!-- The chevron might be part of the select's default UI,
+               or could be a separate .adw-combo-row__button span if native arrow is hidden -->
+        </div>
+        ```
+    *   **Web Component `<adw-combo-row>`:** This component likely generates an internal structure that utilizes these (or similar) classes. Refer to its specific implementation if you need to target internal parts not exposed via attributes/properties.
+    *   `.adw-combo-row__title`, `.adw-combo-row__subtitle`: Style the text parts.
+    *   `.adw-combo-row-select` (from `_row_types.scss`): This class is crucial for styling the native `<select>` element. It gives it a subtle bottom border, removes default browser appearance for cleaner integration, and applies an accent color border on focus.
+    *   `.adw-combo-row__selected-value` (from `_combo_row.scss`): An optional element to display the selected value text separately, often to the right.
+    *   `.adw-combo-row__button` (from `_combo_row.scss`): Styles a chevron icon, useful if the native dropdown arrow of `<select>` is hidden (which is complex and often avoided for native `<select>`).
+*   **Theming:**
+    *   The row itself inherits ActionRow theming (background, hover, active states).
+    *   The `<select>` element (`.adw-combo-row-select`) uses `var(--borders-color)` for its bottom border and `var(--accent-color)` for the border on focus.
+    *   Disabled state styles the entire row and the select element as inactive (e.g., dashed border for select, opacity).
 
 ---
 Next: [ViewSwitcher](./viewswitcher.md)

--- a/adwaita-web/docs/widgets/dialog.md
+++ b/adwaita-web/docs/widgets/dialog.md
@@ -149,9 +149,35 @@ A declarative way to define Adwaita dialogs. This component does not use Shadow 
 
 ## Styling
 
-*   Primary SCSS: `scss/_dialog.scss` (and potentially `scss/_alert_dialog.scss` for specialized versions).
-*   Variables: Uses general theme variables from `scss/_variables.scss` (e.g., `--dialog-bg-color`, `--dialog-fg-color`, `--popover-bg-color` as dialogs are popover-like).
-*   The backdrop is styled via `.adw-dialog-backdrop`.
+*   **SCSS Source:** `scss/_dialog.scss`. This file styles the base `adw-dialog` (and `adw-about-dialog` host elements) and also includes specific styling for content typically found in alert dialogs.
+*   **Base Dialog Structure & Classes (for `<adw-dialog>` Web Component's Light DOM / Slots):**
+    *   Host: `adw-dialog` (or `adw-about-dialog`, `adw-preferences-dialog`). Styled as a modal overlay with background, shadow, and border radius.
+        *   `max-width`: Default is `550px`, can be overridden by specialized dialogs.
+        *   Animated with `opacity` and `transform: scale()` on open/close.
+    *   Header: A `div` with class `adw-dialog__header` (typically not directly slotted, but part of the WC's template if a title is provided).
+        *   Contains `h2.adw-dialog__title` for the dialog title.
+        *   Contains a close button (e.g., `.adw-dialog-close-button`).
+    *   Content Area: A `div` with class `adw-dialog-content` (content provided via the default slot or `slot="content"` goes here).
+        *   `padding: var(--spacing-l)`.
+    *   Footer: A `div` with class `adw-dialog-footer` (content provided via `slot="buttons"` goes here).
+        *   `padding: var(--spacing-m)`, `border-top`, `gap` for buttons.
+*   **Alert Dialog Content Classes (styled within `_dialog.scss` inside `.adw-dialog-content`):**
+    *   `.adw-alert-dialog-heading`: For the main heading of an alert.
+    *   `.adw-alert-dialog-body`: For the descriptive body text of an alert.
+    *   `.adw-alert-dialog-responses`: A flex container for alert buttons. Can be `.horizontal`.
+*   **Backdrop:**
+    *   Class: `.adw-dialog-backdrop`.
+    *   Covers the entire viewport behind the dialog.
+    *   Styled with `background-color: var(--dialog-backdrop-color)`.
+*   **Key Theming Variables:**
+    *   `--dialog-bg-color`, `--dialog-fg-color`
+    *   `--dialog-box-shadow`, `--window-radius` (for dialog corners)
+    *   `--dialog-backdrop-color`
+    *   `--z-index-dialog`, `--z-index-dialog-backdrop`
+    *   `--animation-duration-short`, `--animation-ease-out-cubic` (for open/close transitions)
+    *   Border colors use `var(--border-color)`.
+
+Specialized dialogs like `<adw-about-dialog>` and `<adw-preferences-dialog>` use these base dialog styles and add their own specific content styling (see `_about_dialog.scss`, `_preferences.scss`). `<adw-alert-dialog>` also uses the base `adw-dialog` and the alert-specific content classes from `_dialog.scss`.
 
 ---
-Next: [Avatar](./avatar.md)
+Next: [AlertDialog](./alertdialog.md)

--- a/adwaita-web/docs/widgets/entry.md
+++ b/adwaita-web/docs/widgets/entry.md
@@ -79,14 +79,16 @@ To add icons inside an entry (e.g., a search icon or a clear button), use the `.
 ## Styling & Theming
 
 *   **SCSS Source:** `scss/_entry.scss`
-*   **CSS Variables:** Entry styles are primarily determined by global CSS custom properties:
-    *   **Background:** `var(--view-bg-color)`
-    *   **Text Color:** `var(--window-fg-color)`
-    *   **Border:** `var(--border-color)` for the default state.
-    *   **Focus:** Border and focus ring use `var(--accent-color)`.
-    *   **Validation States:** Borders and focus rings use `var(--error-color)`, `var(--warning-color)`, or `var(--success-color)`.
+*   **Key Visual Aspects:**
+    *   **Appearance:** Entries have a subtle inset shadow (`box-shadow: inset 0 1px 1px var(--shade-color);`).
+    *   **Background:** `var(--view-bg-color)`.
+    *   **Text Color:** `var(--window-fg-color)`.
+    *   **Border:** `var(--border-width) solid var(--border-color)` for the default state.
+    *   **Focus:** Border color changes to `var(--accent-color)`, and an outer focus ring (`0 0 0 var(--focus-ring-width) var(--accent-color)`) is added while maintaining the inset shadow.
+    *   **Validation States:** Border and focus ring colors change to `var(--error-color)`, `var(--warning-color)`, or `var(--success-color)`.
     *   **Placeholder:** Uses `currentColor` with `opacity: 0.5`.
     *   **Disabled State:** Uses `var(--disabled-opacity)`.
+    *   **Specific Input Type Resets:** For `input[type="number"]` and `input[type="search"]`, default browser spinners and clear buttons (on WebKit/Blink) are removed for a cleaner look.
 
 Refer to the [Theming Reference](../general/theming.md) and `scss/_variables.scss` for more details.
 

--- a/adwaita-web/docs/widgets/expanderrow.md
+++ b/adwaita-web/docs/widgets/expanderrow.md
@@ -134,10 +134,36 @@ Log entry 3...</pre>
 
 ## Styling
 
-*   Primary SCSS: `scss/_expander_row.scss` (and inherits from `_listbox.scss` / `_row_types.scss`).
-*   Includes styling for the header part (title, subtitle, chevron icon) and the collapsible content area.
-*   The chevron icon rotates to indicate the expanded/collapsed state.
-*   The content area is typically hidden/shown using `display: none/block` or by adjusting `max-height` for CSS transitions.
+*   **SCSS Sources:** `scss/_expander_row.scss` and `scss/_row_types.scss` (for `AdwExpanderRow` sections).
+*   **Key Classes and Structure:**
+    *   `.adw-expander-row`: The main container for the expander row.
+        *   An inner element, typically an `<div class="adw-action-row activatable">`, serves as the clickable header.
+        *   Inside the header, an icon element (e.g., `<span class="adw-icon adw-expander-row-chevron"></span>`) displays the chevron. The chevron uses `pan-down-symbolic.svg` and rotates.
+            *   Default state (collapsed): Rotated -90 degrees (points right in LTR).
+            *   When `.adw-expander-row.expanded` or its header part has an `.expanded` class: Rotated 0 degrees (points down).
+    *   `.adw-expander-row-content`: The container for the collapsible content.
+        *   Hidden by default (e.g., `display: none` or `max-height: 0` with `overflow: hidden` and `opacity: 0`).
+        *   When the row is expanded (e.g., by adding an `.expanded` class to this element or its parent `.adw-expander-row`), it becomes visible (e.g., `display: block` or `max-height` increased, `opacity: 1`).
+        *   Styled with padding and a top border to separate it from the header.
+*   **CSS-Only Variant (`<details>`/`<summary>`):**
+    *   `_expander_row.scss` also includes styles for a CSS-only expander using the `<details>` HTML element with class `.adw-css-expander-row`.
+    *   The `<summary>` element is styled with `.adw-action-row` and gets a custom chevron via its `::after` pseudo-element.
+    *   The content within the `<details>` element (not the summary) should be wrapped in a `div` with class `.adw-expander-row-content` to pick up the correct styling.
+    ```html
+    <details class="adw-css-expander-row">
+      <summary class="adw-action-row activatable">
+        <span class="adw-action-row-title">CSS Expander Title</span>
+        <!-- The ::after pseudo-element on summary creates the chevron -->
+      </summary>
+      <div class="adw-expander-row-content">
+        <p>This content is revealed by the CSS-only expander.</p>
+      </div>
+    </details>
+    ```
+*   **Theming:**
+    *   `--expander-content-bg-color`: Background for the content area (defaults to `--window-bg-color`).
+    *   Chevron icon color is `currentColor` (inherited text color), opacity from `--icon-opacity`.
+    *   Animation uses `--animation-duration-short` and `--animation-ease-out-sine` or `--animation-ease-out-cubic`.
 
 ---
 Next: [SwitchRow](./switchrow.md) (as it's another common row type)

--- a/adwaita-web/docs/widgets/headerbar.md
+++ b/adwaita-web/docs/widgets/headerbar.md
@@ -108,14 +108,33 @@ A declarative way to define Adwaita header bars.
 
 ## Styling
 
-*   Primary SCSS: `scss/_headerbar.scss`
-*   Variables:
-    *   `--headerbar-bg-color`
-    *   `--headerbar-fg-color`
-    *   `--headerbar-border-color` (typically for the bottom border)
-    *   `--headerbar-shade-color` (used for subtle shadows or darker borders when scrolled)
-    *   `--headerbar-backdrop-color` (background when window is not focused, or for "transparent" header bars blending with content)
-*   The internal structure uses flexbox to arrange the start, center (title/subtitle), and end sections.
+*   **SCSS Source:** `scss/_headerbar.scss`
+*   **Key CSS Classes & Structure:**
+    *   `.adw-header-bar`: Main container element.
+        *   Background: `var(--headerbar-bg-color)`.
+        *   Text Color: `var(--headerbar-fg-color)`.
+        *   Bottom Border: `var(--border-width) solid var(--headerbar-shade-color)`.
+    *   `.adw-header-bar-start`: Container for elements at the start (left).
+    *   `.adw-header-bar-center-box`: Flex container for centered title and subtitle.
+        *   `.adw-header-bar-title`: For the main title text.
+        *   `.adw-header-bar-subtitle`: For the subtitle text (dimmed opacity).
+    *   `.adw-header-bar-end`: Container for elements at the end (right).
+*   **Button Styling:** Buttons placed directly in `.adw-header-bar-start` or `.adw-header-bar-end` are styled flat by default (transparent background, inherit header bar text color).
+    *   Use the `.raised` class on a button to make it retain its standard bordered/background appearance.
+    *   `suggested-action` and `destructive-action` buttons retain their specific styling.
+*   **States & Variants:**
+    *   `.scrolled` or `.raised-border`: Added to `.adw-header-bar` when content scrolls under it (e.g., in `AdwToolbarView`). Changes `border-bottom-color` to `var(--headerbar-darker-shade-color)`.
+    *   `.backdrop`: When the window is inactive, this class (or a parent `.window.backdrop`) changes the header bar's background to `var(--headerbar-backdrop-color)`.
+    *   `.flat` (DEPRECATED): Makes the header bar transparent with no border. `AdwToolbarView` should be used for this effect.
+    *   **Development Style:** If `.adw-header-bar` is inside an element with class `.devel`, it gets a striped background for visual distinction (e.g., for nightly application builds).
+*   **Theming Variables:**
+    *   `--headerbar-bg-color`, `--headerbar-fg-color`
+    *   `--headerbar-shade-color`, `--headerbar-darker-shade-color` (for borders)
+    *   `--headerbar-backdrop-color`
+    *   `--dim-opacity` (for subtitle)
+    *   Buttons use `var(--headerbar-fg-color-rgb)` for hover/active alpha overlays.
+
+Refer to `scss/_headerbar.scss` for detailed structure and variables.
 
 ---
 Next: [Window](./window.md)

--- a/adwaita-web/docs/widgets/listbox.md
+++ b/adwaita-web/docs/widgets/listbox.md
@@ -75,14 +75,40 @@ Various types of rows can be placed inside an `adw-list-box`. Each has its own s
 
 ## Styling & Theming
 
-*   **SCSS Source:** `scss/_listbox.scss`, `scss/_row_types.scss` (and individual row SCSS).
-*   **CSS Variables:**
-    *   **Default ListBox:** Uses `var(--view-bg-color)` for background, `var(--border-color)` for border. Row separators use `var(--list-separator-color)`.
-    *   **`.boxed-list`:** Uses `var(--card-bg-color)`, `var(--card-fg-color)`, and `var(--card-shade-color)` for its "inner border" shadow effect and row separators.
-    *   **Selected/Active Rows:** Typically use `var(--accent-bg-color)` and `var(--accent-fg-color)`.
-    *   **Row Hover:** `var(--list-row-hover-bg-color)`.
+*   **SCSS Source:** `scss/_listbox.scss`. Also see individual row SCSS files (e.g., `_action_row.scss`).
+*   **Key Visual Aspects:**
+    *   **Default ListBox:**
+        *   Background: `var(--view-bg-color)`.
+        *   Border: `var(--border-width) solid var(--border-color)`.
+        *   Shadow: `var(--subtle-box-shadow)` is applied unless it's `.flat` or `.boxed-list`.
+        *   Row separators: `var(--border-width) solid var(--list-separator-color)`.
+        *   First/last rows have `var(--border-radius-default)`.
+    *   **`.boxed-list`:**
+        *   Background: `var(--card-bg-color)`. Text color: `var(--card-fg-color)`.
+        *   Border: None. Uses a composite shadow: `0 0 0 var(--border-width) var(--card-shade-color)` (for an inner border effect) and an outer shadow (`0 1px 2px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.05)`).
+        *   Padding: None on the listbox itself; rows handle padding.
+        *   Row separators: `var(--border-width) solid var(--card-shade-color)`.
+        *   First/last rows have `var(--border-radius-large)`.
+    *   **`.boxed-list-separate`:**
+        *   ListBox itself is transparent and borderless.
+        *   Each child `.adw-row` is styled as a separate card (see `_card.scss`), with `margin-bottom: var(--spacing-s)` between them.
+    *   **`.flat`:**
+        *   Background, border, and shadow are removed from the listbox.
+        *   If also `.boxed-list`, it retains card-like separators. Otherwise, uses default list separators.
+        *   Rows within a flat listbox generally have no individual rounded corners.
+    *   **`.navigation-sidebar`:**
+        *   Background: `var(--sidebar-bg-color)`. Text color: `var(--sidebar-fg-color)`.
+        *   No borders or separators between rows.
+        *   Rows have `var(--border-radius-small)`.
+*   **Row States (General):**
+    *   **Hover:** `var(--list-row-hover-bg-color)`. Activatable rows might use `var(--list-row-active-bg-color)` for hover.
+    *   **Selected/Activated (`.selected`, `.activated` classes):**
+        *   Default listbox: `var(--list-row-selected-bg-color)` and `var(--list-row-selected-fg-color)` (typically accent colors).
+        *   Boxed list: `var(--accent-bg-color)` and `var(--accent-fg-color)`.
+        *   Navigation sidebar: `var(--accent-bg-color)` and `var(--accent-fg-color)`.
+    *   **Focus:** Activatable rows show a focus ring (`var(--focus-ring-width) solid var(--focus-ring-color)`), often slightly inset.
 
-Refer to the [Theming Reference](../general/theming.md) and relevant SCSS files for more details.
+Refer to the [Theming Reference](../general/theming.md) and `scss/_listbox.scss` for more details.
 
 ## Interactivity
 

--- a/adwaita-web/docs/widgets/popover.md
+++ b/adwaita-web/docs/widgets/popover.md
@@ -1,0 +1,96 @@
+# Popover CSS Styling (Adwaita Skin)
+
+Popovers are transient views that appear above other content, typically anchored to a specific UI element. They are used for menus, information bubbles, and other temporary interactions. Adwaita Skin provides CSS classes to style elements as Adwaita-compliant popovers.
+
+## HTML Structure and CSS Classes
+
+A basic popover structure involves a container element with the class `adw-popover`. This element is positioned by JavaScript. For visibility, the class `.open` is added.
+
+**Basic Popover Structure:**
+```html
+<div class="adw-popover" id="myPopover">
+  <!-- Popover content goes here -->
+  <div class="adw-popover-surface"> <!-- Optional: for content popovers that might have an arrow -->
+    <p>This is a popover!</p>
+  </div>
+</div>
+
+<button id="triggerButton" aria-haspopup="true" aria-controls="myPopover">Open Popover</button>
+```
+
+**Menu Popover Structure:**
+Popovers are commonly used for menus. In this case, the `.adw-popover` element itself often gets the `.menu` or `.menu-popover` class and contains an `adw-list-box` for menu items.
+
+```html
+<div class="adw-popover menu" id="myMenuPopover" role="menu">
+  <div class="adw-list-box flat"> <!-- Flat listbox is typical for menus -->
+    <div class="adw-action-row activatable" role="menuitem">
+      <span class="adw-action-row-title">Menu Item 1</span>
+    </div>
+    <div class="adw-action-row activatable" role="menuitem">
+      <span class="adw-action-row-title">Menu Item 2</span>
+    </div>
+    <hr class="popover-divider"> <!-- Optional divider -->
+    <div class="adw-action-row destructive-action activatable" role="menuitem">
+      <span class="adw-action-row-title">Close</span>
+    </div>
+  </div>
+</div>
+```
+
+## Modifier Classes
+
+*   `.adw-popover`: Base class for the popover container.
+    *   `.open`: Add this class (usually via JS) to make the popover visible and trigger animations.
+    *   `.menu` or `.menu-popover`: Apply to `.adw-popover` if it's directly acting as a menu surface. Styles background, shadow, and padding for menu items.
+*   `.adw-popover-surface`: (Optional) Use this class for a `div` inside `.adw-popover` if you need a distinct surface, especially for content popovers that might include an arrow.
+    *   `.menu`: If the `.adw-popover-surface` itself is the menu (less common than `.adw-popover.menu`).
+*   `.adw-popover-arrow`: (Optional) An element to display an arrow pointing from the popover to its anchor. Requires JavaScript for positioning and directional classes.
+    *   `.arrow-up`: Popover is below the target.
+    *   `.arrow-down`: Popover is above the target.
+    *   `.arrow-left`: Popover is to the right of the target.
+    *   `.arrow-right`: Popover is to the left of the target.
+
+## Styling & Theming
+
+*   **SCSS Source:** `scss/_popover.scss`
+*   **CSS Variables:**
+    *   `--popover-bg-color`: Background color of the popover.
+    *   `--popover-box-shadow`: Box shadow for the popover.
+    *   `--popover-shade-color`: Used for arrow borders if applicable.
+    *   `--z-index-popover`: Controls stacking order.
+    *   `--animation-duration-short`, `--animation-ease-out-cubic`: For open/close animations.
+    *   Menu items within popovers leverage ListBox and ActionRow variables for hover and selection (e.g., `var(--list-row-hover-bg-color)`, `var(--accent-bg-color)`).
+
+## Interactivity (JavaScript)
+
+Popovers heavily rely on JavaScript for:
+1.  **Positioning:** Calculating and setting the `top` and `left` (or `right`, `bottom`) properties relative to an anchor element.
+2.  **Visibility:** Toggling the `.open` class.
+3.  **Focus Management:** Moving focus into and out of the popover, and handling "click-away" to close.
+4.  **Arrow Positioning and Direction:** If using `.adw-popover-arrow`, JS needs to position it and apply the correct directional class (`.arrow-up`, etc.).
+
+**Example (Conceptual JavaScript for toggling):**
+```javascript
+const popover = document.getElementById('myPopover');
+const triggerButton = document.getElementById('triggerButton');
+
+triggerButton.addEventListener('click', () => {
+  // Basic toggle, actual positioning logic is more complex
+  popover.classList.toggle('open');
+  const isOpen = popover.classList.contains('open');
+  triggerButton.setAttribute('aria-expanded', isOpen.toString());
+  if (isOpen) {
+    // Position popover logic here...
+    // popover.style.left = ...;
+    // popover.style.top = ...;
+    popover.focus(); // Or focus first focusable element inside
+  }
+});
+
+// Add click-away listener, Escape key listener, etc.
+```
+The `index.html` in the root of this project contains a more concrete example of basic popover JS for demonstration.
+
+---
+Next: [Preferences Styling](./preferencesdialog.md) (or other relevant component)

--- a/adwaita-web/docs/widgets/switch.md
+++ b/adwaita-web/docs/widgets/switch.md
@@ -95,16 +95,50 @@ A declarative way to create Adwaita switches.
 </script>
 ```
 
-## Styling
+## HTML Structure (for CSS Styling)
 
-*   Primary SCSS: `scss/_switch.scss`
-*   Variables:
-    *   `--switch-knob-bg-color`, `--switch-slider-off-bg-color`.
-    *   Uses `--accent-bg-color` for the slider when the switch is active.
-    *   Disabled states use variables like `--switch-knob-disabled-bg-color`, `--switch-slider-disabled-off-bg-color`.
-*   The switch consists of a "slider" (the track) and a "knob" (the movable part).
-*   Visual state changes significantly between active/inactive and enabled/disabled states.
-*   Focus indicators are important for accessibility.
+The CSS for `.adw-switch` expects a specific HTML structure, which is typically encapsulated by the `<adw-switch>` web component or created by the JavaScript factory. If styling manually, it would look like:
+
+```html
+<label class="adw-switch">
+  <input type="checkbox"> <!-- The actual state holder -->
+  <span class="adw-switch-slider"></span> <!-- Visual representation of track and knob (via ::before) -->
+</label>
+```
+Or using a `div` as the root and associating a separate `<label>` using `for`:
+```html
+<div class="adw-switch">
+  <input type="checkbox" id="my-standalone-switch">
+  <span class="adw-switch-slider"></span>
+</div>
+<label for="my-standalone-switch">My Setting</label> <!-- Optional external label -->
+```
+
+## Styling Details
+
+*   **SCSS Source:** `scss/_switch.scss`
+*   **Key Components & States:**
+    *   `.adw-switch`: The main container. Defines width (44px) and height (24px).
+    *   `input[type="checkbox"]`: Hidden visually but holds the actual checked/unchecked state.
+    *   `.adw-switch-slider`: The visual track of the switch.
+        *   **Off State:** Background uses `var(--switch-slider-off-bg-color)`.
+        *   **On State (when `input:checked + .adw-switch-slider`):** Background uses `var(--accent-bg-color)`.
+        *   The knob is created using the `::before` pseudo-element of the slider.
+            *   Knob background: `var(--switch-knob-bg-color)`.
+            *   Knob moves via `transform: translateX(20px)` when checked.
+    *   **Disabled States:**
+        *   **Off & Disabled:** Slider uses `var(--switch-slider-disabled-off-bg-color)`. Knob uses `var(--switch-knob-disabled-bg-color)` and loses shadow.
+        *   **On & Disabled:** Slider uses `var(--accent-bg-color)` but with `var(--disabled-opacity)`. Knob color remains standard but loses shadow.
+    *   **Focus State (`input:focus-visible + .adw-switch-slider`):** An outline (`2px solid var(--accent-color)`) is applied to the slider.
+*   **Theming Variables:**
+    *   `--accent-bg-color` (for "on" track)
+    *   `--switch-slider-off-bg-color`
+    *   `--switch-knob-bg-color`
+    *   `--switch-slider-disabled-off-bg-color`
+    *   `--switch-knob-disabled-bg-color`
+    *   `--disabled-opacity`
+    *   `--accent-color` (for focus ring)
+*   Transitions are applied for smooth visual changes.
 
 ---
 Related: [SwitchRow](./switchrow.md) (uses `AdwSwitch`)

--- a/adwaita-web/docs/widgets/tabview.md
+++ b/adwaita-web/docs/widgets/tabview.md
@@ -199,13 +199,43 @@ The TabView system provides a way to manage multiple pages of content, where eac
 </script>
 ```
 
-## Styling
+## Styling Details
 
-*   `scss/_tabs.scss` is the primary file.
-*   `AdwTabBar` styles the container for tab buttons (flex layout, borders).
-*   `AdwTabButton` styles individual tabs (padding, borders, active state, close button).
-*   `AdwTabPage` is usually a simple block container, with `display: none` toggled by `AdwTabView`.
-*   `AdwTabView` structures the tab bar and content area.
+*   **SCSS Source:** `scss/_tabs.scss`
+*   **Key CSS Classes & Structure:**
+    *   **`.adw-tab-button`**:
+        *   Styles the individual tab. Rounded top corners, transparent background when inactive, dimmed text.
+        *   Padding: `var(--spacing-s) var(--spacing-m)`.
+        *   Margin: `margin-right: var(--spacing-xxs)` and negative bottom margin to overlap `AdwTabBar`'s border.
+        *   Hover: Opacity 1, subtle background (`rgba(var(--headerbar-fg-color-rgb), 0.05)`).
+        *   Active (`.active` class): Background `var(--view-bg-color)`, text `var(--accent-color)` (bold), full opacity. Border color `var(--headerbar-border-color)` on sides/top, bottom border blends with view background.
+        *   Focus: Inset box shadow using `var(--accent-color)`.
+        *   Internal Structure (assumed by SCSS for full styling):
+            *   `.adw-tab-button-content-wrapper`: Flex container for icon and label.
+            *   `.adw-tab-button-icon`: For an optional icon.
+            *   `.adw-tab-button-label`: For the text label (handles overflow with ellipsis).
+            *   `.adw-tab-button-close`: A close button (styled like a small, flat `.adw-button`).
+    *   **`.adw-tab-bar`**:
+        *   The container for tab buttons. Uses `flex` display.
+        *   Background: `var(--headerbar-bg-color)`, text `var(--headerbar-fg-color)`.
+        *   Padding: Horizontal `var(--spacing-s)`.
+        *   Border: `border-bottom: var(--border-width) solid var(--headerbar-border-color)`.
+        *   `.adw-tab-bar-new-tab-button`: A small, circular, flat icon button for adding new tabs.
+        *   `.inline` variant: Transparent background (or `var(--window-bg-color)`), standard border. Active tabs look more like toggle buttons.
+    *   **`.adw-tab-page`**:
+        *   Container for a single tab's content.
+        *   Padding: `var(--spacing-l)`.
+        *   Background: `var(--view-bg-color)`. Text: `var(--view-fg-color)`.
+        *   Typically `display: block; height: 100%; overflow: auto;`. Visibility controlled by JavaScript.
+    *   **`.adw-tab-view`**:
+        *   Main container, uses flex column layout for tab bar and page container.
+        *   Background: `var(--window-bg-color)`.
+        *   `.adw-tab-view-pages-container`: Wraps the tab pages, handles overflow, and uses `position: relative` for absolute positioning of pages if needed for transitions.
+        *   Active page (e.g., with `.active-page` class) is made visible.
+    *   **`.adw-tab-overview`**: Placeholder styles for a grid view of tab thumbnails.
+*   **Theming Variables:** Many variables from `_headerbar.scss` and `_view.scss` are reused (e.g., `--headerbar-bg-color`, `--view-bg-color`, `--accent-color`).
+
+Refer to `scss/_tabs.scss` for comprehensive styling details.
 
 ---
 Next: [NavigationView](./navigationview.md)

--- a/index.html
+++ b/index.html
@@ -168,6 +168,8 @@
         .icon-status-weather-clear-night-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/weather-clear-night-symbolic.svg"); mask-image: url("build/data/icons/symbolic/weather-clear-night-symbolic.svg");}
         .icon-status-avatar-default-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/avatar-default-symbolic.svg"); mask-image: url("build/data/icons/symbolic/avatar-default-symbolic.svg");}
         .icon-ui-view-more-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/view-more-symbolic.svg"); mask-image: url("build/data/icons/symbolic/view-more-symbolic.svg");}
+        .icon-actions-view-reveal-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/view-reveal-symbolic.svg"); mask-image: url("build/data/icons/symbolic/view-reveal-symbolic.svg"); }
+        .icon-actions-view-conceal-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/view-conceal-symbolic.svg"); mask-image: url("build/data/icons/symbolic/view-conceal-symbolic.svg"); }
         /* For icons that might be directly in symbolic/ (like pan-up, pan-down, window-close from logs) */
         .icon-pan-up-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/pan-up-symbolic.svg"); mask-image: url("build/data/icons/symbolic/pan-up-symbolic.svg"); }
         .icon-pan-down-symbolic { -webkit-mask-image: url("build/data/icons/symbolic/pan-down-symbolic.svg"); mask-image: url("build/data/icons/symbolic/pan-down-symbolic.svg"); }
@@ -278,6 +280,21 @@
                 <button class="adw-button pill">Pill Button 1</button>
                 <button class="adw-button pill active">Pill Active</button>
                  <button class="adw-button pill" disabled>Pill Disabled</button>
+            </div>
+            <h3 class="adw-label title-3">Small Buttons</h3>
+            <div class="control-group">
+                <button class="adw-button small">Small</button>
+                <button class="adw-button small suggested-action">Small Suggested</button>
+                <button class="adw-button small destructive-action">Small Destructive</button>
+                <button class="adw-button small flat"><span class="adw-icon icon-actions-view-refresh-symbolic"></span> Small Flat Icon</button>
+                <button class="adw-button small icon-only" aria-label="Small Icon"><span class="adw-icon icon-actions-system-search-symbolic"></span></button>
+            </div>
+            <h3 class="adw-label title-3">OSD (On-Screen Display) Buttons</h3>
+            <div class="control-group" style="background-color: #777; padding: var(--spacing-s); border-radius: var(--border-radius-small);">
+                <button class="adw-button osd">OSD Button</button>
+                <button class="adw-button osd suggested-action">OSD Suggested</button>
+                <button class="adw-button osd icon-only" aria-label="OSD Icon"><span class="adw-icon icon-status-weather-clear-night-symbolic"></span></button>
+                <button class="adw-button osd" disabled>OSD Disabled</button>
             </div>
         </section>
 
@@ -402,10 +419,17 @@
                     </div>
                 </div>
                 <div style="margin-bottom: var(--spacing-l);"> <!-- Added specific margin for better separation -->
-                    <h3 class="adw-label title-3">Toggle Buttons (Standalone)</h3>
-                    <button class="adw-button toggle">Toggle Me</button> <!-- Add .toggle class if needed, or rely on JS to add .active -->
-                    <button class="adw-button active" aria-pressed="true">Pressed Toggle</button>
-                    <button class="adw-button" disabled>Disabled Toggle</button>
+                    <h3 class="adw-label title-3">Toggle Buttons (Standalone - static <code>.active</code> state)</h3>
+                    <div class="control-group">
+                        <button class="adw-button active" aria-pressed="true">Active</button>
+                        <button class="adw-button flat active" aria-pressed="true">Flat Active</button>
+                        <button class="adw-button suggested-action active" aria-pressed="true">Suggested Active</button>
+                        <button class="adw-button flat suggested-action active" aria-pressed="true">Flat Suggested Active</button>
+                        <button class="adw-button destructive-action active" aria-pressed="true">Destructive Active</button>
+                        <button class="adw-button flat destructive-action active" aria-pressed="true">Flat Destructive Active</button>
+                        <button class="adw-button" aria-pressed="false">Inactive</button>
+                        <button class="adw-button" disabled aria-pressed="true">Disabled Active</button>
+                    </div>
 
                     <h3 class="adw-label title-3" style="margin-top:var(--spacing-s);">Toggle Group (Linked)</h3>
                     <div class="adw-toggle-group linked">
@@ -668,6 +692,14 @@
                 <span class="adw-label">Activatable Row</span>
                 <div style="flex-grow: 1;"></div>
                 <span class="adw-icon icon-actions-go-next-symbolic"></span>
+            </div>
+            <div class="adw-action-row activatable" style="margin-top: var(--spacing-s); border-radius: var(--border-radius-medium);">
+                <div class="adw-action-row-prefix"><span class="adw-icon icon-status-dialog-information-symbolic"></span></div>
+                <div class="adw-action-row-content">
+                    <div class="adw-action-row-title">Standalone Action Row</div>
+                    <div class="adw-action-row-subtitle">With prefix, content, and suffix</div>
+                </div>
+                <div class="adw-action-row-suffix"><span class="adw-icon icon-actions-go-next-symbolic"></span></div>
             </div>
         </section>
 


### PR DESCRIPTION
- Updated index.html showcase with OSD buttons, small buttons, toggle states, and new icon definitions.
- Created documentation for Popover and Card components.
- Updated existing widget documentation (Button, ListBox, ActionRow, Entry, Dialog, AlertDialog, HeaderBar, Switch, TabView, ExpanderRow, ComboRow, BreakpointBin) to align with SCSS and add missing details.
- Updated general documentation (Theming Guide, Usage Guide, Theming Reference) for accuracy and completeness.
- Added a new tutorial for creating a simple application interface with Adwaita Web.