### PR TITLE
Revert: Remove Markdown editor and client-side rendering

### DIFF
--- a/adwaita-web/scss/_app-demo-specific.scss
+++ b/adwaita-web/scss/_app-demo-specific.scss
@@ -428,53 +428,6 @@ $app-sidebar-breakpoint: 768px;
   }
 }
 
-// Markdown Toolbar Styling
-.custom-toolbar {
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-m);
-  padding: var(--spacing-xs);
-  margin-bottom: var(--spacing-xs);
-  background-color: var(--secondary-bg-color);
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-xxs);
-
-  button, // Native buttons if any
-  md-bold,
-  md-italic,
-  md-strikethrough,
-  md-header,
-  md-quote,
-  md-code,
-  md-link,
-  md-image,
-  md-unordered-list,
-  md-ordered-list {
-    font-family: var(--font-family-ui);
-    font-size: var(--font-size-s);
-    padding: var(--spacing-xxs) var(--spacing-xs);
-    border: 1px solid var(--button-border-color);
-    background-color: var(--button-bg-color);
-    color: var(--button-fg-color);
-    border-radius: var(--border-radius-s);
-    cursor: pointer;
-    transition: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out;
-    display: inline-flex; // Ensures items behave like buttons
-    align-items: center;
-    justify-content: center;
-
-    &:hover, &:focus {
-      border-color: var(--button-hover-border-color);
-      background-color: var(--button-hover-bg-color);
-      outline: none; // Assuming Adwaita focus styles are handled elsewhere or not needed for these simple buttons
-    }
-    &:active {
-      background-color: var(--button-active-bg-color);
-      border-color: var(--button-active-border-color);
-    }
-  }
-}
-
 .blog-content-card.adw-card {
   // Base styles inherited from .adw-card
   // Overriding padding from base .adw-card if it was var(--spacing-m)

--- a/app-demo/templates/base.html
+++ b/app-demo/templates/base.html
@@ -48,16 +48,6 @@
         }
       })();
     </script>
-    <style nonce="{{ csp_nonce() if csp_nonce else '' }}">
-        /* General styling for images within rendered markdown content */
-        .styled-text-content img {
-            max-width: 100%;
-            height: auto;
-            border-radius: var(--border-radius-m); /* Optional: consistent image corner rounding */
-            margin-top: var(--spacing-s);
-            margin-bottom: var(--spacing-s);
-        }
-    </style>
 </head>
 <body>
 

--- a/app-demo/templates/gallery_full.html
+++ b/app-demo/templates/gallery_full.html
@@ -36,19 +36,7 @@
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="adw-action-row column-layout">
                  <label for="gallery-comment-text" class="adw-action-row-title" style="margin-bottom: var(--spacing-xs);">Your Comment</label>
