### PR TITLE
Update JS factory documentation & remove non-existent ones

### DIFF
--- a/adwaita-web/docs/widgets/aboutdialog.md
+++ b/adwaita-web/docs/widgets/aboutdialog.md
@@ -1,91 +1,12 @@
 # AboutDialog
 
-An AboutDialog displays information about an application, such as its name, version, copyright, website, developers, and license.
+An AboutDialog displays information about an application, such as its name, version, copyright, website, developers, and license. Adwaita Web provides the `<adw-about-dialog>` Web Component for this purpose.
 
-## JavaScript Factory: `Adw.createAboutDialog()`
-
-Creates and manages an Adwaita-styled "About" dialog.
-
-**Signature:**
-
-```javascript
-Adw.createAboutDialog(options = {}) -> { dialog: HTMLDivElement, open: function, close: function }
-```
-
-**Parameters:**
-
-*   `options` (Object, required): Configuration options for the about dialog. Many fields are optional but providing more information makes the dialog richer.
-    *   `appName` (String, optional): The name of the application.
-    *   `appIcon` (String, optional): URL or CSS class for the application icon (small icon).
-    *   `logo` (String, optional): URL for a larger logo image displayed prominently.
-    *   `version` (String, optional): Application version string.
-    *   `copyright` (String, optional): Copyright information (e.g., "© 2023 Your Name").
-    *   `developerName` (String | Array<String>, optional): Name(s) of the primary
-        developer(s).
-    *   `website` (String, optional): URL of the application's or developer's website.
-    *   `websiteLabel` (String, optional): Custom label for the website link
-        (defaults to the URL itself).
-    *   `licenseType` (String, optional): SPDX license identifier (e.g., "MIT",
-        "GPL-3.0-or-later"). Will attempt to link to spdx.org.
-    *   `licenseText` (String, optional): The full text of the license, if not
-        using a standard SPDX type or for custom licenses. Often displayed in a
-        scrollable area or expander.
-    *   `comments` (String, optional): General comments or a brief description of the
-        application.
-    *   `developers` (Array<String>, optional): List of developers.
-    *   `designers` (Array<String>, optional): List of designers.
-    *   `documenters` (Array<String>, optional): List of documenters.
-    *   `translatorCredits` (String, optional): Credits for translators.
-    *   `artists` (Array<String>, optional): List of artists.
-    *   `acknowledgements` (Array<String | Object>, optional): List of
-        acknowledgements. Can be strings or objects like
-        `{title: "Group Name", names: ["Person A", "Library B"]}`.
-    *   `onClose` (Function, optional): Callback executed when the dialog is closed.
-
-**Returns:**
-
-*   An `Object` with dialog instance (`dialog`), `open()` and `close()` methods.
-
-**Example:**
-
-```html
-<div id="js-aboutdialog-trigger"></div>
-<script>
-  const triggerContainer = document.getElementById('js-aboutdialog-trigger');
-
-  const showAboutBtn = Adw.createButton("About This App (JS)", {
-    onClick: () => {
-      const aboutDialog = Adw.createAboutDialog({
-        appName: "My Awesome App",
-        appIcon: "app-demo/static/img/default_avatar.png", // Path to a small icon
-        logo: "app-demo/static/img/default_avatar.png",    // Path to a larger logo
-        version: "1.2.3",
-        copyright: "© 2023 Developer Name",
-        developerName: "The Developer Team",
-        website: "https://example.com",
-        websiteLabel: "Visit our Website",
-        comments: "This application helps you do amazing things with web " +
-                  "technologies, styled with Adwaita!",
-        licenseType: "GPL-3.0-or-later",
-        // licenseText: "Full license text here if not using SPDX or for custom details...",
-        developers: ["Dev A", "Dev B"],
-        designers: ["Designer X"],
-        acknowledgements: [
-            "Special thanks to the Adwaita-Web project.",
-            { title: "Powered By", names: ["Coffee", "Determination"] }
-        ],
-        onClose: () => console.log("About dialog closed.")
-      });
-      aboutDialog.open();
-    }
-  });
-  triggerContainer.appendChild(showAboutBtn);
-</script>
-```
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createAboutDialog()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the Web Component.)*
 
 ## Web Component: `<adw-about-dialog>`
 
-A declarative way to define Adwaita "About" dialogs.
+A declarative way to define Adwaita "About" dialogs. This component encapsulates the structure and behavior of an about dialog.
 
 **HTML Tag:** `<adw-about-dialog>`
 

--- a/adwaita-web/docs/widgets/actionrow.md
+++ b/adwaita-web/docs/widgets/actionrow.md
@@ -2,80 +2,31 @@
 
 An ActionRow is a specialized type of `AdwRow` designed for presenting an action or navigation item, often with a title, subtitle, and an optional icon or chevron. It's commonly used within an `AdwListBox`.
 
-## JavaScript Factory: `Adw.createActionRow()`
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createActionRow()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the CSS classes with manual HTML structure, or the `<adw-action-row>` Web Component if available.)*
 
-Creates an Adwaita-styled action row.
+## HTML Structure (for CSS Styling)
 
