### PR TITLE
Fix NameError in Activity model and add AGENTS.md instructions

### DIFF
--- a/app-demo/AGENTS.md
+++ b/app-demo/AGENTS.md
@@ -164,3 +164,22 @@ When implementing UI elements, choose the Adwaita widget that semantically and v
 *   **Toggle Switches vs. Checkboxes**: For boolean settings (on/off, enable/disable), an Adwaita Switch (visual toggle switch) should **always** be preferred over a simple checkbox. Adwaita's implementation typically involves an `<input type='checkbox' class='adw-switch'>` styled accordingly, wrapped in a `<label class='adw-switch'>` with a sibling `<span class='adw-switch-slider'>`. Ensure the HTML structure matches what the Adwaita CSS expects for that widget, as detailed in the component's SCSS file (e.g., `adwaita-web/scss/_switch.scss` requires a specific structure for `.adw-switch` to render correctly). Simple checkboxes (`<input type="checkbox">` without switch styling) should generally be avoided for settings.
 
 Ensure the HTML structure matches what the Adwaita CSS expects for that widget, as detailed in the component's SCSS file.
+
+---
+
+## Database Model Changes (NEW SECTION)
+
+**IMPORTANT**: After any changes to database models in `app-demo/models.py` (e.g., adding, removing, or altering tables or columns), you **MUST** also update the `app-demo/setup_db.py` script accordingly.
+
+This script is responsible for initializing the database schema. If it's not kept in sync with the models, errors will occur during database setup or application runtime.
+
+**Procedure:**
+1.  Modify `app-demo/models.py`.
+2.  Carefully review `app-demo/setup_db.py` and make any necessary adjustments to reflect the model changes. This might involve:
+    *   Ensuring `db.create_all()` correctly creates the new schema.
+    *   Updating any initial data seeding logic if model structures have changed.
+    *   Modifying how tables are dropped or created if specific logic beyond `db.create_all()` is used.
+    *   If new tables or columns are added, ensure they are correctly initialized or populated if `setup_db.py` handles initial data.
+3.  Test `app-demo/setup_db.py` (e.g., by running `python app-demo/setup_db.py --config your_config.yaml --deletedb`) to confirm it works with the updated models.
+
+Failure to update `setup_db.py` is a common source of errors and will likely be caught by the user. Always remember this step.

--- a/app-demo/config.yaml.example
+++ b/app-demo/config.yaml.example
@@ -1,0 +1,70 @@
+# Example configuration for app-demo/setup_db.py and app-demo application
+# Copy this file to config.yaml and update with your actual settings.
+# Values in config.yaml will override environment variables and defaults in config.py.
+
+# Flask App Configuration
+SECRET_KEY: "your_very_secret_key_here_CHANGE_ME"  # IMPORTANT: Change this in your actual config.yaml
+DEBUG: True # Set to False in production
+
+# SQLAlchemy Database Configuration
+# Choose one of the following database configurations or add your own.
+
+# Option 1: SQLite (simple, file-based)
+# The path is relative to the instance folder if not absolute.
+# For app-demo, if instance_path is 'instance' in project root, this would be 'instance/app_demo.db'.
+# If running setup_db.py from project root, 'sqlite:///app_demo.db' creates it in project root.
+# For consistency with the app, it's often better to use an absolute path or ensure instance_relative_config.
+SQLALCHEMY_DATABASE_URI: "sqlite:///app_demo.db"
+
+# To use SQLite in-memory (for quick tests, data lost on script/app exit):
+# SQLALCHEMY_DATABASE_URI: "sqlite:///:memory:"
+
+# Option 2: PostgreSQL
+# Ensure you have psycopg2-binary installed: pip install psycopg2-binary
+# SQLALCHEMY_DATABASE_URI: "postgresql://username:password@host:port/database_name"
+# Example (ensure these match your PostgreSQL setup and environment variables if used as fallback):
+# SQLALCHEMY_DATABASE_URI: "postgresql://user:secret@localhost:5432/mydatabase"
+
+# Option 3: MySQL / MariaDB
+# Ensure you have PyMySQL installed: pip install PyMySQL
+# SQLALCHEMY_DATABASE_URI: "mysql+pymysql://username:password@host:port/database_name"
+# Example:
+# SQLALCHEMY_DATABASE_URI: "mysql+pymysql://user:secret@localhost:3306/mydatabase"
+
+SQLALCHEMY_TRACK_MODIFICATIONS: False
+SQLALCHEMY_ECHO: False # Set to True to see generated SQL queries, useful for debugging
+
+# Application-specific settings (examples)
+POSTS_PER_PAGE: 10
+COMMENTS_PER_PAGE: 20 # Example for comments pagination
+NOTIFICATIONS_PER_PAGE: 15
+
+# File Upload Configuration
+UPLOAD_FOLDER: "app-demo/static/uploads/profile_pics" # Relative to project root for app context
+GALLERY_UPLOAD_FOLDER: "app-demo/static/uploads/gallery_photos" # Relative to project root
+MAX_PROFILE_PHOTO_SIZE_BYTES: 2097152    # 2MB
+MAX_GALLERY_PHOTO_SIZE_BYTES: 10485760   # 10MB
+ALLOWED_EXTENSIONS: ['png', 'jpg', 'jpeg', 'gif', 'webp']
+
+# Site Settings Defaults (if applicable for setup_db.py or initial app run)
+# These are just examples; actual site settings are managed in the DB via SiteSetting model.
+# DEFAULT_SITE_TITLE: "My Awesome Flask App"
+# DEFAULT_MAINTENANCE_MODE: False
+
+# User list for setup_db.py --config (optional)
+# See app-demo/AGENTS.md for details on the USERS structure and setup_db.py user creation.
+# USERS:
+#   - username: "admin@example.com"
+#     password: "securepassword1"
+#     full_name: "Administrator"
+#     bio: "Site admin."
+#     is_admin: true
+#     is_approved: true
+#     is_active: true
+#   - username: "testuser@example.com"
+#     password: "password123"
+#     full_name: "Test User"
+#     bio: "Just a test user."
+#     is_admin: false
+#     is_approved: true
+#     is_active: true

--- a/app-demo/models.py
+++ b/app-demo/models.py
@@ -369,7 +369,7 @@ class Activity(db.Model):
     # The user who performed the activity (actor)
     actor = db.relationship('User', foreign_keys=[user_id], backref=db.backref('activities', lazy='dynamic', order_by=lambda: desc(Activity.timestamp)))
 
-    target_post = db.relationship('Post', foreign_keys=[target_post_id])
+    # target_post = db.relationship('Post', foreign_keys=[target_post_id]) # This line caused NameError
     # User being targeted by the activity (e.g., user being followed)
     # Need a different backref name if User.activities is already taken by the actor's activities.
     # Or, access this target user differently if not frequently needed as a direct backref on User.


### PR DESCRIPTION
This commit addresses a NameError in the Activity model that occurred after refactoring to polymorphic targets. The error was due to a lingering db.relationship definition attempting to use a removed foreign key column name.

Fixes:
- Removed the erroneous `target_post` relationship definition from the `Activity` model in `app-demo/models.py`.

New Files & Documentation:
- Created `app-demo/AGENTS.md` to include critical instructions for developers (or AI agents) to always update `app-demo/setup_db.py` after any database model changes.
- Created `app-demo/config.yaml.example` to provide users with a template for their local application and database setup configuration.

This ensures the application can load correctly after the polymorphic refactor and provides better guidance for future development and setup.