### PR TITLE
Refactor file upload logic with a common utility

### DIFF
--- a/app-demo/config.yaml.example
+++ b/app-demo/config.yaml.example
@@ -40,8 +40,9 @@ COMMENTS_PER_PAGE: 20 # Example for comments pagination
 NOTIFICATIONS_PER_PAGE: 15
 
 # File Upload Configuration
-UPLOAD_FOLDER: "app-demo/static/uploads/profile_pics" # Relative to project root for app context
-GALLERY_UPLOAD_FOLDER: "app-demo/static/uploads/gallery_photos" # Relative to project root
+# Paths should be relative to the 'static' folder.
+UPLOAD_FOLDER: "uploads/profile_pics" # e.g., app-demo/static/uploads/profile_pics
+GALLERY_UPLOAD_FOLDER: "uploads/gallery_photos" # e.g., app-demo/static/uploads/gallery_photos
 MAX_PROFILE_PHOTO_SIZE_BYTES: 2097152    # 2MB
 MAX_GALLERY_PHOTO_SIZE_BYTES: 10485760   # 10MB
 ALLOWED_EXTENSIONS: ['png', 'jpg', 'jpeg', 'gif', 'webp']


### PR DESCRIPTION
Introduced a new utility function `save_uploaded_file` in `app-demo/utils.py` to consolidate common file upload operations for profile photos and gallery photos.

Key changes:
- The `save_uploaded_file` utility handles:
    - File validation (type, size based on configuration).
    - Secure and unique filename generation (UUID-based).
    - Construction of save paths (relative to the static folder, including user-specific subfolders for gallery images).
    - Image processing for profile photos (cropping via `crop_coords` parameter, thumbnailing).
    - Deletion of old profile photos when a new one is uploaded.
    - Error handling and flashing messages.
- Refactored the `edit_profile` and `upload_gallery_photo` routes in `app-demo/routes/profile_routes.py` to use this new utility, significantly reducing code duplication.
- Updated `app-demo/config.yaml.example` to specify `UPLOAD_FOLDER` and `GALLERY_UPLOAD_FOLDER` as paths relative to the application's static folder, aligning with the utility's expectations.
- Removed `allowed_file_util` from direct use in `profile_routes.py` as its functionality is incorporated into the new utility.

This refactor makes the file upload process more maintainable, consistent, and easier to extend for future upload types.