-**Signature:**
-
-```javascript
-Adw.createActionRow(options = {}) -> HTMLDivElement
-```
-
-**Parameters:**
-
-*   `options` (Object, optional): Configuration options:
-    *   `title` (String, required): The main title text of the row.
-    *   `subtitle` (String, optional): Additional descriptive text displayed
-        below the title.
-    *   `iconHTML` (String, optional): HTML string for an SVG icon or an icon font
-        class to be displayed at the start of the row. *Security: Ensure
-        trusted/sanitized HTML if user-supplied.*
-    *   `onClick` (Function, optional): Callback function executed when the row is
-        clicked. Makes the row interactive.
-    *   `showChevron` (Boolean, optional): If `true`, displays a chevron (navigation
-        arrow) at the end of the row, indicating it leads to another view.
-        Defaults to `false` but might be implied if `onClick` is present and
-        it's a navigation action.
-    *   `suffix` (HTMLElement, optional): An element to place at the end of the row,
-        before any chevron (e.g., a switch, a small button, a spinner).
-    *   `disabled` (Boolean, optional): If `true`, disables the row, making it
-        non-interactive and visually muted.
-
-**Returns:**
-
-*   `(HTMLDivElement)`: The created `<div>` element representing the action row.
-
-**Example:**
+To create an action row manually, you would typically use a `div` with the class `.adw-action-row` and structure its content using helper classes:
 
 ```html
-<div id="js-actionrow-listbox" style="max-width: 400px;">
-  <!-- AdwListBox would typically wrap these -->
+<div class="adw-action-row activatable">
+  <div class="adw-action-row-prefix">
+    <span class="adw-icon icon-settings-symbolic"></span> <!-- Example -->
+  </div>
+  <div class="adw-action-row-content">
+    <span class="adw-action-row-title">Settings</span>
+    <span class="adw-action-row-subtitle">Configure application preferences</span>
+  </div>
+  <div class="adw-action-row-suffix">
+    <span class="adw-icon adw-action-row-chevron"></span> <!-- Navigational chevron -->
+  </div>
 </div>
-<script>
-  const container = document.getElementById('js-actionrow-listbox');
-
-  // ActionRow for navigation
-  const networkRow = Adw.createActionRow({
-    title: "Network",
-    subtitle: "Wi-Fi, Ethernet, VPN",
-    // Example icon (details omitted for brevity)
-    iconHTML: '<svg viewBox="0 0 16 16"><path d="M8 0C3.582Z"/></svg>',
-    showChevron: true,
-    onClick: () => Adw.createToast("Navigate to Network Settings")
-  });
-  container.appendChild(networkRow);
-
-  // ActionRow with a suffix (e.g., a spinner)
-  const updateSpinner = Adw.createSpinner({ active: true, size: 'small' }); // Assuming AdwSpinner exists
-  const updatesRow = Adw.createActionRow({
-    title: "Software Updates",
-    subtitle: "Checking for updates...",
-    suffix: updateSpinner,
-    onClick: () => Adw.createToast("Checking for updates action...")
-  });
-  container.appendChild(updatesRow);
-
-  // Disabled ActionRow
-  const disabledRow = Adw.createActionRow({
-    title: "Advanced Settings",
-    subtitle: "Requires admin privileges",
-    disabled: true,
-    showChevron: true
-  });
-  container.appendChild(disabledRow);
-</script>
 ```
+*   Add `.activatable` if the row should have hover/active states and be clickable.
+*   `.adw-action-row-prefix`: For icons or widgets at the start.
+*   `.adw-action-row-content`: Wraps title and subtitle.
+*   `.adw-action-row-title`, `.adw-action-row-subtitle`: For text content.
+*   `.adw-action-row-suffix`: For icons (like chevrons) or widgets (like switches, spinners) at the end.
 
 ## Web Component: `<adw-action-row>`
 

--- a/adwaita-web/docs/widgets/avatar.md
+++ b/adwaita-web/docs/widgets/avatar.md
@@ -2,71 +2,30 @@
 
 Avatars are used to display a user's profile picture or a placeholder with initials. Adwaita-Web provides `Adw.createAvatar()` for JavaScript creation and the `<adw-avatar>` Web Component.
 
-## JavaScript Factory: `Adw.createAvatar()`
+Avatars are used to display a user's profile picture or a placeholder with initials. Adwaita Web provides styling for avatars via the `.adw-avatar` CSS class and an `<adw-avatar>` Web Component.
 
-Creates an Adwaita-styled avatar.
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createAvatar()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the CSS classes with manual HTML structure, or the `<adw-avatar>` Web Component.)*
 
-**Signature:**
+## HTML Structure (for CSS Styling)
 
-```javascript
-Adw.createAvatar(options = {}) -> HTMLDivElement
-```
-
-**Parameters:**
-
-*   `options` (Object, optional): Configuration options:
-    *   `size` (Number, optional): The size (width and height) of the avatar in pixels. Defaults to `48`.
-    *   `imageSrc` (String, optional): URL of the image to display. If not provided or if the image fails to load, text initials will be shown.
-    *   `text` (String, optional): Text to display as initials if no image is provided or loads. Typically 1 to 3 characters. If not provided, a generic icon might be shown (styling dependent).
-    *   `alt` (String, optional): Alternative text for the image, for accessibility. Defaults to "Avatar".
-    *   `backgroundColor` (String, optional): Custom background color for the avatar (e.g., if `imageSrc` is not set or fails).
-    *   `textColor` (String, optional): Custom text color for the initials.
-
-**Returns:**
-
-*   `(HTMLDivElement)`: The created avatar `<div>` element.
-
-**Example:**
+To create an avatar manually, you would use a `div` with the class `.adw-avatar` and potentially other size or content-specific classes or inline styles.
 
 ```html
-<div id="js-avatar-container" style="display: flex; align-items: center; gap: 10px;"></div>
-<script>
-  const container = document.getElementById('js-avatar-container');
+<!-- Avatar with image -->
+<div class="adw-avatar" style="width: 64px; height: 64px; background-image: url('path/to/image.png');"></div>
 
-  // Avatar with image
-  const avatarWithImage = Adw.createAvatar({
-    size: 64,
-    imageSrc: "app-demo/static/img/default_avatar.png", // Replace with a valid image path
-    alt: "User Avatar"
-  });
-  container.appendChild(avatarWithImage);
+<!-- Avatar with text initials -->
+<div class="adw-avatar" style="width: 48px; height: 48px; background-color: var(--accent-bg-color);">
+  <span class="adw-avatar-text" style="color: var(--accent-fg-color); font-size: 18px;">JD</span>
+</div>
 
-  // Avatar with text initials
-  const avatarWithText = Adw.createAvatar({
-    size: 48,
-    text: "JD", // John Doe
-    backgroundColor: "var(--accent-bg-color)", // Use theme accent
-    textColor: "var(--accent-fg-color)"
-  });
-  container.appendChild(avatarWithText);
-
-  // Smaller avatar with text
-  const smallAvatar = Adw.createAvatar({
-    size: 32,
-    text: "A"
-  });
-  container.appendChild(smallAvatar);
-
-  // Avatar that will show fallback (if image path is wrong)
-  const fallbackAvatar = Adw.createAvatar({
-    size: 48,
-    imageSrc: "path/to/nonexistent-image.png",
-    text: "??",
-    alt: "Fallback Avatar"
-  });
-  container.appendChild(fallbackAvatar);
-</script>
+<!-- Avatar with an icon (ensure icon is styled and sized appropriately) -->
+<div class="adw-avatar size-32"> <!-- .size-32 is an example utility or direct style -->
+  <span class="adw-icon icon-status-avatar-default-symbolic"></span>
+</div>
 ```
+*   The `adw-avatar-text` class can be used for text initials, which then needs to be sized and centered.
+*   Specific sizes (like `.size-24`, `.size-32`, etc.) are defined in `_avatar.scss` or can be set with inline styles.
 
 ## Web Component: `<adw-avatar>`
 

