### PR TITLE
Enforce consistent HTML sanitization for Markdown content

### DIFF
--- a/app-demo/utils.py
+++ b/app-demo/utils.py
@@ -6,7 +6,7 @@ from markupsafe import Markup, escape
 # Assuming bleach is used for sanitization, if not, this part would need adjustment
 # For now, to avoid dependency errors if bleach isn't in requirements.txt,
 # we'll make a very basic sanitizer. A proper setup would use bleach.
-# import bleach
+import bleach # <-- Ensure bleach is imported
 import markdown as md_lib # Use md_lib to avoid conflict with template filter name
 
 def generate_slug_util(text, max_length=255):
@@ -118,7 +118,18 @@ def markdown_to_html_and_sanitize_util(text):
     # The responsibility of full sanitization would be higher up or assumed by content trust.
     # For this demo, this might be acceptable if content sources are somewhat trusted or if
     # the markdown library itself does some level of safe HTML generation.
-    return Markup(html_content)
+    # ---- OLD CODE END ----
+
+    # Step 2: Sanitize the generated HTML using Bleach
+    # Uses the ALLOWED_TAGS_CONFIG and ALLOWED_ATTRIBUTES_CONFIG defined in this file.
+    sanitized_html = bleach.clean(
+        html_content,
+        tags=ALLOWED_TAGS_CONFIG,
+        attributes=ALLOWED_ATTRIBUTES_CONFIG,
+        strip=True  # Remove disallowed tags entirely
+    )
+
+    return Markup(sanitized_html)
 
 
 def init_app(app):


### PR DESCRIPTION
Updated the `markdown_to_html_and_sanitize_util` function in `app-demo/utils.py` to use `bleach.clean` with the globally defined `ALLOWED_TAGS_CONFIG` and `ALLOWED_ATTRIBUTES_CONFIG`.

Previously, this utility converted Markdown to HTML but did not apply the project's standard Bleach sanitization policy to the resulting HTML. This change ensures that all user-generated content rendered through the `markdown` Jinja2 filter (such as post content, comments, and photo captions) is now consistently sanitized against the same rules applied to direct HTML inputs like user profile information.

This enhances security by providing a unified approach to preventing XSS and ensuring safe HTML rendering across the application.