### PR TITLE
Fix: Correct arguments for like_button_and_count macro

### DIFF
--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -229,7 +229,7 @@
                         </footer>
                         <div class="adw-card__actions card-secondary-actions">
                             {% from "_macros.html" import like_button_and_count %}
-                            {{ like_button_and_count(post, current_user, csrf_token()) }}
+                            {{ like_button_and_count(post, current_user) }}
                         </div>
                     </article>
                     {% endfor %}


### PR DESCRIPTION
The `like_button_and_count` Jinja2 macro was being called with three arguments (`post`, `current_user`, `csrf_token()`) in `profile.html`, but its definition in `_macros.html` only accepts two (`post`, `current_user`).

The `csrf_token()` function is globally available and is correctly called within the macro itself for form protection. This commit removes the extraneous `csrf_token()` from the macro call site to resolve the TypeError.