--- a/adwaita-web/docs/widgets/banner.md
+++ b/adwaita-web/docs/widgets/banner.md
@@ -2,66 +2,70 @@
 
 An `AdwBanner` is a prominent message area typically displayed at the top of a
 view or window, used for important announcements or status messages that require
-user attention but are not necessarily modal. Adwaita-Web provides
-`Adw.createBanner()` and the `<adw-banner>` Web Component.
+user attention but are not necessarily modal.
 
-## JavaScript Factory: `Adw.createBanner()`
+Adwaita Web provides styling for banners via the `.adw-banner` CSS class and helper JavaScript functions in `adwaita-web/js/banner.js` to initialize their interactivity (e.g., dismissal). There isn't a direct JavaScript factory like `Adw.createBanner()` for programmatic creation; banners are typically defined in HTML.
 
-Creates an Adwaita-styled banner element.
+## HTML Structure
 
-**Signature:**
-
-```javascript
-Adw.createBanner(title, options = {}) -> HTMLElement
-```
-
-**Parameters:**
-
-*   `title` (String): The main text to display in the banner. HTML can be used if
-    `useMarkup` is true.
-*   `options` (Object, optional): Configuration options:
-    *   `useMarkup` (Boolean, optional): If `true`, the `title` string is treated
-        as HTML. Defaults to `false`. **Use with caution and ensure any HTML is
-        sanitized if from user input.**
-    *   `buttonLabel` (String, optional): If provided, a button with this label is
-        added to the banner.
-    *   `onButtonClicked` (Function, optional): A callback function executed when
-        the button is clicked. The banner instance is passed as an argument.
-    *   `type` (String, optional): Sets the visual style of the banner. Common types
-        could be `'info'`, `'warning'`, `'error'`, `'success'`. This usually
-        applies a corresponding CSS class (e.g., `adw-banner-warning`). Defaults
-        to a neutral/info style.
-    *   `id` (String, optional): A specific ID to set on the banner element.
-
-**Returns:**
-
-*   `(HTMLElement)`: The created banner element (typically a `div` with class `adw-banner`).
-
-**Example:**
+To create a banner, you would typically use the following HTML structure:
 
 ```html
-<div id="banner-container"></div>
-<script>
-  const container = document.getElementById('banner-container');
+<div class="adw-banner [type-class]" role="status">
+  <div class="adw-banner__content">
+    <span class="adw-icon [icon-class]"></span> <!-- Optional icon -->
+    <p class="adw-label body">Your banner message here.</p>
+  </div>
+  <div class="adw-banner__actions">
+    <!-- Optional action button -->
+    <button class="adw-button flat">Action</button>
+    <!-- Dismiss button (functionality initialized by banner.js) -->
+    <button class="adw-button flat adw-banner-dismiss-button">Dismiss</button>
+  </div>
+</div>
+```
+*   Apply `.adw-banner` to the main container.
+*   Optional type classes: `.info`, `.warning`, `.error`, `.success` (these might need to be defined in `_banner.scss` or use existing status color variables). The `index.html` showcase uses `.warning` as an example.
+*   `.adw-banner__content`: Wraps the icon and message.
+*   `.adw-banner__actions`: Wraps action and dismiss buttons.
+*   A dismiss button should have class `.adw-banner-dismiss-button` or `.adw-banner-dismiss` for `banner.js` to make it functional.
 
-  const infoBanner = Adw.createBanner("This is an informational banner.");
-  container.appendChild(infoBanner);
+## JavaScript Initialization (`banner.js`)
 
-  const actionBanner = Adw.createBanner("Your session will expire soon.", {
-    buttonLabel: "Renew Session",
-    type: "warning",
-    onButtonClicked: (banner) => {
-      console.log("Renew Session clicked!");
-      banner.remove(); // Example: dismiss banner on action
-    }
-  });
-  container.appendChild(actionBanner);
-</script>
+The `adwaita-web/js/banner.js` script provides:
+*   `Adw.initBanners()`: Call this function (it's also called automatically on DOMContentLoaded) to find all `.adw-banner` elements and attach click listeners to their dismiss buttons.
+*   `Adw.dismissBanner(bannerElement)`: A function to programmatically dismiss a banner.
+
+**Example (HTML and JS Interaction):**
+
+```html
+<div id="banner-container">
+  <div class="adw-banner warning" role="alert">
+    <div class="adw-banner__content">
+      <span class="adw-icon icon-status-dialog-warning-symbolic"></span>
+      <p class="adw-label body">This is a warning banner that can be dismissed.</p>
+    </div>
+    <div class="adw-banner__actions">
+      <button class="adw-button flat adw-banner-dismiss-button">Dismiss</button>
+    </div>
+  </div>
+</div>
+
+<script src="path/to/adwaita-web/js/banner.js"></script>
+<!-- Adw.initBanners() is called automatically by banner.js -->
 ```
 
-## Web Component: `<adw-banner>`
+## Web Component: `<adw-banner>` (If Available)
 
-A declarative way to create Adwaita banners.
+(This section describes a hypothetical Web Component. If `adwaita-web/js/banner.js` or another file defines an `<adw-banner>` custom element, its specific API would be documented here. Based on current findings, `banner.js` focuses on initializing HTML-defined banners.)
+
+If a Web Component `adw-banner` exists, it would likely encapsulate the HTML structure and dismissal logic. Example hypothetical usage:
+```html
+<!-- Hypothetical <adw-banner> Web Component -->
+<adw-banner title="Welcome to Adwaita-Web!" type="info" closable button-label="Learn More"></adw-banner>
+```
+*Check the `adwaita-web/js/` directory for a definition of `<adw-banner>` if you intend to use it as a Web Component.*
+For now, primary usage is via HTML structure and `banner.js` initialization.
 
 **HTML Tag:** `<adw-banner>`
 

--- a/adwaita-web/docs/widgets/checkbox.md
+++ b/adwaita-web/docs/widgets/checkbox.md
@@ -1,66 +1,18 @@
 # Checkbox
 
-An AdwCheckbox is a standard checkbox input that allows users to select or deselect an option. It can be used standalone or in groups.
+An AdwCheckbox is a standard checkbox input that allows users to select or deselect an option. It can be used standalone or in groups. Adwaita Web provides styling for checkboxes via the `.adw-checkbox` class (and wrapper) and an `<adw-checkbox>` Web Component.
 
-## JavaScript Factory: `Adw.createCheckbox()`
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createCheckbox()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the CSS classes with the specified HTML structure, or the `<adw-checkbox>` Web Component.)*
 
-Creates an Adwaita-styled checkbox.
+## HTML Structure (for CSS Styling)
 
