### PR TITLE
FIX: Correct Jinja2 template syntax in post.html

### DIFF
--- a/app-demo/templates/post.html
+++ b/app-demo/templates/post.html
@@ -573,6 +573,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 
+{% endblock %} {# Closes content block #}
+
 {% block scripts %}
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
This commit fixes a `TemplateSyntaxError` in `app-demo/templates/post.html` caused by a missing `{% endblock %}` for the `content` block.

This corrects the error introduced during the reversion of the Markdown toolbar features.

Revert: Remove Markdown editor and client-side rendering

This reverts the introduction of the Markdown editing toolbar (<markdown-toolbar-element>) and associated client-side Markdown rendering (Marked.js, DOMPurify) for photo gallery comments.

It also removes the Markdown editing toolbar from post comments, maintaining the existing server-side Python-Markdown rendering for them.

Specific changes:
- Removed <markdown-toolbar-element> from comment forms in post.html and gallery_full.html.
- Removed CDN links for markdown-toolbar-element, Marked.js, and DOMPurify from gallery_full.html and post.html (where applicable).
- Removed client-side JavaScript rendering logic in gallery_full.html.
- Removed associated CSS for the toolbar from _app-demo-specific.scss.
- Removed global CSS for responsive images in Markdown from base.html.