### PR TITLE
FIX: Update deprecated SASS color functions

### DIFF
--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -384,7 +384,7 @@ $accent-definitions: (
   --toast-bg-color: #{$adw-dark-3};
   --toast-fg-color: #{$adw-light-1};
   $_toast_fg_color_sass: $adw-light-1;
-  --toast-fg-color-rgb: #{color.red($_toast_fg_color_sass)}, #{color.green($_toast_fg_color_sass)}, #{color.blue($_toast_fg_color_sass)};
+  --toast-fg-color-rgb: #{color.channel($_toast_fg_color_sass, "red", $space: rgb)}, #{color.channel($_toast_fg_color_sass, "green", $space: rgb)}, #{color.channel($_toast_fg_color_sass, "blue", $space: rgb)};
   --toast-secondary-fg-color: #{rgba($adw-light-1, 0.7)};
   --toast-accent-color: var(--accent-color);
   --toast-box-shadow: var(--popover-box-shadow-dark);


### PR DESCRIPTION
Replaced deprecated `color.red()`, `color.green()`, and `color.blue()` SASS functions with the new `color.channel()` syntax in `adwaita-web/scss/_variables.scss`.

This resolves SASS deprecation warnings that appeared during the build process for the `--toast-fg-color-rgb` variable.