-**Signature:**
-
-```javascript
-Adw.createCheckbox(options = {}) -> HTMLLabelElement (wrapper)
-```
-
-**Parameters:**
-
-*   `options` (Object, optional): Configuration options:
-    *   `label` (String, optional): Text label to display next to the checkbox.
-    *   `checked` (Boolean, optional): Initial checked state. Defaults to `false`.
-    *   `disabled` (Boolean, optional): If `true`, disables the checkbox. Defaults to `false`.
-    *   `name` (String, optional): The `name` attribute for the underlying `<input type="checkbox">`.
-    *   `value` (String, optional): The `value` attribute for the input. Defaults to "on".
-    *   `onChanged` (Function, optional): Callback function executed when the checkbox state changes. Receives the `change` event as an argument, so `event.target.checked` gives the new state.
-
-**Returns:**
-
-*   `(HTMLLabelElement)`: The created `<label>` element which wraps the actual `<input type="checkbox">` and its visual representation.
-
-**Example:**
+To style a checkbox manually, you typically wrap an `<input type="checkbox">` and its label text within a `<label>` element that has the `.adw-checkbox-wrapper` class. The input itself gets the `.adw-checkbox` class.
 
 ```html
-<div id="js-checkbox-container" style="padding: 10px; display: flex; flex-direction: column; gap: 10px;"></div>
-<script>
-  const container = document.getElementById('js-checkbox-container');
-
-  // Checkbox with label
-  const rememberMeCheck = Adw.createCheckbox({
-    label: "Remember me on this computer",
-    name: "remember",
-    onChanged: (event) => Adw.createToast(`Remember me: ${event.target.checked}`)
-  });
-  container.appendChild(rememberMeCheck);
-
-  // Checked and disabled checkbox
-  const termsCheck = Adw.createCheckbox({
-    label: "I agree to the terms (already agreed)",
-    checked: true,
-    disabled: true,
-    name: "terms_agreed"
-  });
-  container.appendChild(termsCheck);
-
-  // Standalone checkbox (no label text via options)
-  const standaloneCheck = Adw.createCheckbox({
-    checked: false,
-    onChanged: (e) => console.log("Standalone checked:", e.target.checked)
-  });
-  // You might wrap this with an external label:
-  const externalLabel = Adw.createLabel("Enable option: ", {htmlTag: 'span'});
-  const box = Adw.createBox({children: [externalLabel, standaloneCheck], align: "center"});
-  container.appendChild(box)
-
-</script>
+<label class="adw-checkbox-wrapper">
+  <input type="checkbox" class="adw-checkbox" name="option1" value="value1">
+  Option Text
+</label>
 ```
 
 ## Web Component: `<adw-checkbox>`

--- a/adwaita-web/docs/widgets/comborow.md
+++ b/adwaita-web/docs/widgets/comborow.md
@@ -9,6 +9,8 @@ inside an `AdwListBox`.
 
 Adwaita-Web provides the `<adw-combo-row>` Web Component for creating this type of row.
 
+*(Note: Previous versions of this documentation may have described or implied a JavaScript factory like `Adw.createComboRow()`. As of the current review, a direct factory function for ComboRow was not found in the core `adwaita-web/js` source. Usage should primarily rely on the `<adw-combo-row>` Web Component or by applying CSS classes to a manually constructed HTML structure as detailed in the "Styling" section.)*
+
 **HTML Tag:** `<adw-combo-row>`
 
 **Attributes:**
@@ -91,75 +93,6 @@ Adwaita-Web provides the `<adw-combo-row>` Web Component for creating this type 
 
 </script>
 ```
-
-## JavaScript Factory Approach (Composite)
-
-A dedicated `Adw.createComboRow()` might not be available. If so, you would construct it by combining `Adw.createRow`, labels, and a styled `<select>` element.
-
-**Conceptual Example:**
-
-```javascript
-function createCustomComboRow(options = {}) {
-  const titleLabel = Adw.createLabel(options.title || "", { htmlTag: "span" });
-  titleLabel.classList.add("adw-combo-row-title"); // Or appropriate class
-
-  const textContentDiv = document.createElement("div");
-  textContentDiv.classList.add("adw-combo-row-text-content");
-  textContentDiv.appendChild(titleLabel);
-
-  if (options.subtitle) {
-    const subtitleLabel = Adw.createLabel(options.subtitle, { htmlTag: "span" });
-    subtitleLabel.classList.add("adw-combo-row-subtitle");
-    textContentDiv.appendChild(subtitleLabel);
-  }
-
-  const selectEl = document.createElement('select');
-  selectEl.classList.add('adw-combo-row-select'); // Ensure this class is styled
-  if (options.selectOptions && Array.isArray(options.selectOptions)) {
-    options.selectOptions.forEach(opt => {
-      const optionEl = document.createElement('option');
-      optionEl.value = opt.value;
-      optionEl.textContent = opt.label;
-      selectEl.appendChild(optionEl);
-    });
-  }
-  if (options.value) selectEl.value = options.value;
-  if (options.disabled) selectEl.disabled = true; // Disable select only
-
-  selectEl.addEventListener('change', () => {
-    if (options.onChanged) {
-      options.onChanged(selectEl.value);
-    }
-  });
-
-  const row = Adw.createRow({
-    children: [textContentDiv, selectEl],
-    disabled: options.disabled || false // Disables the whole row
-  });
-  row.classList.add('adw-combo-row');
-  if(options.disabled) row.classList.add('disabled');
-
-  // Add methods to mimic WC properties
-  row.getValue = () => selectEl.value;
-  row.setValue = (val) => { selectEl.value = val; };
-  // ... and for selectOptions, disabled
-
-  return row;
-}
-
-// Usage:
-const jsComboContainer = document.getElementById('js-comborow-container'); // Assuming div exists
-if(jsComboContainer) {
-    const myJsComboRow = createCustomComboRow({
-        title: "JS Combo Row",
-        selectOptions: [ {label: "Yes", value: "yes"}, {label: "No", value: "no"}],
-        value: "no",
-        onChanged: (value) => Adw.createToast(`JS Combo selected: ${value}`)
-    });
-    jsComboContainer.appendChild(myJsComboRow);
-}
-```
-*The `<adw-combo-row>` Web Component encapsulates this logic.*
 
 ## Styling
 

--- a/adwaita-web/docs/widgets/expanderrow.md
+++ b/adwaita-web/docs/widgets/expanderrow.md
@@ -2,69 +2,35 @@
 
 An ExpanderRow is a row that can be expanded or collapsed to reveal or hide additional content. It typically displays a title, an optional subtitle, and an expander icon (chevron).
 
-## JavaScript Factory: `Adw.createExpanderRow()`
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createExpanderRow()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the CSS classes with manual HTML structure, or the `<adw-expander-row>` Web Component.)*
 
-Creates an Adwaita-styled expander row.
+## HTML Structure (for CSS Styling)
 
-**Signature:**
-
-```javascript
-Adw.createExpanderRow(options = {}) -> HTMLDivElement
-```
-
-**Parameters:**
-
-*   `options` (Object, optional): Configuration options:
-    *   `title` (String, required): The main title text of the row.
-    *   `subtitle` (String, optional): Additional descriptive text displayed below the title.
-    *   `content` (HTMLElement, optional): The HTML element to be revealed when the row is expanded. *Security: Ensure content is trusted/sanitized.*
-    *   `expanded` (Boolean, optional): If `true`, the row is initially expanded. Defaults to `false`.
-    *   `onToggled` (Function, optional): Callback function executed when the row's expanded state changes. Receives a boolean argument indicating the new `expanded` state.
-    *   `disabled` (Boolean, optional): If `true`, disables the row, preventing expansion/collapse.
-
-**Returns:**
-
-*   `(HTMLDivElement)`: The created `<div>` element representing the expander row. It will have methods like `setExpanded(boolean)` and `isExpanded()` if not part of the base HTMLElement prototype.
-
-**Example:**
-
+To create an expander row manually for CSS styling, you would use a structure like:
 ```html
