### PR TITLE
Fix: Correct setup_db.py cascade delete and add --config option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repository contains two main projects:
     *   It utilizes the `adwaita-web` library to style its user interface.
     *   The application is structured using a Flask application factory (`create_app` located in `app-demo/__init__.py`) and is run using the `flask run` command (after setting `FLASK_APP=app_demo`).
     *   Currently, `app-demo` uses a manually included (or to-be-built and copied) version of the `adwaita-web` library's assets (CSS, JS, icons, fonts). Refer to `build-adwaita-web.sh` for an example of how these might be prepared and copied into `app-demo/static/`.
-    *   For specific instructions related to the `app-demo` application (e.g., running the Flask app, database setup, testing), please refer to the `app-demo/AGENTS.md` file.
+    *   For specific instructions related to the `app-demo` application (e.g., running the Flask app, database setup using `app-demo/setup_db.py`, testing), please refer to the `app-demo/AGENTS.md` file.
 
 **General Workflow:**
 


### PR DESCRIPTION
- Modifies setup_db.py to use `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` for PostgreSQL when --deletedb is used. This resolves issues with foreign key constraints preventing table drops.
- Adds a `--config <filepath>` argument to setup_db.py, allowing users to override default configurations by providing a YAML file. Requires PyYAML.
- Updates app-demo/AGENTS.md with detailed information on these changes, including usage, warnings, and the PyYAML dependency.
- Updates root AGENTS.md to correctly refer to app-demo/AGENTS.md for these details.