### PR TITLE
Feat: Enhance @mention linkify to check user existence

### DIFF
--- a/antisocialnet/utils.py
+++ b/antisocialnet/utils.py
@@ -47,8 +47,9 @@ def human_readable_date(dt, show_time=True):
 
 def linkify_mentions(text):
     """
-    Converts @username mentions into links to user profiles.
-    This is a simplified version. A robust version would check user existence.
+    Converts @username mentions in a string into Markdown links if the user exists,
+    otherwise leaves the mention as plain text.
+    Requires an active Flask app context for database queries.
     """
     if text is None:
         return ''
@@ -56,39 +57,23 @@ def linkify_mentions(text):
     # Regex to find @username patterns
     # Allows alphanumeric characters and underscores in usernames
     mention_regex = r'@([a-zA-Z0-9_]+)'
+    from .models import User # Import User model for existence check
 
     def replace_mention(match):
         username = match.group(1)
-        # In a real app, you'd use url_for here, but that's not available directly in utils
-        # without app context. This filter is applied in app context, so this is conceptual.
-        # For direct usage if needed outside app context, the URL structure would be hardcoded or passed.
-        # Here, we just format it, assuming url_for will be used in the template filter call.
-        # This utility function should just return the structure that the template filter can use.
-        # For now, it prepares a string that can be made into a link.
-        # The actual href creation is better handled in the template filter or by passing url_for.
-        # However, the current app structure calls this from the markdown filter.
-
-        # Simple version for now, actual URL generation might need app context or url_for
-        # from flask import url_for # This would cause circular import if utils is imported by __init__ too early
-        # For now, let's assume the markdown filter will handle the final URL construction if this
-        # function is only returning the username. Or, we create a placeholder link.
-
-        # Placeholder link structure, actual linking happens in template filter context
-        # This function is more about identifying and formatting, less about final URL generation here.
-        # The existing template filter for linkify_mentions in __init__ seems to expect this to return text.
-        # Then markdown_to_html_and_sanitize_util probably makes it a link.
-        # This function is more about identifying and formatting, less about final URL generation here.
-        # The existing template filter for linkify_mentions in __init__ seems to expect this to return text.
-        # Then markdown_to_html_and_sanitize_util probably makes it a link.
-        # Let's assume this is used by a filter that will then use url_for.
-        # A more direct approach would be for this to generate the <a> tag if it had url_for.
-        # Based on its usage in `actual_markdown_filter` in `__init__.py`, it seems this function
-        # should return text that `markdown_to_html_and_sanitize_util` then processes.
-        # The `linkify_mentions_util` is called *before* markdown.
-
-        # Let's make it generate a markdown link, which markdown_to_html_and_sanitize_util will process.
-        # This is a common pattern.
-        return f'[@{username}](/profile/{username})' # Generates a markdown link
+        # Check if user exists. This requires an app context to perform DB query.
+        # This function is used as a filter, so app context should be available.
+        user = User.query.filter_by(username=username).first()
+        if user:
+            # User exists, generate Markdown link.
+            # The URL structure /profile/<username> is hardcoded here.
+            # A more dynamic approach would use url_for, but that's harder to integrate
+            # cleanly at this stage of the text processing pipeline if the function
+            # is to remain a simple text->text utility.
+            return f'[@{username}](/profile/{username})'
+        else:
+            # User does not exist, return the mention as plain text.
+            return f'@{username}'
 
     linked_text = re.sub(mention_regex, replace_mention, text)
     return linked_text


### PR DESCRIPTION
The `linkify_mentions` utility function in `utils.py` now queries the database to check if a mentioned user exists.

- If the user exists, a Markdown link `[@username](/profile/username)` is generated.
- If the user does not exist, the mention `@username` is left as plain text.
- This makes the mention linking more robust by avoiding dead links.

Updated the function's docstring and internal comments to reflect the new logic. Updated tests in `test_utils.py` to cover these scenarios, requiring an app context for DB queries.