-<div id="js-expanderrow-listbox" style="max-width: 450px;">
-  <!-- AdwListBox would typically wrap these -->
+<div class="adw-expander-row">
+  <div class="adw-action-row activatable"> <!-- This is the clickable header -->
+    <span class="adw-action-row-title">Expander Title</span>
+    <div style="flex-grow: 1;"></div> <!-- Spacer -->
+    <span class="adw-icon adw-expander-row-chevron"></span>
+  </div>
+  <div class="adw-expander-row-content">
+    <p>This is the content that expands.</p>
+  </div>
 </div>
-<script>
-  const container = document.getElementById('js-expanderrow-listbox');
+```
+JavaScript is required to toggle an `.expanded` class on `.adw-expander-row` or `.adw-expander-row-content` to control visibility and chevron rotation.
 
-  // Create content for the expander
-  const detailsContent = document.createElement('div');
-  // Indent content for visual hierarchy
-  detailsContent.style.padding = "var(--spacing-s) 0 0 var(--spacing-l)";
-  detailsContent.innerHTML = `
-    <p>This is the detailed content that was hidden.</p>
-    <adw-entry placeholder="Enter detail..."></adw-entry>
-  `;
-
-  const expanderRow = Adw.createExpanderRow({
-    title: "Advanced Settings",
-    subtitle: "Click to see more options",
-    content: detailsContent,
-    expanded: false,
-    onToggled: (isExpanded) => {
-      Adw.createToast(`Expander is now ${isExpanded ? 'open' : 'closed'}`);
-    }
-  });
-  container.appendChild(expanderRow);
-
-  // Initially expanded row
-  const initiallyExpandedContent = Adw.createLabel("This content is visible by default.");
-  initiallyExpandedContent.style.padding = "var(--spacing-s) 0 0 var(--spacing-l)";
-  const autoExpandedRow = Adw.createExpanderRow({
-    title: "Visible Details",
-    content: initiallyExpandedContent,
-    expanded: true
-  });
-  container.appendChild(autoExpandedRow);
-</script>
+Alternatively, for a CSS-only solution, use the `<details>` and `<summary>` elements:
+```html
+<details class="adw-css-expander-row">
+  <summary class="adw-action-row activatable">
+    <span class="adw-action-row-title">CSS Expander Title</span>
+  </summary>
+  <div class="adw-expander-row-content">
+    <p>This content is revealed by the CSS-only expander.</p>
+  </div>
+</details>
 ```
 
 ## Web Component: `<adw-expander-row>`

--- a/adwaita-web/docs/widgets/headerbar.md
+++ b/adwaita-web/docs/widgets/headerbar.md
@@ -1,70 +1,31 @@
 # HeaderBar
 
-A HeaderBar is a crucial component in Adwaita applications, typically appearing at the top of a window or view, containing a title and actions. Adwaita-Web provides `Adw.createHeaderBar()` and the `<adw-header-bar>` Web Component.
+A HeaderBar is a crucial component in Adwaita applications, typically appearing at the top of a window or view, containing a title and actions. Adwaita Web provides styling for header bars via the `.adw-header-bar` CSS class and an `<adw-header-bar>` Web Component.
 
-## JavaScript Factory: `Adw.createHeaderBar()`
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createHeaderBar()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the CSS classes with manual HTML structure, or the `<adw-header-bar>` Web Component.)*
 
-Creates an Adwaita-styled header bar.
+## HTML Structure (for CSS Styling)
 
-**Signature:**
-
-```javascript
-Adw.createHeaderBar(options = {}) -> HTMLElement
-```
-
-**Parameters:**
-
-*   `options` (Object, optional): Configuration options:
-    *   `title` (String, optional): Main title text for the header bar.
-    *   `subtitle` (String, optional): Subtitle text, displayed below the main title.
-    *   `start` (Array<HTMLElement>, optional): An array of HTML elements (e.g., `Adw.createButton()`) to place at the start (left side) of the header bar.
-    *   `end` (Array<HTMLElement>, optional): An array of HTML elements to place at the end (right side) of the header bar.
-
-**Returns:**
-
-*   `(HTMLElement)`: The created `<header>` element representing the header bar. This element will have methods like `updateTitleSubtitle(title, subtitle)`, `setStartWidgets(widgetsArray)`, and `setEndWidgets(widgetsArray)` monkey-patched onto it if they don't exist, allowing dynamic updates.
-
-**Example:**
-
+To create a header bar manually using CSS classes, structure your HTML like this:
 ```html
