### PR TITLE
Fix: Correct arguments for like_button_and_count macro in index.html

### DIFF
--- a/app-demo/templates/index.html
+++ b/app-demo/templates/index.html
@@ -49,7 +49,7 @@
             </footer>
                         <div class="adw-card__actions card-secondary-actions"> {# New container for likes etc. #}
                             {% from "_macros.html" import like_button_and_count %}
-                            {{ like_button_and_count(post, current_user, csrf_token()) }}
+                            {{ like_button_and_count(post, current_user) }}
                             {# Add other actions like comments count link here if desired #}
                         </div>
         </article>


### PR DESCRIPTION
The `like_button_and_count` macro was updated to take 2 arguments instead of 3 (removing the explicit csrf_token parameter as it now calls csrf_token() directly). This commit updates the call to this macro in `app-demo/templates/index.html` to match the new definition, resolving a TypeError that occurred when rendering the index page.