-                <markdown-toolbar for="gallery-comment-text" class="custom-toolbar">
-                    <md-bold>Bold</md-bold>
-                    <md-italic>Italic</md-italic>
-                    <md-strikethrough>Strike</md-strikethrough>
-                    <md-header>Heading</md-header>
-                    <md-quote>Quote</md-quote>
-                    <md-code>Code</md-code>
-                    <md-link>Link</md-link>
-                    <md-image>Image/GIF</md-image>
-                    <md-unordered-list>List</md-unordered-list>
-                    <md-ordered-list>Ordered List</md-ordered-list>
-                </markdown-toolbar>
-                <textarea id="gallery-comment-text" name="text" class="adw-entry" rows="4" placeholder="Write a comment..." required style="width: 100%; min-height: 100px; box-sizing: border-box; margin-top: var(--spacing-xs);"></textarea>
+                <textarea id="gallery-comment-text" name="text" class="adw-entry" rows="4" placeholder="Write a comment..." required style="width: 100%; min-height: 100px; box-sizing: border-box;"></textarea> {# Removed margin-top from Markdown toolbar #}
                 <div id="gallery-comment-error" class="error-text adw-label caption" style="display:none; margin-top: var(--spacing-xs);"></div>
             </div>
             <div class="form-actions-end" style="margin-top: var(--spacing-s);">
@@ -143,18 +131,6 @@
 
 {% block scripts %}
 {{ super() }}
-<script type="module" src="https://cdn.jsdelivr.net/npm/@github/markdown-toolbar-element@1.0.3/dist/index.umd.js" nonce="{{ csp_nonce() if csp_nonce else '' }}"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.12/marked.min.js" nonce="{{ csp_nonce() if csp_nonce else '' }}"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.6/purify.min.js" nonce="{{ csp_nonce() if csp_nonce else '' }}"></script>
-<style nonce="{{ csp_nonce() if csp_nonce else '' }}">
-  /* Styles specific to photo comments images, if different from global .styled-text-content img */
-  /* For now, the global one in base.html should cover it. This is a placeholder if needed. */
-  .photo-comments-area .styled-text-content img {
-      /* max-width: 100%; */ /* Already handled by global style */
-      /* height: auto; */ /* Already handled by global style */
-      /* border-radius: var(--border-radius-m); */ /* Already handled by global style */
-  }
-</style>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     // Full-size gallery photo dialog logic
@@ -192,9 +168,10 @@ document.addEventListener('DOMContentLoaded', function () {
         comments.forEach(comment => {
             const commentDiv = document.createElement('div');
             commentDiv.classList.add('adw-action-row');
-            // Sanitize and render markdown for comment text
-            const unsafeHtml = marked.parse(comment.text || ''); // Use marked.parse (or marked())
-            const safeHtml = DOMPurify.sanitize(unsafeHtml);
+            // Display plain text for comment text
+            const commentTextNode = document.createElement('div');
+            commentTextNode.classList.add('adw-action-row-subtitle'); // Keep styling consistent
+            commentTextNode.textContent = comment.text || ''; // Display plain text
 
             commentDiv.innerHTML = `
                 <span class="adw-avatar size-small" style="margin-right: var(--spacing-s);">
@@ -202,7 +179,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 </span>
                 <span class="adw-action-row-text-content">
                     <a href="${comment.author.profile_url}" class="adw-link adw-action-row-title">${comment.author.full_name || comment.author.username}</a>
-                    <div class="adw-action-row-subtitle styled-text-content">${safeHtml}</div>
+                    ${commentTextNode.outerHTML} {# Inject the plain text node's HTML #}
                     <small class="adw-label caption">${formatCommentDate(comment.created_at)}</small>
                 </span>
             `;
@@ -223,6 +200,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
             const comments = await response.json();
+            // Assuming comments from API are plain text or server-rendered HTML if that's the new backend strategy
+            // If API still sends Markdown, and we need to display it as plain text, this is fine.
+            // If API sends pre-rendered HTML, and it's safe, this is also fine.
+            // The goal here is to remove client-side Marked and DOMPurify.
             displayGalleryComments(comments);
         } catch (error) {
             console.error('Error fetching gallery comments:', error);

--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -215,19 +215,7 @@
                     <span class="adw-action-row-subtitle error-text" style="margin-bottom: var(--spacing-xs);">{{form.text.errors|join(' ')}}</span>
                 {% endif %}
 
-                <markdown-toolbar for="{{ form.text.id or 'comment_text_input' }}" class="custom-toolbar">
-                    <md-bold>Bold</md-bold>
-                    <md-italic>Italic</md-italic>
-                    <md-strikethrough>Strike</md-strikethrough>
-                    <md-header>Heading</md-header>
-                    <md-quote>Quote</md-quote>
-                    <md-code>Code</md-code>
-                    <md-link>Link</md-link>
-                    <md-image>Image/GIF</md-image> {# Users will paste URL for image/GIF #}
-                    <md-unordered-list>List</md-unordered-list>
-                    <md-ordered-list>Ordered List</md-ordered-list>
-                </markdown-toolbar>
-                <textarea name="{{ form.text.name }}" id="{{ form.text.id or 'comment_text_input' }}" class="adw-entry" rows="6" style="width: 100%; min-height: 120px; box-sizing: border-box; margin-top: var(--spacing-xs);">{{ form.text.data or ''}}</textarea>
+                <textarea name="{{ form.text.name }}" id="{{ form.text.id or 'comment_text_input' }}" class="adw-entry" rows="6" style="width: 100%; min-height: 120px; box-sizing: border-box;">{{ form.text.data or ''}}</textarea> {# Removed margin-top from Markdown toolbar #}
             </div>
 
             <div class="form-actions-container form-actions-end comment-form-actions" style="margin-top: var(--spacing-m); padding: 0;"> {# Simplified padding as form has it now #}
@@ -587,5 +575,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
 {% block scripts %}
 {{ super() }}
-<script type="module" src="https://cdn.jsdelivr.net/npm/@github/markdown-toolbar-element@1.0.3/dist/index.umd.js" nonce="{{ csp_nonce() if csp_nonce else '' }}"></script>
 {% endblock %}


### PR DESCRIPTION
This commit reverts the introduction of the Markdown editing toolbar (<markdown-toolbar-element>) and associated client-side Markdown rendering (Marked.js, DOMPurify) for photo gallery comments.

It also removes the Markdown editing toolbar from post comments, maintaining the existing server-side Python-Markdown rendering for them.

Specific changes:
- Removed <markdown-toolbar-element> from comment forms in post.html and gallery_full.html.
- Removed CDN links for markdown-toolbar-element, Marked.js, and DOMPurify from gallery_full.html and post.html (where applicable).
- Removed client-side JavaScript rendering logic in gallery_full.html.
- Removed associated CSS for the toolbar from _app-demo-specific.scss.
- Removed global CSS for responsive images in Markdown from base.html.