-<div id="js-headerbar-container">
-  <!-- This container will house a full window structure usually -->
-</div>
-<script>
-  const container = document.getElementById('js-headerbar-container');
-
-  const backButton = Adw.createButton("", {
-    icon: '<svg viewBox="0 0 16 16"><path d="M12 8a.5.5Z"/></svg>', // Left arrow (shortened)
-    flat: true,
-    onClick: () => Adw.createToast("Back button clicked")
-  });
-
-  const menuButton = Adw.createButton("", {
-    icon: '<svg viewBox="0 0 16 16"><path d="M2.5 12a.5.5Z"/></svg>', // Menu icon (shortened)
-    flat: true,
-    onClick: () => Adw.createToast("Menu button clicked")
-  });
-
-  const myHeaderBar = Adw.createHeaderBar({
-    title: "My Application",
-    subtitle: "Current View",
-    start: [backButton],
-    end: [menuButton]
-  });
-  container.appendChild(myHeaderBar); // Typically, a header bar is part of an AdwWindow
-
-  // Example of updating title dynamically
-  setTimeout(() => {
-    if (myHeaderBar.updateTitleSubtitle) { // Check if method exists
-        myHeaderBar.updateTitleSubtitle("Updated Title", "New Subtitle");
-    } else { // Fallback for older versions or direct manipulation
-        const titleEl = myHeaderBar.querySelector('.adw-header-bar-title');
-        const subtitleEl = myHeaderBar.querySelector('.adw-header-bar-subtitle');
-        if (titleEl) titleEl.textContent = "Updated Title";
-        if (subtitleEl) subtitleEl.textContent = "New Subtitle";
-    }
-  }, 2000);
-</script>
+<header class="adw-header-bar">
+  <div class="adw-header-bar-start">
+    <!-- Start items, e.g., back button -->
+    <button class="adw-button circular flat" aria-label="Back">
+      <span class="adw-icon icon-actions-go-previous-symbolic"></span>
+    </button>
+  </div>
+  <div class="adw-header-bar-center-box">
+    <h1 class="adw-header-bar-title">Page Title</h1>
+    <h2 class="adw-header-bar-subtitle">Optional Subtitle</h2>
+  </div>
+  <div class="adw-header-bar-end">
+    <!-- End items, e.g., action buttons -->
+    <button class="adw-button flat" aria-label="Menu">
+      <span class="adw-icon icon-actions-open-menu-symbolic"></span>
+    </button>
+  </div>
+</header>
 ```
 
 ## Web Component: `<adw-header-bar>`

--- a/adwaita-web/docs/widgets/label.md
+++ b/adwaita-web/docs/widgets/label.md
@@ -1,79 +1,18 @@
 # Label
 
-An `AdwLabel` is used to display text. It can be configured for various text behaviors like wrapping, justification, and ellipsization. Adwaita-Web provides `Adw.createLabel()` and the `<adw-label>` Web Component.
+An `AdwLabel` is used to display text. It can be configured for various text behaviors like wrapping, justification, and ellipsization. Adwaita Web provides CSS classes like `.adw-label` and its variants (e.g., `.title-1`, `.dim-label`) for styling text, and an `<adw-label>` Web Component.
 
-## JavaScript Factory: `Adw.createLabel()`
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createLabel()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on applying CSS classes to standard HTML text elements like `<span>`, `<p>`, `<label>`, or by using the `<adw-label>` Web Component.)*
 
-Creates an Adwaita-styled label.
+## HTML Structure (for CSS Styling)
 
-**Signature:**
-
-```javascript
-Adw.createLabel(text, options = {}) -> HTMLLabelElement | HTMLSpanElement
-```
-*(Returns `HTMLLabelElement` if `mnemonicFor` is provided, otherwise `HTMLSpanElement`)*
-
-**Parameters:**
-
-*   `text` (String): The text content of the label.
-*   `options` (Object, optional): Configuration options:
-    *   `mnemonicFor` (String, optional): The ID of an activatable widget that
-        this label is for. If provided, an `<label>` element is created with a
-        `for` attribute, and the first character of the text that can be a
-        mnemonic will be underlined.
-    *   `selectable` (Boolean, optional): If `true`, allows the text to be
-        selected by the user. Defaults to `false`.
-    *   `wrap` (Boolean, optional): If `true`, the text will wrap if it exceeds the
-        available width. Defaults to `false`. CSS `white-space: normal` is
-        applied.
-    *   `lines` (Number, optional): The number of lines to display. If set, and
-        text exceeds this, ellipsization might occur based on `ellipsize` mode
-        (though primarily works with `wrap: true`).
-    *   `justify` (String, optional): Text alignment. Accepts `'left'`, `'center'`,
-        `'right'`, `'fill'`. Defaults to `'left'`. (CSS `text-align`)
-    *   `ellipsize` (String, optional): How to ellipsize text if it overflows.
-        Accepts `'none'`, `'start'`, `'middle'`, `'end'`. Defaults to `'none'`.
-        (CSS `text-overflow`, often requires `overflow: hidden` and
-        `white-space: nowrap` or line-clamping for multi-line)
-    *   `cssClass` (Array<String>, optional): Additional CSS classes to apply to
-        the label element.
-    *   `id` (String, optional): A specific ID to set on the label element.
-
-**Returns:**
-
-*   `(HTMLLabelElement | HTMLSpanElement)`: The created label element.
-
-**Example:**
+You can style various HTML elements as labels by applying the `.adw-label` class and modifier classes.
 
 ```html
-<div id="js-label-container" style="width: 200px; border: 1px solid #ccc;"></div>
-<input type="text" id="my-input" />
-<script>
-  const container = document.getElementById('js-label-container');
-
-  const simpleLabel = Adw.createLabel("This is a simple label.");
-  container.appendChild(simpleLabel);
-  container.appendChild(document.createElement('br'));
-
-  const wrappedLabel = Adw.createLabel(
-    "This is a longer label that will wrap within its container.",
-    { wrap: true }
-  );
-  container.appendChild(wrappedLabel);
-  container.appendChild(document.createElement('br'));
-
-  const selectableLabel = Adw.createLabel(
-    "This text is selectable.", { selectable: true }
-  );
-  container.appendChild(selectableLabel);
-  container.appendChild(document.createElement('br'));
-
-  const mnemonicLabel = Adw.createLabel("User_name:", { mnemonicFor: "my-input" });
-  // Assuming my-input is an existing input field
-  const inputEl = document.getElementById('my-input');
-  if (inputEl) inputEl.insertAdjacentElement('beforebegin', mnemonicLabel);
-
-</script>
+<span class="adw-label">This is a basic label.</span>
+<p class="adw-label title-1">This is a Title 1 Label.</p>
+<label class="adw-label" for="some-input">Input Label:</label>
+<span class="adw-label dim-label">This is a dimmed label.</span>
 ```
 
 ## Web Component: `<adw-label>`

--- a/adwaita-web/docs/widgets/switch.md
+++ b/adwaita-web/docs/widgets/switch.md
@@ -1,58 +1,10 @@
 # Switch
 
-An `AdwSwitch` is a toggle control that allows users to switch between two states, typically "on" and "off" or "active" and "inactive". Adwaita-Web provides `Adw.createSwitch()` and the `<adw-switch>` Web Component.
+An `AdwSwitch` is a toggle control that allows users to switch between two states, typically "on" and "off" or "active" and "inactive". Adwaita Web provides styling for switches via the `.adw-switch` CSS class and an `<adw-switch>` Web Component.
 
 This component is essential for `AdwSwitchRow`.
 
-## JavaScript Factory: `Adw.createSwitch()`
-
-Creates an Adwaita-styled switch.
-
-**Signature:**
-
-```javascript
-Adw.createSwitch(options = {}) -> HTMLButtonElement (or a custom element wrapper)
-```
-*(Typically, a switch is implemented as a custom element or a styled `button` with `role="switch"`)*
-
-**Parameters:**
-
-*   `options` (Object, optional): Configuration options:
-    *   `active` (Boolean, optional): The initial state of the switch. `true` for on/active, `false` for off/inactive. Defaults to `false`.
-    *   `disabled` (Boolean, optional): If `true`, the switch is non-interactive. Defaults to `false`.
-    *   `onChange` (Function, optional): A callback function executed when the switch's state changes. It receives the new `active` state (boolean) as an argument.
-    *   `id` (String, optional): A specific ID to set on the switch element.
-    *   `cssClass` (Array<String>, optional): Additional CSS classes to apply.
-
-**Returns:**
-
-*   `(HTMLElement)`: The created switch element (e.g., `<adw-switch>` or a styled `button`).
-
-**Example:**
-
-```html
-<div id="js-switch-container" style="display: flex; flex-direction: column; gap: 10px;"></div>
-<script>
-  const container = document.getElementById('js-switch-container');
-
-  const simpleSwitch = Adw.createSwitch({
-    onChange: (isActive) => console.log("Switch 1 state:", isActive)
-  });
-  container.appendChild(simpleSwitch);
-
-  const activeSwitch = Adw.createSwitch({
-    active: true,
-    onChange: (isActive) => console.log("Switch 2 state:", isActive)
-  });
-  container.appendChild(activeSwitch);
-
-  const disabledSwitch = Adw.createSwitch({
-    active: true,
-    disabled: true
-  });
-  container.appendChild(disabledSwitch);
-</script>
-```
+*(Note: Previous versions of this documentation may have described a JavaScript factory like `Adw.createSwitch()`. As of the current review, this specific factory function was not found in the core `adwaita-web/js` source. Usage should primarily rely on the CSS classes with the specified HTML structure, or the `<adw-switch>` Web Component.)*
 
 ## Web Component: `<adw-switch>`
 

--- a/adwaita-web/docs/widgets/tabview.md
+++ b/adwaita-web/docs/widgets/tabview.md
@@ -9,104 +9,11 @@ The TabView system provides a way to manage multiple pages of content, where eac
 *   **`AdwTabButton`**: An individual button in the `AdwTabBar`, representing a page.
 *   **`AdwTabPage`**: A container for the content of a single tab.
 
-## JavaScript Factories
-
-### `Adw.createTabButton(options = {}) -> HTMLDivElement`
-
-*   **`options`**:
-    *   `label` (String): Text for the tab.
-    *   `iconHTML` (String, optional): HTML for an icon. *Security: Ensure trusted HTML.*
-    *   `pageName` (String, required): Unique identifier for the page this tab controls.
-    *   `isActive` (Boolean, optional): Initial active state.
-    *   `isClosable` (Boolean, optional): If `true` (default), shows a close button.
-    *   `onSelect` (Function, optional): `onSelect(pageName)` callback.
-    *   `onClose` (Function, optional): `onClose(pageName)` callback for the close button.
-*   **Returns**: The tab button `<div>` element.
-
-### `Adw.createTabBar(options = {}) -> HTMLDivElement (with methods)`
-
-*   **`options`**:
-    *   `tabsData` (Array<Object>, optional): Initial tabs, each object matching `Adw.createTabButton` options.
-    *   `activeTabName` (String, optional): `pageName` of the initially active tab.
-    *   `onTabSelect` (Function, optional): `onTabSelect(pageName)` callback.
-    *   `onTabClose` (Function, optional): `onTabClose(pageName)` callback.
-    *   `showNewTabButton` (Boolean, optional): If `true`, shows a '+' button.
-    *   `onNewTabRequested` (Function, optional): Callback for the new tab button.
-*   **Returns**: The tab bar `<div>` element, augmented with methods:
-    *   `setActiveTab(pageName)`
-    *   `addTab(tabData, makeActive?)`
-    *   `removeTab(pageName)`
-
-### `Adw.createTabPage(options = {}) -> HTMLDivElement`
-
-*   **`options`**:
-    *   `content` (HTMLElement, required): The main content element for this tab page.
-    *   `pageName` (String, required): Unique identifier for this page.
-*   **Returns**: The tab page `<div>` container.
-
-### `Adw.createTabView(options = {}) -> HTMLDivElement (with methods)`
-
-*   **`options`**:
-    *   `pages` (Array<Object>, optional): Initial pages. Each object: `{ name: String, title: String, content: HTMLElement, isClosable?: boolean }`.
-    *   `activePageName` (String, optional): Initially active page name.
-    *   `showNewTabButton` (Boolean, optional): Passed to `AdwTabBar`.
-    *   `onNewTabRequested` (Function, optional): Passed to `AdwTabBar`. App should
-        call `adwTabView.addPage()`.
-    *   `onPageChanged` (Function, optional): `onPageChanged(pageName)` callback.
-    *   `onBeforePageClose` (Function, optional):
-        `onBeforePageClose(pageName) -> boolean`. Return `false` to prevent
-        closing.
-    *   `onPageClosed` (Function, optional): `onPageClosed(pageName)` callback.
-*   **Returns**: The main tab view `<div>`, augmented with methods:
-    *   `addPage(pageData, makeActive?)`
-    *   `removePage(pageName)`
-    *   `setActivePage(pageName)`
-    *   `getActivePageName() -> String | null`
-
-**JavaScript Example (Full TabView):**
-
-```html
-<div id="js-tabview-container" style="height: 300px; border: 1px solid var(--borders-color);"></div>
-<script>
-  const tabViewContainer = document.getElementById('js-tabview-container');
-  let pageCounter = 2;
-
-  const page1Content = Adw.createLabel("Content for Page 1");
-  const page2Content = Adw.createEntry({placeholder: "Input for Page 2"});
-  const initialPages = [
-    { name: "page1", title: "Page 1", content: page1Content, isClosable: true },
-    { name: "page2", title: "Page Two", content: page2Content, isClosable: true }
-  ];
-
-  const myTabView = Adw.createTabView({
-    pages: initialPages,
-    activePageName: "page1",
-    showNewTabButton: true,
-    onNewTabRequested: () => {
-      pageCounter++;
-      const newPageName = `page${pageCounter}`;
-      myTabView.addPage({
-        name: newPageName,
-        title: `Page ${pageCounter}`,
-        content: Adw.createLabel(`Content for new Page ${pageCounter}`),
-        isClosable: true
-      }, true); // Add and make active
-    },
-    onPageChanged: (pageName) => Adw.createToast(`Switched to ${pageName}`),
-    onBeforePageClose: (pageName) => {
-      if (pageName === "page1") {
-        // return confirm("Are you sure you want to close Page 1? It's important!");
-      }
-      return true; // Allow close
-    },
-    onPageClosed: (pageName) => Adw.createToast(`${pageName} was closed.`)
-  });
-
-  tabViewContainer.appendChild(myTabView);
-</script>
-```
+*(Note: Previous versions of this documentation may have described JavaScript factories like `Adw.createTabView()`, `Adw.createTabBar()`, etc. As of the current review, these specific factory functions were not found in the core `adwaita-web/js` source. Usage should primarily rely on the Web Components detailed below or by applying CSS classes to manually structured HTML.)*
 
 ## Web Components
+
+The TabView system is primarily implemented via a set of interconnected Web Components:
 
 ### `<adw-tab-button>`
 

--- a/adwaita-web/docs/widgets/toast.md
+++ b/adwaita-web/docs/widgets/toast.md
@@ -13,72 +13,65 @@ Creates an Adwaita-styled toast element. This function typically creates the toa
 **Signature:**
 
 ```javascript
-Adw.createToast(title, options = {}) -> HTMLElement
+Adw.createToast(title, options = {}) -> HTMLElement | null
 ```
 
 **Parameters:**
 
-*   `title` (String): The main text to display in the toast.
+*   `title` (String): The main message text to display in the toast. The factory currently supports a single string for the primary content.
 *   `options` (Object, optional): Configuration options:
     *   `timeout` (Number, optional): Duration in milliseconds before the toast
         automatically dismisses. Defaults to `3000` (3 seconds). A value of `0` or
-        negative might mean it persists until an action or manual dismissal.
+        negative makes the toast persistent until manually dismissed via its close button or action.
     *   `actionName` (String, optional): If provided, an action button with this
         label is added to the toast.
     *   `onAction` (Function, optional): A callback function executed when the
-        action button is clicked. The toast instance is passed as an argument.
-    *   `priority` (String, optional): Priority of the toast. Can be `'normal'` or
-        `'high'`. High priority toasts might be styled differently or placed
-        above normal priority ones. Defaults to `'normal'`.
+        action button (if `actionName` is provided) is clicked. The toast element itself is passed as an argument to this function.
     *   `id` (String, optional): A specific ID to set on the toast element.
+    *   `type` (String, optional): Intended for future styling (e.g., 'info', 'success'). Currently not implemented to change visual style.
 
 **Returns:**
 
-*   `(HTMLElement)`: The created toast element (typically a `div` with class `adw-toast`).
+*   `(HTMLElement | null)`: The created toast `div` element (with class `adw-toast`), or `null` if the required toast overlay container (`#adw-toast-overlay`) is not found in the DOM. The toast is automatically appended to the overlay and managed.
 
-**Example (Conceptual - requires a toast manager/overlay):**
+**Example:**
 
 ```html
-<div id="toast-container" style="position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 1500; display: flex; flex-direction: column; gap: 10px;"></div>
+<!-- Ensure this overlay exists in your main HTML structure -->
+<div id="adw-toast-overlay" class="adw-toast-overlay"></div>
+
 <button id="show-toast-btn">Show Toast</button>
 <button id="show-action-toast-btn">Show Toast with Action</button>
 
 <script>
-  const toastContainer = document.getElementById('toast-container');
-
-  function showToast(toastElement) {
-    toastContainer.appendChild(toastElement);
-    // Basic dismissal logic for example
-    const timeout = parseInt(toastElement.dataset.timeout, 10) || 3000;
-    if (timeout > 0) {
-      setTimeout(() => {
-        toastElement.remove();
-      }, timeout);
-    }
-  }
+  // Adw.createToast is defined in adwaita-web/js/toast.js
+  // Ensure toast.js is loaded.
 
   document.getElementById('show-toast-btn').addEventListener('click', () => {
-    const myToast = Adw.createToast("File saved successfully!");
-    showToast(myToast);
+    Adw.createToast("File saved successfully!");
   });
 
   document.getElementById('show-action-toast-btn').addEventListener('click', () => {
-    const actionToast = Adw.createToast("Update available.", {
+    Adw.createToast("Update available.", {
       actionName: "Install",
       timeout: 5000, // 5 seconds
-      onAction: (toast) => {
+      onAction: (toastElement) => {
         console.log("Install action clicked!");
-        toast.remove(); // Dismiss toast after action
+        // Toast will dismiss on action click if Adw.dismissToast is called within onAction,
+        // or if the action itself leads to a state where the toast is no longer relevant.
+        // The default behavior is that the toast remains until its timeout or manual close,
+        // unless onAction explicitly dismisses it.
+        Adw.dismissToast(toastElement); // Example: dismiss after action
       }
     });
-    showToast(actionToast);
   });
 </script>
 ```
+*Note: The `Adw.createToast` function handles appending the toast to an element with ID `adw-toast-overlay` and manages its show/hide lifecycle.*
 
 ## Web Component: `<adw-toast>`
 
-While toasts are often created dynamically via the factory, a web component can be used for declarative scenarios or within other components.
+While toasts are typically created dynamically via the `Adw.createToast()` factory, a web component `<adw-toast>` can be defined for scenarios requiring declarative toast elements or for use within other web components. (Note: A web component for `<adw-toast>` is not explicitly provided in `toast.js`; this section describes a general pattern if one were to be used or created).
 
 **HTML Tag:** `<adw-toast>`
 


### PR DESCRIPTION
- Corrected documentation for Adw.createToast factory based on JS implementation.
- Removed JavaScript factory sections from documentation for components where factories were not found in the JS source (AboutDialog, Banner, ActionRow, Switch, TabView, ExpanderRow, ComboRow, HeaderBar, Avatar, Label, Checkbox, and others).
- Added notes to affected docs guiding users to CSS classes or Web Components.
- Ensured Web Component documentation stands on its own after factory removal.