### PR TITLE
Refactor: Implement PII changes for user identifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,15 @@ This repository contains two main projects:
     *   For web components with Shadow DOM, if internal styles need access to asset paths (like icons), prefer using CSS Custom Properties defined in global SCSS to pass these paths rather than hardcoding them in JS or inline styles within the component.
 
 Please consult the respective `AGENTS.md` files in each subdirectory for more detailed, context-specific instructions.
+
+**PII (Personally Identifiable Information) Guidelines:**
+
+*   **User Email Addresses:**
+    *   Email addresses are primarily for user login, account recovery, and notifications.
+    *   They should **not** be used as public-facing identifiers such as in @mentions or as part of avatar display logic (unless explicitly for a service like Gravatar where the user understands their email is used, and even then, prefer anonymized or user-chosen identifiers if possible).
+    *   Users may choose to display their email on their profile, but this should be an explicit choice and not the default way their identity is represented.
+*   **User Mentions and Display:**
+    *   For @mentions, user lists, and general display of user identity within the application, always prefer `username` or `full_name` (display name).
+    *   Ensure that any system that generates user links or displays user information defaults to these non-sensitive identifiers.
+*   **Avatar Display:**
+    *   Avatar generation or display logic should not depend on or expose email addresses. If a default avatar system is used (e.g., identicons), it should be based on a non-sensitive, stable user ID or username.

--- a/antisocialnet/__init__.py
+++ b/antisocialnet/__init__.py
@@ -121,7 +121,7 @@ def create_app(config_name=None, yaml_config_override=None): # Added yaml_config
             user_id_int = int(user_id_str)
             user = db.session.get(models.User, user_id_int) # Use models.User
             # if user:
-            #     app.logger.info(f"[LOAD_USER] User {user.username} (ID: {user.id}) loaded.")
+            #     app.logger.info(f"[LOAD_USER] User ID: {user.id} (Handle: {user.handle}) loaded.")
             # else:
             #     app.logger.warning(f"[LOAD_USER] No user found for ID: {user_id_int}")
             return user
@@ -239,19 +239,19 @@ def create_app(config_name=None, yaml_config_override=None): # Added yaml_config
 
     @app.errorhandler(403)
     def forbidden_page(error):
-        user_info = f"User: {current_user.username}" if current_user.is_authenticated else "User: Anonymous"
+        user_info = f"User ID: {current_user.id} (Handle: {current_user.handle})" if current_user.is_authenticated else "User: Anonymous"
         app.logger.warning(f"[ERROR_HANDLER] 403 Forbidden - Path: {request.path}, IP: {request.remote_addr}, {user_info}, Error: {error}")
         return render_template('403.html'), 403
 
     @app.errorhandler(404)
     def page_not_found(error):
-        user_info = f"User: {current_user.username}" if current_user.is_authenticated else "User: Anonymous"
+        user_info = f"User ID: {current_user.id} (Handle: {current_user.handle})" if current_user.is_authenticated else "User: Anonymous"
         app.logger.warning(f"[ERROR_HANDLER] 404 Not Found - Path: {request.path}, IP: {request.remote_addr}, {user_info}, Error: {error}")
         return render_template('404.html'), 404
 
     @app.errorhandler(500)
     def server_error_page(error):
-        user_info = f"User: {current_user.username}" if current_user.is_authenticated else "User: Anonymous"
+        user_info = f"User ID: {current_user.id} (Handle: {current_user.handle})" if current_user.is_authenticated else "User: Anonymous"
         app.logger.error(f"[ERROR_HANDLER] 500 Server Error - Path: {request.path}, IP: {request.remote_addr}, {user_info}, Error: {error}", exc_info=True)
         db.session.rollback() # Rollback in case of DB error leading to 500
         return render_template('500.html'), 500

--- a/antisocialnet/email_utils.py
+++ b/antisocialnet/email_utils.py
@@ -12,10 +12,11 @@ def send_password_reset_email(user):
     # For now, email content will be basic. Could use templates later.
     subject = "Password Reset Request for Your App"
     sender = current_app.config.get('MAIL_DEFAULT_SENDER', 'noreply@example.com')
-    recipients = [user.email] # Assuming user model has an 'email' field
+    recipients = [user.username] # User.username stores the email address
 
     # Simple text body, consider HTML template for richer emails
-    text_body = f"""Dear {user.username or 'User'},
+    salutation_name = user.full_name or (('@' + user.handle) if user.handle else 'User')
+    text_body = f"""Dear {salutation_name},
 
 To reset your password, please visit the following link:
 {reset_url}

--- a/antisocialnet/forms.py
+++ b/antisocialnet/forms.py
@@ -10,7 +10,7 @@ from wtforms import (
     IntegerField
 )
 from wtforms.fields import DateField # Changed import for DateField
-from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional, NumberRange # Added Email
+from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional, NumberRange, Regexp # Added Email and Regexp
 from wtforms.widgets import CheckboxInput, ListWidget # Ensure ListWidget is imported if used by QuerySelectMultipleField
 from wtforms_sqlalchemy.fields import QuerySelectMultipleField
 from .models import Category # Import Category from models.py
@@ -24,7 +24,17 @@ class LoginForm(FlaskForm):
 
 class RegistrationForm(FlaskForm):
     full_name = StringField('Display Name', validators=[DataRequired(), Length(min=1, max=120)])
-    email = StringField('Email (Username)', validators=[DataRequired(), Length(min=6, max=120), Email(message="Please enter a valid email address.")])
+    email = StringField('Email (for login)', validators=[DataRequired(), Length(min=6, max=120), Email(message="Please enter a valid email address.")])
+    handle = StringField(
+        'Public Handle (@yourhandle)',
+        validators=[
+            DataRequired(),
+            Length(min=3, max=80),
+            # Basic regex for valid characters (alphanumeric and underscores)
+            # More complex validation (like no leading/trailing underscores, no double underscores) can be added
+            Regexp(r'^[a-zA-Z0-9_]+$', message="Handle can only contain letters, numbers, and underscores.")
+        ]
+    )
     password = PasswordField('Password', validators=[DataRequired(), Length(min=8, message="Password must be at least 8 characters long.")])
     confirm_password = PasswordField(
         'Confirm Password',

--- a/antisocialnet/models.py
+++ b/antisocialnet/models.py
@@ -10,7 +10,8 @@ from flask import current_app # For accessing app config (SECRET_KEY)
 # Models (Copied from app.py, generate_slug replaced with generate_slug_util)
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(80), unique=True, nullable=False)
+    username = db.Column(db.String(80), unique=True, nullable=False) # Stores email, used for login
+    handle = db.Column(db.String(80), unique=True, nullable=True, index=True) # TODO: Make nullable=False after data migration and form updates
     password_hash = db.Column(db.String(256), nullable=False)
     profile_info = db.Column(db.Text, nullable=True)
     profile_photo_url = db.Column(db.String(512), nullable=True)

--- a/antisocialnet/routes/admin_routes.py
+++ b/antisocialnet/routes/admin_routes.py
@@ -17,7 +17,7 @@ def admin_required(f):
     @login_required
     def decorated_function(*args, **kwargs):
         if not current_user.is_admin:
-            current_app.logger.warning(f"Non-admin user {current_user.username} attempted to access admin route {request.path}.")
+            current_app.logger.warning(f"Non-admin User ID: {current_user.id} (Handle: {current_user.handle}) attempted to access admin route {request.path}.")
             abort(403)
         return f(*args, **kwargs)
     return decorated_function
@@ -25,7 +25,7 @@ def admin_required(f):
 @admin_bp.route('/flags', methods=['GET'])
 @admin_required
 def view_flags():
-    current_app.logger.debug(f"Admin {current_user.username} accessing /admin/flags")
+    current_app.logger.debug(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) accessing /admin/flags")
     page = request.args.get('page', 1, type=int)
     per_page = current_app.config.get('ADMIN_FLAGS_PER_PAGE', 15)
 
@@ -40,13 +40,13 @@ def view_flags():
         flag.delete_comment_form = delete_form
         active_flags_with_forms.append(flag)
 
-    current_app.logger.info(f"Admin {current_user.username} viewing flagged comments page {page}. Found {len(active_flags_with_forms)} active flags.")
+    current_app.logger.info(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) viewing flagged comments page {page}. Found {len(active_flags_with_forms)} active flags.")
     return render_template('admin_flags.html', active_flags=active_flags_with_forms, flag_pagination=flag_pagination)
 
 @admin_bp.route('/flag/<int:flag_id>/resolve', methods=['POST'])
 @admin_required
 def resolve_flag(flag_id):
-    current_app.logger.debug(f"Admin {current_user.username} attempting to resolve flag ID {flag_id}")
+    current_app.logger.debug(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) attempting to resolve flag ID {flag_id}")
     flag = CommentFlag.query.get_or_404(flag_id)
     if flag.is_resolved:
         flash('This flag has already been resolved.', 'info')
@@ -58,22 +58,22 @@ def resolve_flag(flag_id):
         flag.resolver_user_id = current_user.id
         db.session.add(flag)
         db.session.commit()
-        current_app.logger.info(f"Admin {current_user.username} resolved flag ID {flag_id} for comment ID {flag.comment_id}.")
+        current_app.logger.info(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) resolved flag ID {flag_id} for comment ID {flag.comment_id}.")
         flash(f'Flag for comment "{flag.comment.text[:30]}..." resolved.', 'toast_success')
     except Exception as e:
         db.session.rollback()
-        current_app.logger.error(f"Error resolving flag {flag_id} by admin {current_user.username}: {e}", exc_info=True)
+        current_app.logger.error(f"Error resolving flag {flag_id} by Admin User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
         flash('Error resolving flag.', 'danger')
     return redirect(url_for('admin.view_flags'))
 
 @admin_bp.route('/site-settings', methods=['GET', 'POST'])
 @admin_required
 def site_settings():
-    current_app.logger.debug(f"Admin {current_user.username} accessing /admin/site-settings, Method: {request.method}")
+    current_app.logger.debug(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) accessing /admin/site-settings, Method: {request.method}")
     form = SiteSettingsForm(request.form)
 
     if form.validate_on_submit():
-        current_app.logger.info(f"Admin {current_user.username} updating site settings.")
+        current_app.logger.info(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) updating site settings.")
         try:
             SiteSetting.set('site_title', form.site_title.data, 'string')
             try:
@@ -88,10 +88,10 @@ def site_settings():
                 flash("Invalid value for Posts Per Page. Must be an integer.", "danger")
             SiteSetting.set('allow_registrations', form.allow_registrations.data, 'bool')
             flash('Site settings updated successfully!', 'toast_success')
-            current_app.logger.info(f"Site settings updated by admin {current_user.username}.")
+            current_app.logger.info(f"Site settings updated by Admin User ID: {current_user.id} (Handle: {current_user.handle}).")
             return redirect(url_for('admin.site_settings'))
         except Exception as e:
-            current_app.logger.error(f"Error updating site settings: {e}", exc_info=True)
+            current_app.logger.error(f"Error updating site settings by Admin User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
             flash('An unexpected error occurred while saving settings.', 'danger')
     elif request.method == 'POST':
         flash_form_errors_util(form)
@@ -106,56 +106,60 @@ def site_settings():
 @admin_bp.route('/pending_users', methods=['GET'])
 @admin_required
 def pending_users():
-    current_app.logger.debug(f"Admin {current_user.username} accessing /admin/pending_users")
+    current_app.logger.debug(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) accessing /admin/pending_users")
     page = request.args.get('page', 1, type=int)
     per_page = current_app.config.get('ADMIN_USERS_PER_PAGE', 15)
     users_query = User.query.filter_by(is_approved=False, is_active=False)\
                             .order_by(User.id.asc())
     user_pagination = users_query.paginate(page=page, per_page=per_page, error_out=False)
     pending_users_list = user_pagination.items
-    current_app.logger.info(f"Admin {current_user.username} viewing pending users page {page}. Found {len(pending_users_list)} pending users.")
+    current_app.logger.info(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) viewing pending users page {page}. Found {len(pending_users_list)} pending users.")
     return render_template('admin_pending_users.html', pending_users=pending_users_list, user_pagination=user_pagination)
 
 @admin_bp.route('/users/<int:user_id>/approve', methods=['POST'])
 @admin_required
 def approve_user(user_id):
-    current_app.logger.debug(f"Admin {current_user.username} attempting to approve user ID {user_id}")
+    current_app.logger.debug(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) attempting to approve user ID {user_id}")
     user_to_approve = User.query.get_or_404(user_id)
+    display_name_approve = user_to_approve.full_name or (('@' + user_to_approve.handle) if user_to_approve.handle else user_to_approve.username)
     if user_to_approve.is_approved and user_to_approve.is_active:
-        flash(f'User {user_to_approve.username} is already approved and active.', 'info')
+        flash(f'User {display_name_approve} is already approved and active.', 'info')
         return redirect(url_for('admin.pending_users'))
     try:
         user_to_approve.is_approved = True
         user_to_approve.is_active = True
         db.session.add(user_to_approve)
         db.session.commit()
-        current_app.logger.info(f"Admin {current_user.username} approved user ID {user_id} ({user_to_approve.username}).")
-        flash(f'User {user_to_approve.username} has been approved and activated.', 'toast_success')
+        current_app.logger.info(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) approved User ID: {user_id} (Approved User Handle: {user_to_approve.handle}, Email: {user_to_approve.username}).")
+        flash(f'User {display_name_approve} has been approved and activated.', 'toast_success')
     except Exception as e:
         db.session.rollback()
-        current_app.logger.error(f"Error approving user {user_id} by admin {current_user.username}: {e}", exc_info=True)
+        current_app.logger.error(f"Error approving User ID: {user_id} by Admin User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
         flash('Error approving user.', 'danger')
     return redirect(url_for('admin.pending_users'))
 
 @admin_bp.route('/users/<int:user_id>/reject', methods=['POST'])
 @admin_required
 def reject_user(user_id):
-    current_app.logger.debug(f"Admin {current_user.username} attempting to reject user ID {user_id}")
+    current_app.logger.debug(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) attempting to reject user ID {user_id}")
     user_to_reject = User.query.get_or_404(user_id)
+    display_name_reject = user_to_reject.full_name or (('@' + user_to_reject.handle) if user_to_reject.handle else user_to_reject.username)
+    original_username_for_log = user_to_reject.username # Email, for logging before deletion
+    original_handle_for_log = user_to_reject.handle # Handle, for logging
+
     if user_to_reject.is_approved or user_to_reject.is_active:
-        flash(f'User {user_to_reject.username} is already active or approved and cannot be rejected from this interface.', 'warning')
+        flash(f'User {display_name_reject} is already active or approved and cannot be rejected from this interface.', 'warning')
         return redirect(url_for('admin.pending_users'))
     if user_to_reject.is_admin:
         flash('Cannot reject an administrator account through this interface.', 'danger')
         return redirect(url_for('admin.pending_users'))
     try:
-        username_rejected = user_to_reject.username
         db.session.delete(user_to_reject)
         db.session.commit()
-        current_app.logger.info(f"Admin {current_user.username} rejected and deleted user ID {user_id} (Username: {username_rejected}).")
-        flash(f'User {username_rejected} has been rejected and deleted.', 'toast_success')
+        current_app.logger.info(f"Admin User ID: {current_user.id} (Handle: {current_user.handle}) rejected and deleted User ID: {user_id} (Rejected User Handle: {original_handle_for_log}, Email: {original_username_for_log}).")
+        flash(f'User {display_name_reject} has been rejected and deleted.', 'toast_success')
     except Exception as e:
         db.session.rollback()
-        current_app.logger.error(f"Error rejecting user {user_id} by admin {current_user.username}: {e}", exc_info=True)
+        current_app.logger.error(f"Error rejecting User ID: {user_id} by Admin User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
         flash('Error rejecting user.', 'danger')
     return redirect(url_for('admin.pending_users'))

--- a/antisocialnet/routes/api_routes.py
+++ b/antisocialnet/routes/api_routes.py
@@ -150,9 +150,10 @@ def serialize_actor(user_model_instance):
 
     return {
         "id": user_model_instance.id,
-        "username": user_model_instance.username,
+        "handle": user_model_instance.handle, # Added handle
         "full_name": user_model_instance.full_name,
         "profile_photo_url": profile_photo_url_val
+        # Removed username (which is email) from public API actor serialization
     }
 
 def serialize_post_item(post):
@@ -203,7 +204,7 @@ def serialize_photo_item(photo):
             "image_url_large": url_for('static', filename=photo.image_filename, _external=True) if photo.image_filename else None,
             # "image_url_thumbnail": ..., # Placeholder
             "comment_count": photo.comments.count(),
-            "gallery_url": url_for('profile.view_gallery', username=photo.user.username, _anchor=f'photo-{photo.id}', _external=True)
+            "gallery_url": url_for('profile.view_gallery', handle=photo.user.handle, _anchor=f'photo-{photo.id}', _external=True) if photo.user else None
         }
     }
 # Add other API routes here in the future

--- a/antisocialnet/routes/auth_routes.py
+++ b/antisocialnet/routes/auth_routes.py
@@ -15,7 +15,9 @@ auth_bp = Blueprint('auth', __name__, url_prefix='/auth')
 def register():
     current_app.logger.debug(f"Accessing /auth/register, Method: {request.method}, IP: {request.remote_addr}")
     if current_user.is_authenticated:
-        current_app.logger.debug(f"User {current_user.username} already authenticated, redirecting to general.index.")
+        user_id_log = current_user.id if hasattr(current_user, 'id') else 'N/A'
+        user_handle_log = current_user.handle if hasattr(current_user, 'handle') else 'N/A'
+        current_app.logger.debug(f"User ID {user_id_log} (Handle: {user_handle_log}) already authenticated, redirecting to general.index.")
         return redirect(url_for('general.index'))
 
     if not SiteSetting.get('allow_registrations', False):
@@ -28,16 +30,25 @@ def register():
         current_app.logger.debug(f"Registration form submitted. Email: '{form.email.data}'")
 
     if form.validate_on_submit():
-        existing_user = User.query.filter_by(username=form.email.data).first()
-        if existing_user:
+        # Check 1: Email (which is User.username) uniqueness
+        existing_user_by_email = User.query.filter_by(username=form.email.data).first()
+        if existing_user_by_email:
             current_app.logger.warning(f"Registration attempt with existing email: '{form.email.data}'.")
             flash('An account with this email address already exists. Please log in or use a different email.', 'danger')
-            return render_template('register.html', form=form) # Show form again with error
+            return render_template('register.html', form=form)
+
+        # Check 2: Handle uniqueness
+        existing_user_by_handle = User.query.filter_by(handle=form.handle.data).first()
+        if existing_user_by_handle:
+            current_app.logger.warning(f"Registration attempt with existing handle: '{form.handle.data}'.")
+            flash('This public handle is already taken. Please choose a different one.', 'danger')
+            return render_template('register.html', form=form)
 
         try:
             new_user = User(
-                username=form.email.data,
-                full_name=form.full_name.data, # Added full_name
+                username=form.email.data,  # Email for login
+                handle=form.handle.data,    # Public handle
+                full_name=form.full_name.data,
                 is_approved=False,
                 is_active=False,
                 is_admin=False # Explicitly false for new registrations
@@ -45,19 +56,22 @@ def register():
             new_user.set_password(form.password.data)
             db.session.add(new_user)
             db.session.commit()
-            current_app.logger.info(f"New user '{new_user.username}' (ID: {new_user.id}) registered successfully. Pending approval.")
+            # Log email (new_user.username) here as it's relevant to account creation internal logs, but be mindful.
+            # Handle is the primary public identifier.
+            current_app.logger.info(f"New user registered - Email: '{new_user.username}', Handle: '{new_user.handle}', ID: {new_user.id}. Pending approval.")
             flash('Registration successful! Your account is pending admin approval.', 'success')
             return redirect(url_for('auth.login'))
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error during new user registration for email '{form.email.data}': {e}", exc_info=True)
+            current_app.logger.error(f"Error during new user registration for email '{form.email.data}', handle '{form.handle.data}': {e}", exc_info=True)
             flash('An unexpected error occurred during registration. Please try again later.', 'danger')
-            # It's important to render the template again here, not redirect,
-            # so the user doesn't lose their input if it was a transient error.
             return render_template('register.html', form=form)
 
     elif request.method == 'POST': # Catches validation failures on POST
-        current_app.logger.warning(f"Registration form validation failed for email: '{form.email.data}'. Errors: {form.errors}")
+        # Log both email and handle for context on validation failure
+        log_email = form.email.data if form.email else "N/A"
+        log_handle = form.handle.data if form.handle else "N/A"
+        current_app.logger.warning(f"Registration form validation failed for email: '{log_email}', handle: '{log_handle}'. Errors: {form.errors}")
         flash_form_errors_util(form)
 
     current_app.logger.debug(f"Rendering register template for {request.path}")
@@ -67,26 +81,29 @@ def register():
 def login():
     current_app.logger.debug(f"Accessing /auth/login, Method: {request.method}, IP: {request.remote_addr}")
     if current_user.is_authenticated:
-        current_app.logger.debug(f"User {current_user.username} already authenticated, redirecting to general.index.")
+        user_id_log = current_user.id if hasattr(current_user, 'id') else 'N/A'
+        user_handle_log = current_user.handle if hasattr(current_user, 'handle') else 'N/A'
+        current_app.logger.debug(f"User ID {user_id_log} (Handle: {user_handle_log}) already authenticated, redirecting to general.index.")
         return redirect(url_for('general.index'))
 
     form = LoginForm(request.form)
     if request.method == 'POST':
-        current_app.logger.debug(f"Login form submitted. Username: '{form.username.data}'")
+        # form.username.data is the email used for login
+        current_app.logger.debug(f"Login form submitted. Email (for login): '{form.username.data}'")
 
     if form.validate_on_submit(): # validate_on_submit checks method and validates
-        user = User.query.filter_by(username=form.username.data).first()
+        user = User.query.filter_by(username=form.username.data).first() # User.username is email
         if user and user.check_password(form.password.data):
             if not user.is_active:
-                current_app.logger.warning(f"Login attempt by inactive user: '{user.username}'.")
+                current_app.logger.warning(f"Login attempt by inactive user - Email: '{user.username}', Handle: '{user.handle}'.")
                 flash('Your account is not active. Please contact an administrator.', 'danger')
             elif not user.is_approved:
-                current_app.logger.warning(f"Login attempt by unapproved user: '{user.username}'.")
+                current_app.logger.warning(f"Login attempt by unapproved user - Email: '{user.username}', Handle: '{user.handle}'.")
                 flash('Your account is pending admin approval.', 'danger')
             else:
                 login_user(user)
-                current_app.logger.info(f"User '{user.username}' (ID: {user.id}) logged in successfully.")
-                current_app.logger.debug(f"Session after login for user '{user.username}': {dict(session)}")
+                current_app.logger.info(f"User logged in - Email: '{user.username}', Handle: '{user.handle}', ID: {user.id}.")
+                current_app.logger.debug(f"Session after login for user (Handle: '{user.handle}', ID: {user.id}): {dict(session)}")
             flash('Logged in successfully.', 'toast_success') # Changed to toast_success
             next_page = request.args.get('next')
             # More robust security check for next_page
@@ -105,13 +122,15 @@ def login():
                          current_app.logger.warning(f"Potentially unsafe next URL path: {next_page}")
                          next_page = None # Or just ensure it's a path within the app
 
-            current_app.logger.debug(f"Login next page: '{next_page}', redirecting.")
+            current_app.logger.debug(f"Login next page for user (Handle: {user.handle}, ID: {user.id}): '{next_page}', redirecting.")
             return redirect(next_page or url_for('general.index'))
         else:
-            current_app.logger.warning(f"Invalid login attempt for username: '{form.username.data}'. User exists: {user is not None}.")
+            # Log the email used for login attempt
+            current_app.logger.warning(f"Invalid login attempt for email: '{form.username.data}'. User exists: {user is not None}.")
             flash('Invalid username or password.', 'danger')
     elif request.method == 'POST': # Catches validation failures on POST
-        current_app.logger.warning(f"Login form validation failed for username: '{form.username.data}'. Errors: {form.errors}")
+        # Log the email used for login attempt
+        current_app.logger.warning(f"Login form validation failed for email: '{form.username.data}'. Errors: {form.errors}")
         flash_form_errors_util(form)
         # The original code had an additional flash if form.errors was empty,
         # but validate_on_submit failing usually means form.errors is populated.
@@ -125,14 +144,14 @@ def login():
 @auth_bp.route('/logout')
 @login_required
 def logout():
-    current_app.logger.debug(f"Accessing /auth/logout, User: {current_user.username}")
-    # Store username before logout for logging, if needed
-    username_before_logout = current_user.username
-    user_id_before_logout = current_user.id
+    user_id_log = current_user.id if hasattr(current_user, 'id') else 'N/A'
+    user_handle_log = current_user.handle if hasattr(current_user, 'handle') else 'N/A'
+    user_email_log = current_user.username # Storing email for internal log before logout
+    current_app.logger.debug(f"Accessing /auth/logout, User ID: {user_id_log}, Handle: {user_handle_log}, Email: {user_email_log}")
 
     logout_user()
 
-    current_app.logger.info(f"User '{username_before_logout}' (ID: {user_id_before_logout}) logged out successfully.")
+    current_app.logger.info(f"User logged out - Email: '{user_email_log}', Handle: '{user_handle_log}', ID: {user_id_log}.")
     current_app.logger.debug(f"Session after logout: {dict(session)}")
     flash('Logged out successfully.', 'toast_success') # Changed to toast_success
     return redirect(url_for('general.index'))
@@ -141,31 +160,34 @@ def logout():
 @auth_bp.route('/change-password', methods=['GET', 'POST']) # Removed /settings prefix, part of /auth now
 @login_required
 def change_password_page():
-    current_app.logger.debug(f"Accessing /auth/change-password, Method: {request.method}, User: {current_user.username}")
+    user_id_log = current_user.id
+    user_handle_log = current_user.handle
+    user_email_log = current_user.username # For internal logging context
+    current_app.logger.debug(f"Accessing /auth/change-password, Method: {request.method}, User ID: {user_id_log}, Handle: {user_handle_log}, Email: {user_email_log}")
     form = ChangePasswordForm(request.form)
     if request.method == 'POST':
-        current_app.logger.debug(f"Change password form submitted by {current_user.username}.")
+        current_app.logger.debug(f"Change password form submitted by User ID: {user_id_log}, Handle: {user_handle_log}, Email: {user_email_log}.")
 
     if form.validate_on_submit():
-        current_app.logger.info(f"User {current_user.username} attempting to change password.")
+        current_app.logger.info(f"User ID: {user_id_log} (Handle: {user_handle_log}, Email: {user_email_log}) attempting to change password.")
         if current_user.check_password(form.current_password.data):
             try:
                 current_user.set_password(form.new_password.data)
                 db.session.add(current_user) # Add to session before commit if changed
                 db.session.commit()
-                current_app.logger.info(f"Password changed for user {current_user.username}.")
+                current_app.logger.info(f"Password changed for User ID: {user_id_log} (Handle: {user_handle_log}, Email: {user_email_log}).")
                 flash('Your password has been updated successfully!', 'toast_success')
                 # Redirect to a general settings page or profile page
                 return redirect(url_for('general.settings_page'))
             except Exception as e:
                 db.session.rollback()
-                current_app.logger.error(f"Error saving new password for {current_user.username}: {e}", exc_info=True)
+                current_app.logger.error(f"Error saving new password for User ID: {user_id_log} (Handle: {user_handle_log}, Email: {user_email_log}): {e}", exc_info=True)
                 flash('Error changing password. Please try again.', 'danger')
         else:
-            current_app.logger.warning(f"Invalid current password by user {current_user.username} during password change.")
+            current_app.logger.warning(f"Invalid current password by User ID: {user_id_log} (Handle: {user_handle_log}, Email: {user_email_log}) during password change.")
             flash('Invalid current password.', 'danger')
     elif request.method == 'POST': # Catches validation failures on POST
-        current_app.logger.warning(f"Change password form validation failed for {current_user.username}. Errors: {form.errors}")
+        current_app.logger.warning(f"Change password form validation failed for User ID: {user_id_log} (Handle: {user_handle_log}, Email: {user_email_log}). Errors: {form.errors}")
         flash_form_errors_util(form)
 
     current_app.logger.debug(f"Rendering change_password template for {request.path}")
@@ -178,14 +200,15 @@ def reset_password_request():
         return redirect(url_for('general.index'))
     form = RequestPasswordResetForm()
     if form.validate_on_submit():
-        user = User.query.filter_by(email=form.email.data).first() # Assuming username is email
+        # User.username stores the email address
+        user = User.query.filter_by(username=form.email.data).first()
         if user:
             try:
                 send_password_reset_email(user)
-                current_app.logger.info(f"Password reset email initiated for user {user.username} (Email: {user.email}).")
+                current_app.logger.info(f"Password reset email initiated for User ID: {user.id} (Handle: {user.handle}, Email: {user.username}).")
                 flash('An email has been sent with instructions to reset your password.', 'info')
             except Exception as e:
-                current_app.logger.error(f"Failed to send password reset email for {form.email.data}: {e}", exc_info=True)
+                current_app.logger.error(f"Failed to send password reset email for Email: {form.email.data}: {e}", exc_info=True)
                 flash('Sorry, there was an error sending the password reset email. Please try again later.', 'danger')
         else:
             # Don't reveal if email exists or not for security, same message.
@@ -214,14 +237,14 @@ def reset_password_with_token(token):
             user.set_password(form.password.data)
             db.session.add(user)
             db.session.commit()
-            current_app.logger.info(f"Password has been reset for user {user.username} (ID: {user.id}).")
+            current_app.logger.info(f"Password has been reset for User ID: {user.id} (Handle: {user.handle}, Email: {user.username}).")
             flash('Your password has been reset successfully! You can now log in.', 'success')
             # Optional: Log the user in automatically
             # login_user(user)
             return redirect(url_for('auth.login'))
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error saving reset password for {user.username}: {e}", exc_info=True)
+            current_app.logger.error(f"Error saving reset password for User ID: {user.id} (Handle: {user.handle}, Email: {user.username}): {e}", exc_info=True)
             flash('An error occurred while resetting your password. Please try again.', 'danger')
     elif request.method == 'POST':
         flash_form_errors_util(form)

--- a/antisocialnet/routes/notification_routes.py
+++ b/antisocialnet/routes/notification_routes.py
@@ -8,7 +8,7 @@ notification_bp = Blueprint('notification', __name__, url_prefix='/notifications
 @notification_bp.route('/')
 @login_required
 def list_notifications():
-    current_app.logger.info(f"User {current_user.username} accessing notifications page.")
+    current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) accessing notifications page.")
     page = request.args.get('page', 1, type=int)
     # Consider a specific config for NOTIFICATIONS_PER_PAGE or use an existing one
     per_page = current_app.config.get('POSTS_PER_PAGE', 20)
@@ -29,15 +29,15 @@ def list_notifications():
             Notification.query.filter(Notification.id.in_(ids_to_mark_read))\
                               .update({'is_read': True}, synchronize_session=False)
             db.session.commit()
-            current_app.logger.info(f"Marked {len(ids_to_mark_read)} notifications as read for user {current_user.username}.")
+            current_app.logger.info(f"Marked {len(ids_to_mark_read)} notifications as read for User ID: {current_user.id} (Handle: {current_user.handle}).")
             # Note: The unread_notifications_count in base.html might not update on this same page load
             # without a redirect or AJAX, as it's calculated before this route logic runs fully for the render.
             # A redirect(url_for('notification.list_notifications', page=page)) could fix this, but might be too much.
             # For now, count will update on next page load/navigation.
 
-        current_app.logger.debug(f"Found {len(notifications_list)} notifications for {current_user.username} on page {page}. Total: {pagination.total}")
+        current_app.logger.debug(f"Found {len(notifications_list)} notifications for User ID: {current_user.id} (Handle: {current_user.handle}) on page {page}. Total: {pagination.total}")
     except Exception as e:
-        current_app.logger.error(f"Error fetching notifications for {current_user.username}: {e}", exc_info=True)
+        current_app.logger.error(f"Error fetching notifications for User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
         flash("Error loading notifications.", "danger")
         notifications_list, pagination = [], None
 

--- a/antisocialnet/routes/photo_routes.py
+++ b/antisocialnet/routes/photo_routes.py
@@ -35,10 +35,10 @@ def get_photo_comments(photo_id):
             'created_at': comment.created_at.isoformat() + "Z", # Add Z for UTC indication
             'author': {
                 'id': comment.author.id,
-                'username': comment.author.username,
-                'full_name': comment.author.full_name or comment.author.username,
+                'handle': comment.author.handle, # Use handle
+                'full_name': comment.author.full_name or ('@' + comment.author.handle if comment.author.handle else comment.author.username), # Display full_name or @handle
                 'profile_photo_url': get_avatar_url(comment.author),
-                'profile_url': url_for('profile.view_profile', username=comment.author.username, _external=False)
+                'profile_url': url_for('profile.view_profile', handle=comment.author.handle, _external=False) if comment.author.handle else None # Link to profile via handle
             }
         })
     return jsonify(comments_data)
@@ -69,38 +69,33 @@ def post_photo_comment(photo_id):
         # Commit the comment first to get its ID for notifications
         db.session.commit()
 
-        # Process mentions in the comment
-        mentioned_usernames = extract_mentions(new_comment.text)
+        # Process mentions in the comment (now using handles)
+        mentioned_handles = extract_mentions(new_comment.text) # extract_mentions now looks for handles
         new_mentions_created = False
-        if mentioned_usernames:
-            for username_str in mentioned_usernames:
-                mentioned_user_obj = User.query.filter_by(username=username_str).first()
+        if mentioned_handles:
+            for handle_str in mentioned_handles:
+                mentioned_user_obj = User.query.filter_by(handle=handle_str).first() # Query by handle
                 if mentioned_user_obj: # Check if user exists
                     if mentioned_user_obj.id != current_user.id: # Don't notify for self-mentions
                         # Avoid duplicate notifications for this specific comment
                         existing_notif = Notification.query.filter_by(
                             user_id=mentioned_user_obj.id,
                             actor_id=current_user.id,
-                            type='mention_in_photo_comment', # Specific type for photo comments
-                                # related_comment_id=new_comment.id # Old field
-                                target_type='photo_comment',      # New field - target is the photo comment
-                                target_id=new_comment.id          # New field
+                            type='mention_in_photo_comment',
+                            target_type='photo_comment',
+                            target_id=new_comment.id
                         ).first()
                         if not existing_notif:
                             mention_notification = Notification(
                                 user_id=mentioned_user_obj.id,
                                 actor_id=current_user.id,
                                 type='mention_in_photo_comment',
-                                    target_type='photo_comment', # Target is the photo comment itself
-                                    target_id=new_comment.id
-                                    # We could add related_photo_id if we decide to keep specific foreign keys
-                                    # For now, the template will use get_target_object() and navigate from there.
-                                    # Example: target_object = notification.get_target_object() (which is a PhotoComment)
-                                    # then photo = target_object.photo
+                                target_type='photo_comment',
+                                target_id=new_comment.id
                             )
                             db.session.add(mention_notification)
                             new_mentions_created = True
-                            current_app.logger.info(f"Mention notification created for user {mentioned_user_obj.username} in photo comment {new_comment.id}")
+                            current_app.logger.info(f"Mention notification created for user (handle: {mentioned_user_obj.handle}) in photo comment {new_comment.id}")
 
         if new_mentions_created:
             db.session.commit() # Commit any new mention notifications
@@ -108,13 +103,13 @@ def post_photo_comment(photo_id):
         return jsonify({
             'id': new_comment.id,
             'text': new_comment.text,
-            'created_at': new_comment.created_at.isoformat() + "Z", # Add Z for UTC indication
+            'created_at': new_comment.created_at.isoformat() + "Z",
             'author': {
                 'id': current_user.id,
-                'username': current_user.username,
-                'full_name': current_user.full_name or current_user.username,
+                'handle': current_user.handle, # Return handle
+                'full_name': current_user.full_name or ('@' + current_user.handle if current_user.handle else current_user.username), # Display full_name or @handle
                 'profile_photo_url': get_avatar_url(current_user),
-                'profile_url': url_for('profile.view_profile', username=current_user.username, _external=False)
+                'profile_url': url_for('profile.view_profile', handle=current_user.handle, _external=False) if current_user.handle else None # Link via handle
             }
         }), 201
     else:

--- a/antisocialnet/routes/post_routes.py
+++ b/antisocialnet/routes/post_routes.py
@@ -16,10 +16,10 @@ def view_post(post_id):
 
     if not post.is_published:
         if not current_user.is_authenticated or current_user.id != post.user_id:
-            user_desc = current_user.username if current_user.is_authenticated else 'Anonymous'
-            current_app.logger.warning(f"User {user_desc} attempted to view unpublished post ID: {post_id}. Denying access.")
+            user_desc = f"User ID: {current_user.id} (Handle: {current_user.handle})" if current_user.is_authenticated else 'Anonymous'
+            current_app.logger.warning(f"{user_desc} attempted to view unpublished post ID: {post_id}. Denying access.")
             abort(404)
-        current_app.logger.debug(f"Author {current_user.username} viewing their own unpublished post ID: {post.id}.")
+        current_app.logger.debug(f"Author User ID: {current_user.id} (Handle: {current_user.handle}) viewing their own unpublished post ID: {post.id}.")
     else:
         current_app.logger.debug(f"Viewing published post ID: {post_id}.")
 
@@ -38,7 +38,7 @@ def view_post(post_id):
         try:
             parent_id_val = form.parent_id.data
             parent_id_int = int(parent_id_val) if parent_id_val and parent_id_val.isdigit() else None
-            current_app.logger.info(f"User {current_user.username} submitting comment on post {post_id}. Parent ID: {parent_id_int}.")
+            current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) submitting comment on post {post_id}. Parent ID: {parent_id_int}.")
 
             comment = Comment(text=form.text.data, user_id=current_user.id, post_id=post_id, parent_id=parent_id_int)
             db.session.add(comment)
@@ -68,7 +68,7 @@ def view_post(post_id):
                 # We can still populate related_post_id for context if the target is a comment.
                 notification.related_post_id = post.id # Keep for context if target is comment
                 db.session.add(notification)
-                current_app.logger.info(f"Notification created for user {post.author.username} about new comment by {current_user.username} on post {post.id}.")
+                current_app.logger.info(f"Notification created for User ID: {post.author.id} (Handle: {post.author.handle}) about new comment by User ID: {current_user.id} (Handle: {current_user.handle}) on post {post.id}.")
 
             # Create Activity entry for new comment
             from ..models import Activity # Local import (already imported for like, but good practice if separated)
@@ -83,45 +83,52 @@ def view_post(post_id):
             # Contextual: if activity is about a comment on a post, also store post_id
             activity.target_post_id = post.id # Keep for context
             db.session.add(activity)
-            current_app.logger.info(f"Activity 'commented_on_post' logged for user {current_user.username} on post {post.id}, comment ID pending (will be {comment.id}).")
+            current_app.logger.info(f"Activity 'commented_on_post' logged for User ID: {current_user.id} (Handle: {current_user.handle}) on post {post.id}, comment ID pending (will be {comment.id}).")
 
             db.session.commit() # Commit comment, notification, and activity together
 
-            current_app.logger.info(f"Comment (ID: {comment.id}) by {current_user.username} added to post {post_id}.")
+            current_app.logger.info(f"Comment (ID: {comment.id}) by User ID: {current_user.id} (Handle: {current_user.handle}) added to post {post_id}.")
             if 'activity' in locals(): # Check if activity was created
-                 current_app.logger.info(f"Activity 'commented_on_post' (ID: {activity.id}) confirmed for user {current_user.username}, post ID {post.id}, comment ID {comment.id}.")
+                 current_app.logger.info(f"Activity 'commented_on_post' (ID: {activity.id}) confirmed for User ID: {current_user.id} (Handle: {current_user.handle}), post ID {post.id}, comment ID {comment.id}.")
 
-            # Process mentions in the comment
-            mentioned_usernames_in_comment = extract_mentions(comment.text)
+            # Process mentions in the comment (extract_mentions now looks for handles)
+            mentioned_handles_in_comment = extract_mentions(comment.text)
             new_mentions_created_comment = False
-            if mentioned_usernames_in_comment:
+            if mentioned_handles_in_comment:
                 from ..models import User # Ensure User model is available
-                for username_str in mentioned_usernames_in_comment:
-                    mentioned_user_obj = User.query.filter_by(username=username_str).first()
+                for handle_str in mentioned_handles_in_comment: # Iterate handles
+                    mentioned_user_obj = User.query.filter_by(handle=handle_str).first() # Query by handle
                     if mentioned_user_obj: # Check if user exists
                         if mentioned_user_obj.id != current_user.id: # Don't notify for self-mentions
                             # Avoid duplicate notifications (simple check)
+                            # Existing related_comment_id is problematic if Notification model changed fully to polymorphic
+                            # Assuming related_comment_id is still there or needs to be target_id/target_type
                             existing_notif = Notification.query.filter_by(
-                                user_id=mentioned_user_obj.id, # Use .id from User object
+                                user_id=mentioned_user_obj.id,
                                 actor_id=current_user.id,
                                 type='mention_in_comment',
-                                related_comment_id=comment.id
+                                target_type='comment', # Check against new polymorphic fields
+                                target_id=comment.id
                             ).first()
                             if not existing_notif:
                                 mention_notification = Notification(
-                                    user_id=mentioned_user_obj.id, # Use .id from User object
+                                    user_id=mentioned_user_obj.id,
                                     actor_id=current_user.id,
                                     type='mention_in_comment',
-                                # related_post_id=post.id, # Old field
-                                # related_comment_id=comment.id # Old field
-                                target_type='comment', # Primary target is the comment where mention occurs
-                                target_id=comment.id
+                                    target_type='comment',
+                                    target_id=comment.id
                                 )
                                 # Contextual post_id for mentions in comments on posts
-                                mention_notification.related_post_id = post.id # Keep for context
+                                # This logic might be redundant if the target_object relationship is robust enough
+                                # For now, let's assume it's okay to keep it if Notification model supports it.
+                                # If Notification.related_post_id was removed, this line would error.
+                                # Let's check Notification model: related_post_id was REMOVED.
+                                # So, this line must be removed or Notification model changed.
+                                # For now, removing. The target is the comment, context comes from comment.post.
+                                # mention_notification.related_post_id = post.id # REMOVE IF related_post_id is removed from Notification
                                 db.session.add(mention_notification)
                                 new_mentions_created_comment = True
-                                current_app.logger.info(f"Mention notification created for user {mentioned_user_obj.username} in comment {comment.id}")
+                                current_app.logger.info(f"Mention notification created for User ID: {mentioned_user_obj.id} (Handle: {mentioned_user_obj.handle}) in comment {comment.id}")
 
             if new_mentions_created_comment:
                 db.session.commit()
@@ -165,11 +172,11 @@ def view_post(post_id):
 @post_bp.route('/create', methods=['GET', 'POST'])
 @login_required
 def create_post():
-    current_app.logger.debug(f"Accessing /create post, Method: {request.method}, User: {current_user.username}")
+    current_app.logger.debug(f"Accessing /create post, Method: {request.method}, User ID: {current_user.id} (Handle: {current_user.handle})")
     form = PostForm(request.form)
     if form.validate_on_submit():
         content = form.content.data # Raw Markdown
-        current_app.logger.info(f"User {current_user.username} creating post.")
+        current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) creating post.")
         try:
             # Posts are now immediately published by default
             new_post = Post(content=content, user_id=current_user.id,
@@ -189,21 +196,21 @@ def create_post():
                 target_id=new_post.id     # New field
             )
             db.session.add(activity)
-            current_app.logger.info(f"Activity 'created_post' logged for user {current_user.username}, post ID pending assignment (will be {new_post.id}).")
+            current_app.logger.info(f"Activity 'created_post' logged for User ID: {current_user.id} (Handle: {current_user.handle}), post ID pending assignment (will be {new_post.id}).")
 
             db.session.commit() # Commit post and activity first to get IDs
 
-            current_app.logger.info(f"Post ID: {new_post.id} (Published: True) created by {current_user.username}.")
+            current_app.logger.info(f"Post ID: {new_post.id} (Published: True) created by User ID: {current_user.id} (Handle: {current_user.handle}).")
             if 'activity' in locals(): # Check if activity was created
-                 current_app.logger.info(f"Activity 'created_post' (ID: {activity.id}) confirmed for user {current_user.username}, post ID {new_post.id}.")
+                 current_app.logger.info(f"Activity 'created_post' (ID: {activity.id}) confirmed for User ID: {current_user.id} (Handle: {current_user.handle}), post ID {new_post.id}.")
 
-            # Process mentions after initial commit
-            mentioned_usernames_in_post = extract_mentions(new_post.content)
+            # Process mentions after initial commit (extract_mentions now looks for handles)
+            mentioned_handles_in_post = extract_mentions(new_post.content)
             new_mentions_created_post = False
-            if mentioned_usernames_in_post:
+            if mentioned_handles_in_post:
                 from ..models import User # Ensure User model is available
-                for username_str in mentioned_usernames_in_post:
-                    mentioned_user_obj = User.query.filter_by(username=username_str).first()
+                for handle_str in mentioned_handles_in_post: # Iterate handles
+                    mentioned_user_obj = User.query.filter_by(handle=handle_str).first() # Query by handle
                     if mentioned_user_obj: # Check if user exists
                         if mentioned_user_obj.id != current_user.id: # Don't notify for self-mentions
                             # Avoid duplicate notifications (simple check for this post)
@@ -211,22 +218,20 @@ def create_post():
                                 user_id=mentioned_user_obj.id,
                                 actor_id=current_user.id,
                                 type='mention_in_post',
-                                # related_post_id=new_post.id # Old field
-                                target_type='post',         # New field
-                                target_id=new_post.id       # New field
+                                target_type='post',
+                                target_id=new_post.id
                             ).first()
                             if not existing_notif:
                                 mention_notification = Notification(
                                     user_id=mentioned_user_obj.id,
                                     actor_id=current_user.id,
                                     type='mention_in_post',
-                                    # related_post_id=new_post.id # Old field
-                                    target_type='post',         # New field
-                                    target_id=new_post.id       # New field
+                                    target_type='post',
+                                    target_id=new_post.id
                                 )
                                 db.session.add(mention_notification)
                                 new_mentions_created_post = True
-                                current_app.logger.info(f"Mention notification created for user {mentioned_user_obj.username} in post {new_post.id}")
+                                current_app.logger.info(f"Mention notification created for User ID: {mentioned_user_obj.id} (Handle: {mentioned_user_obj.handle}) in post {new_post.id}")
             if new_mentions_created_post:
                 db.session.commit() # Commit any mention notifications
 
@@ -234,10 +239,10 @@ def create_post():
             return redirect(url_for('post.view_post', post_id=new_post.id))
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error creating post by {current_user.username} or processing mentions: {e}", exc_info=True)
+            current_app.logger.error(f"Error creating post by User ID: {current_user.id} (Handle: {current_user.handle}) or processing mentions: {e}", exc_info=True)
             flash(f'Error creating post: {str(e)}', 'danger')
     elif request.method == 'POST':
-        current_app.logger.warning(f"Create post form validation failed. Errors: {form.errors}")
+        current_app.logger.warning(f"Create post form validation failed for User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {form.errors}")
         flash_form_errors_util(form)
 
     return render_template('create_post.html', form=form)
@@ -245,10 +250,10 @@ def create_post():
 @post_bp.route('/posts/<int:post_id>/edit', methods=['GET', 'POST'])
 @login_required
 def edit_post(post_id):
-    current_app.logger.debug(f"Accessing /posts/{post_id}/edit, Method: {request.method}, User: {current_user.username}")
+    current_app.logger.debug(f"Accessing /posts/{post_id}/edit, Method: {request.method}, User ID: {current_user.id} (Handle: {current_user.handle})")
     post = Post.query.get_or_404(post_id)
     if post.user_id != current_user.id and not current_user.is_admin: # Allow admin to edit
-        current_app.logger.warning(f"User {current_user.username} not authorized to edit post {post_id}.")
+        current_app.logger.warning(f"User ID: {current_user.id} (Handle: {current_user.handle}) not authorized to edit post {post_id}.")
         abort(403)
 
     # Ensure post is treated as published; editing does not change published status
@@ -263,7 +268,7 @@ def edit_post(post_id):
     delete_form = DeletePostForm(prefix=f"del-eff-post-{post.id}-")
 
     if form.validate_on_submit():
-        current_app.logger.info(f"User {current_user.username} updating post ID: {post_id}.")
+        current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) updating post ID: {post_id}.")
         post.content = form.content.data # Raw Markdown
         # is_published and published_at are not changed during an edit
 
@@ -272,45 +277,36 @@ def edit_post(post_id):
             db.session.add(post)
             db.session.commit() # Commit post content changes first
 
-            current_app.logger.info(f"Post ID {post.id} (Published: {post.is_published}) updated by {current_user.username}.")
+            current_app.logger.info(f"Post ID {post.id} (Published: {post.is_published}) updated by User ID: {current_user.id} (Handle: {current_user.handle}).")
 
-            # Process mentions for updated content
-            # Note: This doesn't remove notifications for users no longer mentioned.
-            # A more complex system would track existing mentions vs new ones.
-            # For now, it just adds new notifications.
-            mentioned_usernames_in_post = extract_mentions(post.content)
+            # Process mentions for updated content (extract_mentions now looks for handles)
+            mentioned_handles_in_post = extract_mentions(post.content)
             new_mentions_created = False
-            if mentioned_usernames_in_post:
+            if mentioned_handles_in_post:
                 from ..models import User # Ensure User model is available
-                for username_str in mentioned_usernames_in_post:
-                    mentioned_user_obj = User.query.filter_by(username=username_str).first()
+                for handle_str in mentioned_handles_in_post: # Iterate handles
+                    mentioned_user_obj = User.query.filter_by(handle=handle_str).first() # Query by handle
                     if mentioned_user_obj: # Check if user exists
                         if mentioned_user_obj.id != current_user.id: # Don't notify for self-mentions
-                            # Avoid duplicate notifications if a user is mentioned multiple times or was already notified for this post edit session
-                            # A more robust solution would check existing notifications of this type for this post by this actor.
-                            # Simplified: just create if they are mentioned in current content.
                             existing_notif = Notification.query.filter_by(
-                                user_id=mentioned_user_obj.id, # Use .id from User object
+                                user_id=mentioned_user_obj.id,
                                 actor_id=current_user.id,
                                 type='mention_in_post',
-                                # related_post_id=post.id # Old field
-                                target_type='post',     # New field
-                                target_id=post.id       # New field
-                            ).first() # This check is simplistic; doesn't account for multiple edits creating multiple notifs over time.
-                                      # A real system might only notify once per post, or if a user is newly added.
+                                target_type='post',
+                                target_id=post.id
+                            ).first()
 
-                            if not existing_notif: # Only create if no similar notification exists (simplistic check)
+                            if not existing_notif:
                                 mention_notification = Notification(
-                                    user_id=mentioned_user_obj.id, # Use .id from User object
+                                    user_id=mentioned_user_obj.id,
                                     actor_id=current_user.id,
                                     type='mention_in_post',
-                                    # related_post_id=post.id # Old field
-                                    target_type='post',     # New field
-                                    target_id=post.id       # New field
+                                    target_type='post',
+                                    target_id=post.id
                                 )
                                 db.session.add(mention_notification)
                                 new_mentions_created = True
-                                current_app.logger.info(f"Mention notification created for user {mentioned_user_obj.username} in updated post {post.id}")
+                                current_app.logger.info(f"Mention notification created for User ID: {mentioned_user_obj.id} (Handle: {mentioned_user_obj.handle}) in updated post {post.id}")
 
             if new_mentions_created:
                 db.session.commit()
@@ -319,10 +315,10 @@ def edit_post(post_id):
             return redirect(url_for('post.view_post', post_id=post.id))
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error updating post {post.id} or processing mentions: {e}", exc_info=True)
+            current_app.logger.error(f"Error updating post {post.id} by User ID: {current_user.id} (Handle: {current_user.handle}) or processing mentions: {e}", exc_info=True)
             flash(f'Error updating post: {str(e)}', 'danger')
     elif request.method == 'POST':
-        current_app.logger.warning(f"Edit post form validation failed for post {post_id}. Errors: {form.errors}")
+        current_app.logger.warning(f"Edit post form validation failed for post {post_id} by User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {form.errors}")
         flash_form_errors_util(form)
 
     if request.method == 'GET':
@@ -335,7 +331,7 @@ def edit_post(post_id):
 @post_bp.route('/posts/<int:post_id>/delete', methods=['POST'])
 @login_required
 def delete_post(post_id): # Renamed from delete_post_route
-    current_app.logger.debug(f"Accessing /posts/{post_id}/delete, User: {current_user.username}")
+    current_app.logger.debug(f"Accessing /posts/{post_id}/delete, User ID: {current_user.id} (Handle: {current_user.handle})")
 
     # Instantiate DeletePostForm for explicit CSRF validation
     form = DeletePostForm(request.form)
@@ -350,7 +346,7 @@ def delete_post(post_id): # Renamed from delete_post_route
 
     if form.validate_on_submit(): # Explicit CSRF validation
         if post.user_id != current_user.id and not current_user.is_admin:
-            current_app.logger.warning(f"User {current_user.username} not authorized to delete post {post_id}.")
+            current_app.logger.warning(f"User ID: {current_user.id} (Handle: {current_user.handle}) not authorized to delete post {post_id}.")
             abort(403)
 
         try:
@@ -388,15 +384,15 @@ def delete_post(post_id): # Renamed from delete_post_route
 
             db.session.delete(post)
             db.session.commit()
-            current_app.logger.info(f"Post ID: {post_id} successfully deleted by {current_user.username}.")
+            current_app.logger.info(f"Post ID: {post_id} successfully deleted by User ID: {current_user.id} (Handle: {current_user.handle}).")
             flash('Post deleted successfully!', 'toast_success')
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error deleting post ID {post_id}: {e}", exc_info=True)
+            current_app.logger.error(f"Error deleting post ID {post_id} by User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
             flash('Error deleting post. Please try again.', 'danger')
         return redirect(url_for('general.dashboard'))
     else: # CSRF validation failed
-        current_app.logger.warning(f"Delete post form validation failed for post ID: {post_id}. Errors: {form.errors}")
+        current_app.logger.warning(f"Delete post form validation failed for post ID: {post_id} by User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {form.errors}")
         flash('Failed to delete post. Invalid request or session expired.', 'danger')
         # Attempt to redirect to a sensible page. Dashboard is the most likely origin.
         return redirect(url_for('general.dashboard'))
@@ -404,13 +400,13 @@ def delete_post(post_id): # Renamed from delete_post_route
 @post_bp.route('/comment/<int:comment_id>/delete', methods=['POST'])
 @login_required
 def delete_comment(comment_id): # Renamed
-    current_app.logger.debug(f"Accessing /comment/{comment_id}/delete, User: {current_user.username}")
+    current_app.logger.debug(f"Accessing /comment/{comment_id}/delete, User ID: {current_user.id} (Handle: {current_user.handle})")
     # Using a specific delete form for CSRF protection on this action
     delete_form = DeleteCommentForm(request.form)
     if delete_form.validate_on_submit(): # Check CSRF
         comment = Comment.query.get_or_404(comment_id)
         post_id = comment.post_id
-        current_app.logger.info(f"User {current_user.username} attempting to delete comment ID: {comment_id} from post ID: {post_id}.")
+        current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) attempting to delete comment ID: {comment_id} from post ID: {post_id}.")
 
         can_delete = False
         if comment.user_id == current_user.id: can_delete = True
@@ -418,7 +414,7 @@ def delete_comment(comment_id): # Renamed
         elif current_user.is_admin: can_delete = True
 
         if not can_delete:
-            current_app.logger.warning(f"User {current_user.username} not authorized to delete comment {comment_id}.")
+            current_app.logger.warning(f"User ID: {current_user.id} (Handle: {current_user.handle}) not authorized to delete comment {comment_id}.")
             abort(403)
         try:
             # Manually delete flags associated with this comment
@@ -428,7 +424,7 @@ def delete_comment(comment_id): # Renamed
             # Manually delete notifications associated with this comment
             # Also consider notifications where this comment was the target_id and target_type='comment'
             Notification.query.filter(
-                (Notification.related_comment_id == comment.id) |
+                (Notification.related_comment_id == comment.id) | # This condition might be obsolete if related_comment_id removed from Notification
                 ((Notification.target_type == 'comment') & (Notification.target_id == comment.id))
             ).delete(synchronize_session=False)
             current_app.logger.debug(f"Deleted notifications for comment ID: {comment_id}.")
@@ -436,7 +432,7 @@ def delete_comment(comment_id): # Renamed
             # Manually delete activities associated with this comment
             # Also consider activities where this comment was the target_id and target_type='comment'
             Activity.query.filter(
-                (Activity.target_comment_id == comment.id) |
+                (Activity.target_comment_id == comment.id) | # This condition might be obsolete if target_comment_id removed from Activity
                 ((Activity.target_type == 'comment') & (Activity.target_id == comment.id))
             ).delete(synchronize_session=False)
             current_app.logger.debug(f"Deleted activities for comment ID: {comment_id}.")
@@ -444,14 +440,14 @@ def delete_comment(comment_id): # Renamed
             db.session.delete(comment)
             db.session.commit()
             flash('Comment deleted.', 'toast_success')
-            current_app.logger.info(f"Comment ID: {comment_id} successfully deleted by {current_user.username}.")
+            current_app.logger.info(f"Comment ID: {comment_id} successfully deleted by User ID: {current_user.id} (Handle: {current_user.handle}).")
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error deleting comment ID: {comment_id}: {e}", exc_info=True)
+            current_app.logger.error(f"Error deleting comment ID: {comment_id} by User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
             flash('Error deleting comment. Please try again.', 'danger')
         return redirect(url_for('post.view_post', post_id=post_id, _anchor=f"post-comments-area")) # Redirect to general comments area
     else: # CSRF validation failed or other form error (if any were added)
-        current_app.logger.warning(f"Delete comment form validation failed for comment ID: {comment_id}. Errors: {delete_form.errors}")
+        current_app.logger.warning(f"Delete comment form validation failed for comment ID: {comment_id} by User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {delete_form.errors}")
         flash('Failed to delete comment. Invalid request or session expired.', 'danger')
         # Try to redirect back to the post page even if comment_id was bad for some reason
         # This part might need a comment_id that is still valid in the DB to get post_id
@@ -463,31 +459,31 @@ def delete_comment(comment_id): # Renamed
 @post_bp.route('/comment/<int:comment_id>/flag', methods=['POST'])
 @login_required
 def flag_comment(comment_id): # Renamed
-    current_app.logger.debug(f"Accessing /comment/{comment_id}/flag, User: {current_user.username}")
+    current_app.logger.debug(f"Accessing /comment/{comment_id}/flag, User ID: {current_user.id} (Handle: {current_user.handle})")
     comment = Comment.query.get_or_404(comment_id)
     form = FlagCommentForm(request.form)
 
     if form.validate_on_submit(): # CSRF check
         existing_flag = CommentFlag.query.filter_by(comment_id=comment_id, flagger_user_id=current_user.id, is_resolved=False).first()
         if existing_flag:
-            current_app.logger.info(f"User {current_user.username} already actively flagged comment {comment_id}.")
+            current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) already actively flagged comment {comment_id}.")
             flash('You have already flagged this comment.', 'info')
         elif comment.user_id == current_user.id:
-            current_app.logger.info(f"User {current_user.username} attempted to flag their own comment {comment_id}.")
+            current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) attempted to flag their own comment {comment_id}.")
             flash("You cannot flag your own comment.", "warning")
         else:
             try:
                 new_flag = CommentFlag(comment_id=comment.id, flagger_user_id=current_user.id)
                 db.session.add(new_flag)
                 db.session.commit()
-                current_app.logger.info(f"Comment {comment_id} flagged by user {current_user.username}.")
+                current_app.logger.info(f"Comment {comment_id} flagged by User ID: {current_user.id} (Handle: {current_user.handle}).")
                 flash('Comment flagged for review.', 'toast_success')
             except Exception as e:
                 db.session.rollback()
-                current_app.logger.error(f"Error flagging comment {comment_id}: {e}", exc_info=True)
+                current_app.logger.error(f"Error flagging comment {comment_id} by User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
                 flash('Error flagging comment. Please try again.', 'danger')
     else:
-        current_app.logger.warning(f"Flag comment form validation failed for comment {comment_id}. Errors: {form.errors}")
+        current_app.logger.warning(f"Flag comment form validation failed for comment {comment_id} by User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {form.errors}")
         flash_form_errors_util(form) # Will show CSRF error if that was the cause
 
     return redirect(url_for('post.view_post', post_id=comment.post_id, _anchor=f"comment-{comment.id}"))
@@ -539,7 +535,7 @@ def like_post_route(post_id):
 
     if form.validate_on_submit():
         if not post.is_published and post.user_id != current_user.id: # Can't like unpublished posts unless own
-            current_app.logger.warning(f"User {current_user.username} attempt to like non-published post {post_id} they don't own.")
+            current_app.logger.warning(f"User ID: {current_user.id} (Handle: {current_user.handle}) attempt to like non-published post {post_id} they don't own.")
             abort(404)
 
         if current_user.has_liked_post(post):
@@ -558,7 +554,7 @@ def like_post_route(post_id):
                             target_id=post.id
                         )
                         db.session.add(notification)
-                        current_app.logger.info(f"Notification created for user {post.author.username} about new like on post {post.id} by {current_user.username}.")
+                        current_app.logger.info(f"Notification created for User ID: {post.author.id} (Handle: {post.author.handle}) about new like on post {post.id} by User ID: {current_user.id} (Handle: {current_user.handle}).")
 
                     # Create Activity entry for new like
                     from ..models import Activity # Local import
@@ -569,21 +565,21 @@ def like_post_route(post_id):
                         target_id=post.id
                     )
                     db.session.add(activity)
-                    current_app.logger.info(f"Activity 'liked_post' logged for user {current_user.username} on post {post.id}.")
+                    current_app.logger.info(f"Activity 'liked_post' logged for User ID: {current_user.id} (Handle: {current_user.handle}) on post {post.id}.")
 
                     db.session.commit()
                     flash('Post liked!', 'toast_success')
-                    current_app.logger.info(f"User {current_user.username} liked post {post_id}.")
+                    current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) liked post {post_id}.")
                 else:
                     # This else branch for current_user.like_post(post) might be redundant if it always returns True or raises
                     flash('Could not like post. An unexpected error occurred.', 'danger')
                     db.session.rollback() # Rollback if like_post indicated failure but didn't raise
             except Exception as e:
                 db.session.rollback()
-                current_app.logger.error(f"Error during like operation for post {post_id} by user {current_user.username}: {e}", exc_info=True)
+                current_app.logger.error(f"Error during like operation for post {post_id} by User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
                 flash('An error occurred while trying to like the post. Please try again.', 'danger')
     else:
-        current_app.logger.warning(f"LikeForm validation failed for post {post_id}, user {current_user.username}. Errors: {form.errors}")
+        current_app.logger.warning(f"LikeForm validation failed for post {post_id}, User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {form.errors}")
         # flash_form_errors_util(form) # This might be too verbose for a simple like button
         flash('Could not like post. Invalid request or session expired.', 'danger')
 
@@ -605,17 +601,17 @@ def unlike_post_route(post_id):
                 if current_user.unlike_post(post):
                     db.session.commit()
                     flash('Post unliked.', 'toast_success')
-                    current_app.logger.info(f"User {current_user.username} unliked post {post_id}.")
+                    current_app.logger.info(f"User ID: {current_user.id} (Handle: {current_user.handle}) unliked post {post_id}.")
                 else:
                     # This else branch for current_user.unlike_post(post) might be redundant
                     flash('Could not unlike post. An unexpected error occurred.', 'danger')
                     db.session.rollback() # Rollback if unlike_post indicated failure
             except Exception as e:
                 db.session.rollback()
-                current_app.logger.error(f"Error during unlike operation for post {post_id} by user {current_user.username}: {e}", exc_info=True)
+                current_app.logger.error(f"Error during unlike operation for post {post_id} by User ID: {current_user.id} (Handle: {current_user.handle}): {e}", exc_info=True)
                 flash('An error occurred while trying to unlike the post. Please try again.', 'danger')
     else:
-        current_app.logger.warning(f"UnlikeForm validation failed for post {post_id}, user {current_user.username}. Errors: {form.errors}")
+        current_app.logger.warning(f"UnlikeForm validation failed for post {post_id}, User ID: {current_user.id} (Handle: {current_user.handle}). Errors: {form.errors}")
         # flash_form_errors_util(form)
         flash('Could not unlike post. Invalid request or session expired.', 'danger')
 

--- a/antisocialnet/setup_db.py
+++ b/antisocialnet/setup_db.py
@@ -29,7 +29,7 @@ User = app_module.models.User
 SiteSetting = app_module.models.SiteSetting # Import SiteSetting
 
 
-def create_or_update_user(flask_app, username, password, full_name, profile_info=None,
+def create_or_update_user(flask_app, username, password, full_name, handle, profile_info=None, # Added handle
                           is_admin=False, is_approved=True, is_active=True,
                           update_if_exists=True, interactive_password_update=False):
     """
@@ -38,9 +38,10 @@ def create_or_update_user(flask_app, username, password, full_name, profile_info
 
     Args:
         flask_app: The Flask application instance.
-        username (str): The username.
+        username (str): The username (email for login).
         password (str): The user's password.
         full_name (str): The user's full name.
+        handle (str): The user's public handle.
         profile_info (str, optional): The user's bio/profile information.
         is_admin (bool): Whether the user should be an admin.
         is_approved (bool): Whether the user account is approved.
@@ -51,15 +52,24 @@ def create_or_update_user(flask_app, username, password, full_name, profile_info
     Returns:
         True if user was created/updated, False otherwise.
     """
-    if not username or not password or not full_name:
-        print("Error: Username, password, and full name are required to create or update a user.")
+    if not username or not password or not full_name or not handle:
+        print("Error: Username (email), password, full name, and handle are required to create or update a user.")
         return False
 
     with flask_app.app_context():
-        existing_user = User.query.filter_by(username=username).first()
+        # Check for handle uniqueness before proceeding, if it's an update or new user
+        # If it's an existing user, ensure the handle isn't taken by *another* user.
+        existing_user_by_handle = User.query.filter(User.handle == handle).first()
+        existing_user_by_username = User.query.filter_by(username=username).first()
 
-        if existing_user:
-            print(f"User '{username}' already exists.")
+        if existing_user_by_handle and (not existing_user_by_username or existing_user_by_handle.id != existing_user_by_username.id):
+            print(f"Error: Handle '{handle}' is already taken by another user. Please choose a different one.")
+            return False
+
+        user_to_process = existing_user_by_username
+
+        if user_to_process:
+            print(f"User with email '{username}' already exists.")
             if not update_if_exists:
                 print(f"Skipping update for user '{username}' as update_if_exists is False.")
                 return False
@@ -67,7 +77,7 @@ def create_or_update_user(flask_app, username, password, full_name, profile_info
             if interactive_password_update:
                 try:
                     update_choice = input(
-                        f"Do you want to update the password for user '{username}'? (y/n): "
+                        f"Do you want to update the password for user '{username}' (Handle: {user_to_process.handle})? (y/n): "
                     ).lower()
                     if update_choice == "y":
                         print(f"Updating password for user '{username}'.")
@@ -79,42 +89,36 @@ def create_or_update_user(flask_app, username, password, full_name, profile_info
                         if new_password != new_password_confirm:
                             print("Passwords do not match. Aborting password update.")
                             return False
-                        existing_user.set_password(new_password)
-                        # Update other details as well
-                        existing_user.full_name = full_name
-                        if profile_info is not None:
-                            existing_user.profile_info = profile_info
-                        existing_user.is_admin = is_admin
-                        existing_user.is_approved = is_approved
-                        existing_user.is_active = is_active
-                        db.session.commit()
-                        print(f"User '{username}' password and details updated interactively.")
-                        return True
+                        user_to_process.set_password(new_password)
                     else:
                         print(f"Password for user '{username}' not updated interactively.")
-                        # Optionally update other details even if password isn't
-                        # For now, if password update is declined, we don't update other things.
-                        return False
+                        # If password update is skipped, we might still want to update other details.
+                        # For simplicity, if 'n' is chosen for password, we proceed to update other details.
+                        pass # Continue to update other details
                 except EOFError:
                     print("Skipping interactive password update for existing user in non-interactive environment.")
-                    return False
-            else: # Non-interactive update
-                print(f"Updating password and details for user '{username}' non-interactively.")
-                existing_user.set_password(password)
-                existing_user.full_name = full_name
-                if profile_info is not None:
-                    existing_user.profile_info = profile_info
-                existing_user.is_admin = is_admin
-                existing_user.is_approved = is_approved
-                existing_user.is_active = is_active
-                db.session.commit()
-                print(f"User '{username}' updated non-interactively.")
-                return True
+                    # Continue to update other details non-interactively for password.
+                    user_to_process.set_password(password) # Fallback to provided password
+            else: # Non-interactive update for password if exists
+                user_to_process.set_password(password)
+
+            # Update other details
+            user_to_process.full_name = full_name
+            user_to_process.handle = handle # Update handle
+            if profile_info is not None:
+                user_to_process.profile_info = profile_info
+            user_to_process.is_admin = is_admin
+            user_to_process.is_approved = is_approved
+            user_to_process.is_active = is_active
+            db.session.commit()
+            print(f"User '{username}' (Handle: '{handle}') details updated.")
+            return True
         else:
             # Create new user
-            print(f"Creating new user: '{username}' with full name '{full_name}'.")
+            print(f"Creating new user: Email '{username}', Handle '{handle}', Full Name '{full_name}'.")
             new_user = User(
                 username=username,
+                handle=handle,
                 full_name=full_name,
                 profile_info=profile_info,
                 is_admin=is_admin,
@@ -124,7 +128,7 @@ def create_or_update_user(flask_app, username, password, full_name, profile_info
             new_user.set_password(password)
             db.session.add(new_user)
             db.session.commit()
-            print(f"User '{username}' created successfully. Admin: {is_admin}, Approved: {is_approved}, Active: {is_active}.")
+            print(f"User '{username}' (Handle: '{handle}') created successfully. Admin: {is_admin}, Approved: {is_approved}, Active: {is_active}.")
 
             # Special handling for the very first admin user created non-interactively by CLI args
             # to set initial site settings. This is a bit of a kludge.
@@ -206,6 +210,7 @@ if __name__ == "__main__":
     # For more control, a dedicated --admin-fullname could be added.
     # For now, will default full_name to admin_user for non-interactive.
     parser.add_argument('--admin-fullname', help='Set initial admin display name (full_name) non-interactively (optional, defaults to admin-user).')
+    parser.add_argument('--admin-handle', help='Set initial admin public handle non-interactively (required if admin-user set).')
     parser.add_argument('--admin-bio', help='Set initial admin bio non-interactively (optional).')
     parser.add_argument('--config', help='Path to a YAML configuration file to override default settings.')
 
@@ -215,8 +220,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Validate non-interactive admin creation args
-    if (args.admin_user and not args.admin_pass) or (not args.admin_user and args.admin_pass):
-        parser.error("--admin-user and --admin-pass must be used together.")
+    if (args.admin_user and not args.admin_pass) or \
+       (not args.admin_user and args.admin_pass) or \
+       (args.admin_user and not args.admin_handle): # admin_handle is required if admin_user is set
+        parser.error("--admin-user, --admin-pass, and --admin-handle must be used together.")
 
     print("Starting database setup...")
 
@@ -292,25 +299,27 @@ if __name__ == "__main__":
         if isinstance(yaml_users, list) and yaml_users:
             print(f"\nProcessing {len(yaml_users)} user(s) from configuration (YAML)...")
             for user_data in yaml_users:
-                username = user_data.get('username')
+                username = user_data.get('username') # This is the email
                 password = user_data.get('password')
                 full_name = user_data.get('full_name')
+                handle = user_data.get('handle') # Get the handle
                 profile_info = user_data.get('bio') # Match example: bio
                 is_admin = user_data.get('is_admin', False)
                 # Default is_approved and is_active to True for YAML users, allow override
                 is_approved = user_data.get('is_approved', True)
                 is_active = user_data.get('is_active', True)
 
-                if not username or not password or not full_name:
-                    print(f"Skipping user due to missing username, password, or full_name: {user_data}")
+                if not username or not password or not full_name or not handle: # Added handle check
+                    print(f"Skipping user due to missing username, password, full_name, or handle: {user_data}")
                     continue
 
-                print(f"Processing user from YAML: {username}")
+                print(f"Processing user from YAML: Email='{username}', Handle='{handle}'")
                 create_or_update_user(
                     flask_app=app,
                     username=username,
                     password=password,
                     full_name=full_name,
+                    handle=handle, # Pass handle
                     profile_info=profile_info,
                     is_admin=is_admin,
                     is_approved=is_approved,
@@ -332,6 +341,7 @@ if __name__ == "__main__":
                     username=args.admin_user,
                     password=args.admin_pass,
                     full_name=args.admin_fullname if args.admin_fullname else args.admin_user,
+                    handle=args.admin_handle, # Use the new admin_handle argument
                     profile_info=args.admin_bio,
                     is_admin=True, # CLI admin is always admin
                     is_approved=True,
@@ -358,6 +368,14 @@ if __name__ == "__main__":
                                 full_name = input(f"Enter Display Name for '{username}': ").strip()
                                 if not full_name:
                                     print("Display Name cannot be empty.")
+
+                            handle_interactive = ""
+                            while not handle_interactive: # Basic validation, could add regex check here too
+                                handle_interactive = input(f"Enter Public Handle for '{username}' (e.g., your_unique_handle): ").strip()
+                                if not handle_interactive:
+                                    print("Public Handle cannot be empty.")
+                                # TODO: Add regex check for handle format consistency if desired, e.g. r'^[a-zA-Z0-9_]+$'
+
                             profile_info = input(f"Enter profile information for '{username}' (optional, press Enter to skip): ").strip() or None
 
                             create_or_update_user(
@@ -365,6 +383,7 @@ if __name__ == "__main__":
                                 username=username,
                                 password=password,
                                 full_name=full_name,
+                                handle=handle_interactive, # Pass interactive handle
                                 profile_info=profile_info,
                                 is_admin=True, # Interactive setup creates an admin
                                 is_approved=True,

--- a/antisocialnet/templates/base.html
+++ b/antisocialnet/templates/base.html
@@ -117,18 +117,18 @@
     <aside class="app-sidebar" id="app-sidebar"> {# Added id for ARIA #}
         {% if current_user.is_authenticated %}
         <div class="sidebar-profile-area">
-            <a href="{{ url_for('profile.view_profile', username=current_user.username) }}" class="sidebar-profile-avatar-link" title="View Profile">
+            <a href="{{ url_for('profile.view_profile', handle=current_user.handle) if current_user.handle else '#' }}" class="sidebar-profile-avatar-link" title="View Profile">
                 <span class="adw-avatar size-large"> {# Changed to size-large #}
                     {% if current_user.profile_photo_url %}
-                        <img src="{{ url_for('static', filename=current_user.profile_photo_url) }}" alt="Avatar">
+                        <img src="{{ url_for('static', filename=current_user.profile_photo_url) }}" alt="{{ current_user.full_name or ('@' + current_user.handle if current_user.handle else '') }} avatar">
                     {% else %}
                         <span class="adw-avatar-text">
-                            {{ current_user.username[0]|upper if current_user.username else 'U' }}
+                            {{ (current_user.full_name[0] if current_user.full_name else (current_user.handle[0] if current_user.handle else 'U'))|upper }}
                         </span>
                     {% endif %}
                 </span>
             </a>
-            <div class="sidebar-profile-name adw-label title-3">{{ current_user.full_name }}</div> {# Prefer full_name directly #}
+            <div class="sidebar-profile-name adw-label title-3">{{ current_user.full_name or ('@' + current_user.handle if current_user.handle else current_user.username) }}</div>
         </div>
         {% endif %}
         <nav class="adw-list-box flat sidebar-nav" aria-label="Main Navigation">

--- a/antisocialnet/templates/followers_list.html
+++ b/antisocialnet/templates/followers_list.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{% block title %}Followers of {{ user_profile.full_name or user_profile.username }}{% endblock %}
+{% block title %}Followers of {{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}{% endblock %}
 
-{% block header_title %}Followers of {{ user_profile.full_name or user_profile.username }}{% endblock %}
+{% block header_title %}Followers of {{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}{% endblock %}
 
 {% block content %}
 <div class="adw-clamp adw-clamp-lg"> {# Wider clamp for user lists potentially #}
@@ -11,35 +11,37 @@
             {% for listed_user in users_list %}
             <div class="adw-action-row user-list-item-row">
                 <div class="adw-action-row-start-content">
-                    <a href="{{ url_for('profile.view_profile', username=listed_user.username) }}">
+                    <a href="{{ url_for('profile.view_profile', handle=listed_user.handle) if listed_user.handle else '#' }}">
                         <span class="adw-avatar size-m">
                             {% if listed_user.profile_photo_url %}
-                            <img src="{{ url_for('static', filename=listed_user.profile_photo_url) }}" alt="{{ listed_user.full_name or listed_user.username }} avatar">
+                            <img src="{{ url_for('static', filename=listed_user.profile_photo_url) }}" alt="{{ listed_user.full_name or ('@' + listed_user.handle if listed_user.handle else listed_user.username) }} avatar">
                             {% else %}
-                            <img src="{{ default_avatar_url }}" alt="{{ listed_user.full_name or listed_user.username }} default avatar">
+                            <img src="{{ default_avatar_url }}" alt="{{ listed_user.full_name or ('@' + listed_user.handle if listed_user.handle else listed_user.username) }} default avatar">
                             {% endif %}
                         </span>
                     </a>
                 </div>
                 <div class="adw-action-row-text-content">
-                    <a href="{{ url_for('profile.view_profile', username=listed_user.username) }}" class="adw-link">
-                        <span class="adw-action-row-title">{{ listed_user.full_name or listed_user.username }}</span>
+                    <a href="{{ url_for('profile.view_profile', handle=listed_user.handle) if listed_user.handle else '#' }}" class="adw-link">
+                        <span class="adw-action-row-title">{{ listed_user.full_name or ('@' + listed_user.handle if listed_user.handle else listed_user.username) }}</span>
                     </a>
-                    {% if listed_user.full_name %}
+                    {% if listed_user.handle %}
+                    <span class="adw-action-row-subtitle">@{{ listed_user.handle }}</span>
+                    {% elif listed_user.full_name %} {# Fallback for older users if handle is somehow missing but full_name exists #}
                     <span class="adw-action-row-subtitle">@{{ listed_user.username }}</span>
                     {% endif %}
                 </div>
                 <div class="adw-action-row-end-content">
                     {% if current_user.is_authenticated and current_user != listed_user %}
                         {% if current_user.is_following(listed_user) %}
-                            <form action="{{ url_for('profile.unfollow_user', username=listed_user.username) }}" method="POST" style="display: inline;">
+                            <form action="{{ url_for('profile.unfollow_user', handle=listed_user.handle) if listed_user.handle else '#' }}" method="POST" style="display: inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small">Unfollow</button> {# Using .small button variant #}
+                                <button type="submit" class="adw-button small" {% if not listed_user.handle %}disabled{% endif %}>Unfollow</button> {# Using .small button variant #}
                             </form>
                         {% else %}
-                            <form action="{{ url_for('profile.follow_user', username=listed_user.username) }}" method="POST" style="display: inline;">
+                            <form action="{{ url_for('profile.follow_user', handle=listed_user.handle) if listed_user.handle else '#' }}" method="POST" style="display: inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small suggested-action">Follow</button>
+                                <button type="submit" class="adw-button small suggested-action" {% if not listed_user.handle %}disabled{% endif %}>Follow</button>
                             </form>
                         {% endif %}
                     {% endif %}
@@ -53,7 +55,7 @@
         <div class="adw-box adw-box-horizontal justify-center list-pagination-box">
             <div class="adw-toggle-group">
                 {% if pagination.has_prev %}
-                    <a href="{{ url_for('profile.followers_list', username=user_profile.username, page=pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
+                    <a href="{{ url_for('profile.followers_list', handle=user_profile.handle, page=pagination.prev_num) if user_profile.handle else '#' }}" class="adw-button icon-only" aria-label="Previous page">
                         <span class="adw-icon icon-actions-go-previous-symbolic"></span>
                     </a>
                 {% else %}
@@ -67,7 +69,7 @@
                         {% if page_num == pagination.page %}
                             <button class="adw-button suggested-action" disabled aria-current="page">{{ page_num }}</button>
                         {% else %}
-                            <a href="{{ url_for('profile.followers_list', username=user_profile.username, page=page_num) }}" class="adw-button">{{ page_num }}</a>
+                            <a href="{{ url_for('profile.followers_list', handle=user_profile.handle, page=page_num) if user_profile.handle else '#' }}" class="adw-button">{{ page_num }}</a>
                         {% endif %}
                     {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
                         <button class="adw-button flat" disabled>…</button>
@@ -75,7 +77,7 @@
                 {% endfor %}
 
                 {% if pagination.has_next %}
-                     <a href="{{ url_for('profile.followers_list', username=user_profile.username, page=pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
+                     <a href="{{ url_for('profile.followers_list', handle=user_profile.handle, page=pagination.next_num) if user_profile.handle else '#' }}" class="adw-button icon-only" aria-label="Next page">
                         <span class="adw-icon icon-actions-go-next-symbolic"></span>
                     </a>
                 {% else %}
@@ -90,7 +92,7 @@
     {% else %}
         <div class="adw-status-page">
             <span class="adw-icon icon-status-user-offline-symbolic adw-status-page-icon app-status-page-icon"></span> {# Example icon #}
-            <h3 class="adw-status-page-title">{{ user_profile.full_name or user_profile.username }} has no followers yet.</h3>
+            <h3 class="adw-status-page-title">{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} has no followers yet.</h3>
             {# <p class="adw-status-page-description">Check back later!</p> #}
         </div>
     {% endif %}

--- a/antisocialnet/templates/following_list.html
+++ b/antisocialnet/templates/following_list.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{% block title %}{{ user_profile.full_name or user_profile.username }} is Following{% endblock %}
+{% block title %}{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} is Following{% endblock %}
 
-{% block header_title %}{{ user_profile.full_name or user_profile.username }} is Following{% endblock %}
+{% block header_title %}{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} is Following{% endblock %}
 
 {% block content %}
 <div class="adw-clamp adw-clamp-lg">
@@ -11,35 +11,37 @@
             {% for listed_user in users_list %}
             <div class="adw-action-row user-list-item-row">
                 <div class="adw-action-row-start-content">
-                    <a href="{{ url_for('profile.view_profile', username=listed_user.username) }}">
+                    <a href="{{ url_for('profile.view_profile', handle=listed_user.handle) if listed_user.handle else '#' }}">
                         <span class="adw-avatar size-m">
                             {% if listed_user.profile_photo_url %}
-                            <img src="{{ url_for('static', filename=listed_user.profile_photo_url) }}" alt="{{ listed_user.full_name or listed_user.username }} avatar">
+                            <img src="{{ url_for('static', filename=listed_user.profile_photo_url) }}" alt="{{ listed_user.full_name or ('@' + listed_user.handle if listed_user.handle else listed_user.username) }} avatar">
                             {% else %}
-                            <img src="{{ default_avatar_url }}" alt="{{ listed_user.full_name or listed_user.username }} default avatar">
+                            <img src="{{ default_avatar_url }}" alt="{{ listed_user.full_name or ('@' + listed_user.handle if listed_user.handle else listed_user.username) }} default avatar">
                             {% endif %}
                         </span>
                     </a>
                 </div>
                 <div class="adw-action-row-text-content">
-                     <a href="{{ url_for('profile.view_profile', username=listed_user.username) }}" class="adw-link">
-                        <span class="adw-action-row-title">{{ listed_user.full_name or listed_user.username }}</span>
+                     <a href="{{ url_for('profile.view_profile', handle=listed_user.handle) if listed_user.handle else '#' }}" class="adw-link">
+                        <span class="adw-action-row-title">{{ listed_user.full_name or ('@' + listed_user.handle if listed_user.handle else listed_user.username) }}</span>
                     </a>
-                    {% if listed_user.full_name %}
+                    {% if listed_user.handle %}
+                    <span class="adw-action-row-subtitle">@{{ listed_user.handle }}</span>
+                    {% elif listed_user.full_name %} {# Fallback for older users if handle is somehow missing but full_name exists #}
                     <span class="adw-action-row-subtitle">@{{ listed_user.username }}</span>
                     {% endif %}
                 </div>
                 <div class="adw-action-row-end-content">
                     {% if current_user.is_authenticated and current_user != listed_user %}
                         {% if current_user.is_following(listed_user) %}
-                            <form action="{{ url_for('profile.unfollow_user', username=listed_user.username) }}" method="POST" style="display: inline;">
+                            <form action="{{ url_for('profile.unfollow_user', handle=listed_user.handle) if listed_user.handle else '#' }}" method="POST" style="display: inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small">Unfollow</button>
+                                <button type="submit" class="adw-button small" {% if not listed_user.handle %}disabled{% endif %}>Unfollow</button>
                             </form>
                         {% else %}
-                            <form action="{{ url_for('profile.follow_user', username=listed_user.username) }}" method="POST" style="display: inline;">
+                            <form action="{{ url_for('profile.follow_user', handle=listed_user.handle) if listed_user.handle else '#' }}" method="POST" style="display: inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small suggested-action">Follow</button>
+                                <button type="submit" class="adw-button small suggested-action" {% if not listed_user.handle %}disabled{% endif %}>Follow</button>
                             </form>
                         {% endif %}
                     {% elif current_user == listed_user %}
@@ -55,7 +57,7 @@
         <div class="adw-box adw-box-horizontal justify-center list-pagination-box">
             <div class="adw-toggle-group">
                 {% if pagination.has_prev %}
-                    <a href="{{ url_for('profile.following_list', username=user_profile.username, page=pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
+                    <a href="{{ url_for('profile.following_list', handle=user_profile.handle, page=pagination.prev_num) if user_profile.handle else '#' }}" class="adw-button icon-only" aria-label="Previous page">
                         <span class="adw-icon icon-actions-go-previous-symbolic"></span>
                     </a>
                 {% else %}
@@ -69,7 +71,7 @@
                         {% if page_num == pagination.page %}
                             <button class="adw-button suggested-action" disabled aria-current="page">{{ page_num }}</button>
                         {% else %}
-                            <a href="{{ url_for('profile.following_list', username=user_profile.username, page=page_num) }}" class="adw-button">{{ page_num }}</a>
+                            <a href="{{ url_for('profile.following_list', handle=user_profile.handle, page=page_num) if user_profile.handle else '#' }}" class="adw-button">{{ page_num }}</a>
                         {% endif %}
                     {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
                         <button class="adw-button flat" disabled>…</button>
@@ -77,7 +79,7 @@
                 {% endfor %}
 
                 {% if pagination.has_next %}
-                     <a href="{{ url_for('profile.following_list', username=user_profile.username, page=pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
+                     <a href="{{ url_for('profile.following_list', handle=user_profile.handle, page=pagination.next_num) if user_profile.handle else '#' }}" class="adw-button icon-only" aria-label="Next page">
                         <span class="adw-icon icon-actions-go-next-symbolic"></span>
                     </a>
                 {% else %}
@@ -92,7 +94,7 @@
     {% else %}
         <div class="adw-status-page">
             <span class="adw-icon icon-actions-find-and-replace-symbolic adw-status-page-icon app-status-page-icon"></span> {# Example icon #}
-            <h3 class="adw-status-page-title">{{ user_profile.full_name or user_profile.username }} is not following anyone yet.</h3>
+            <h3 class="adw-status-page-title">{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} is not following anyone yet.</h3>
             {# <p class="adw-status-page-description">When they follow users, they'll appear here.</p> #}
         </div>
     {% endif %}

--- a/antisocialnet/templates/post.html
+++ b/antisocialnet/templates/post.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{% block page_title %}Post by {{ post.author.full_name or post.author.username }}{% endblock %} {# Keep username as fallback if full_name somehow missing for old data #}
+{% block page_title %}Post by {{ post.author.full_name or ('@' + post.author.handle if post.author.handle else post.author.username) }}{% endblock %}
 
-{% block header_title %}Post by {{ post.author.full_name or post.author.username }}{% endblock %}
+{% block header_title %}Post by {{ post.author.full_name or ('@' + post.author.handle if post.author.handle else post.author.username) }}{% endblock %}
 
 {% block content %}
 <div class="post-view"> {# Removed adw-clamp content-clamp as base.html provides clamp #}
@@ -11,7 +11,7 @@
             {# Title h1 removed #}
             <div class="post-meta-detail">
                 <p class="adw-label body">
-                    By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.full_name or post.author.username if post.author else 'Unknown Author' }}</a>&nbsp;
+                    By: <a href="{{ url_for('profile.view_profile', handle=post.author.handle) if post.author.handle else '#' }}" class="adw-link">{{ post.author.full_name or ('@' + post.author.handle if post.author.handle else post.author.username) if post.author else 'Unknown Author' }}</a>&nbsp;
                     {%- if post.published_at -%}
                         on <time datetime="{{ post.published_at.isoformat() }}">{{ post.published_at | human_readable_date }}</time>
                     {%- else -%} {# Should not happen for new posts, fallback for old data or if published_at was somehow not set #}
@@ -80,11 +80,11 @@
 
         {% if post.author %}
         <section class="author-bio-section adw-card">
-            <h3 class="adw-title-3">About {{ post.author.full_name }}</h3>
+            <h3 class="adw-title-3">About {{ post.author.full_name or ('@' + post.author.handle if post.author.handle else post.author.username) }}</h3>
             <div class="adw-box adw-box-spacing-m author-bio-content">
                 <span class="adw-avatar size-large">
                      {% set author_avatar = url_for('static', filename=post.author.profile_photo_url) if post.author.profile_photo_url else url_for('static', filename='img/default_avatar.png') %}
-                     <img src="{{ author_avatar }}" alt="{{ post.author.full_name }} avatar" class="adw-avatar__image">
+                     <img src="{{ author_avatar }}" alt="{{ post.author.full_name or ('@' + post.author.handle if post.author.handle else post.author.username) }} avatar" class="adw-avatar__image">
                 </span>
                 <div class="author-bio-text-content">
                     {% if post.author.profile_info %}
@@ -94,7 +94,7 @@
                     {% else %}
                     <p class="adw-label body author-bio-text-placeholder">This author has not provided a bio yet.</p>
                     {% endif %}
-                    <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-button flat view-profile-button">View Profile of {{ post.author.full_name }}</a>
+                    <a href="{{ url_for('profile.view_profile', handle=post.author.handle) if post.author.handle else '#' }}" class="adw-button flat view-profile-button">View Profile of {{ post.author.full_name or ('@' + post.author.handle if post.author.handle else post.author.username) }}</a>
                 </div>
             </div>
         </section>
@@ -138,18 +138,18 @@
         <header class="comment-header adw-box adw-box-spacing-s comment-header-box">
             <span class="adw-avatar size-medium">
                {% set comment_avatar = url_for('static', filename=comment.author.profile_photo_url) if comment.author.profile_photo_url else default_avatar_url %}
-               <img src="{{ comment_avatar }}" alt="{{ comment.author.full_name }} avatar" class="adw-avatar__image">
+               <img src="{{ comment_avatar }}" alt="{{ comment.author.full_name or ('@' + comment.author.handle if comment.author.handle else comment.author.username) }} avatar" class="adw-avatar__image">
             </span>
             <div class="comment-author-meta">
-                 <a href="{{ url_for('profile.view_profile', username=comment.author.username) }}" class="adw-link comment-author-link-strong">{{ comment.author.full_name }}</a>
+                 <a href="{{ url_for('profile.view_profile', handle=comment.author.handle) if comment.author.handle else '#' }}" class="adw-link comment-author-link-strong">{{ comment.author.full_name or ('@' + comment.author.handle if comment.author.handle else comment.author.username) }}</a>
                 <small class="adw-label caption comment-timestamp"><time datetime="{{ comment.created_at.isoformat() }}">{{ comment.created_at | human_readable_date }}</time></small>
             </div>
         </header>
-        <div class="comment-text styled-text-content">{{ comment.text | markdown }}</div>
+        <div class="comment-text styled-text-content">{{ comment.text | markdown }}</div> {# Mentions in comment.text are linkified by the markdown filter calling linkify_mentions util #}
 
         <div class="comment-actions">
             {% if current_user.is_authenticated %}
-            <button class="adw-button flat compact reply-button" data-comment-id="{{ comment.id }}" data-comment-author="{{ comment.author.full_name | e }}">Reply</button>
+            <button class="adw-button flat compact reply-button" data-comment-id="{{ comment.id }}" data-comment-author="{{ (comment.author.full_name or ('@' + comment.author.handle if comment.author.handle else comment.author.username)) | e }}">Reply</button>
             {% endif %}
             {% if current_user.is_authenticated and comment.author != current_user %}
                 {% if comment.is_flagged_active %}
@@ -235,7 +235,7 @@
             {% for related_post in related_posts %}
             <a href="{{ url_for('post.view_post', post_id=related_post.id) }}" class="adw-action-row activatable">
                 <div class="adw-action-row-content">
-                    <span class="adw-action-row-title">Post by {{ related_post.author.full_name or related_post.author.username }}</span>
+                    <span class="adw-action-row-title">Post by {{ related_post.author.full_name or ('@' + related_post.author.handle if related_post.author.handle else related_post.author.username) }}</span>
                     {% if related_post.content %}
                     <span class="adw-action-row-subtitle">{{ related_post.content | striptags | truncate(80) }}</span>
                     {% endif %}

--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}Profile: {{ user_profile.full_name or user_profile.username }}{% endblock %}
+{% block title %}Profile: {{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}{% endblock %}
 
-{% block header_title %}{{ user_profile.full_name or user_profile.username }}'s Profile{% endblock %}
+{% block header_title %}{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}'s Profile{% endblock %}
 
 {% block header_actions_start %}
     {% if current_user == user_profile %}
         <a href="{{ url_for('profile.edit_profile') }}" class="adw-button suggested-action">Edit Profile</a>
     {% elif current_user.is_authenticated %} {# Only show follow/unfollow if logged in and not viewing own profile #}
         {% if current_user.is_following(user_profile) %}
-            <form action="{{ url_for('profile.unfollow_user', username=user_profile.username) }}" method="POST" style="display: inline;">
+            <form action="{{ url_for('profile.unfollow_user', handle=user_profile.handle) }}" method="POST" style="display: inline;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="adw-button">Unfollow</button>
             </form>
         {% else %}
-            <form action="{{ url_for('profile.follow_user', username=user_profile.username) }}" method="POST" style="display: inline;">
+            <form action="{{ url_for('profile.follow_user', handle=user_profile.handle) }}" method="POST" style="display: inline;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="adw-button suggested-action">Follow</button>
             </form>
@@ -75,21 +75,23 @@
         <div class="adw-box adw-box-spacing-xl align-center"> {# Horizontal by default #}
             <div class="adw-avatar size-huge" id="profile-page-avatar-container" style="cursor: pointer;" title="View full-size photo"> {# size-huge for 96px, added ID and style #}
                 {% if user_profile.profile_photo_url %}
-                <img id="profile-page-avatar-img" src="{{ url_for('static', filename=user_profile.profile_photo_url) }}" alt="{{ user_profile.full_name or user_profile.username }} avatar">
+                <img id="profile-page-avatar-img" src="{{ url_for('static', filename=user_profile.profile_photo_url) }}" alt="{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} avatar">
                 {% else %}
-                <img id="profile-page-avatar-img" src="{{ default_avatar_url }}" alt="{{ user_profile.full_name or user_profile.username }} default avatar">
+                <img id="profile-page-avatar-img" src="{{ default_avatar_url }}" alt="{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} default avatar">
                 {% endif %}
             </div>
             <div class="adw-box adw-box-vertical adw-box-spacing-xs">
-                <h1 class="adw-label title-1">{{ user_profile.full_name or user_profile.username }}</h1>
-                {% if user_profile.full_name %}
+                <h1 class="adw-label title-1">{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}</h1>
+                {% if user_profile.handle %}
+                <div><span class="adw-label adw-caption">@{{ user_profile.handle }}</span></div>
+                {% elif user_profile.full_name %} {# Fallback for older users who might not have a handle yet, show username (email) if handle is missing #}
                 <div><span class="adw-label adw-caption">@{{ user_profile.username }}</span></div>
                 {% endif %}
                 <div class="adw-box adw-box-horizontal adw-box-spacing-s profile-follow-stats">
-                    <a href="{{ url_for('profile.followers_list', username=user_profile.username) }}" class="adw-link">
+                    <a href="{{ url_for('profile.followers_list', handle=user_profile.handle) }}" class="adw-link">
                         <span class="adw-label body-2"><strong>{{ user_profile.followers.count() }}</strong> Followers</span>
                     </a>
-                    <a href="{{ url_for('profile.following_list', username=user_profile.username) }}" class="adw-link">
+                    <a href="{{ url_for('profile.following_list', handle=user_profile.handle) }}" class="adw-link">
                         <span class="adw-label body-2"><strong>{{ user_profile.followed.count() }}</strong> Following</span>
                     </a>
                 </div>
@@ -99,7 +101,7 @@
         {# Profile Details Group #}
         <div class="adw-preferences-group" role="group" aria-labelledby="profile-details-title-{{user_profile.id}}">
              <div class="adw-preferences-group__title-container">
-                <h2 class="adw-preferences-group__title title-2" id="profile-details-title-{{user_profile.id}}">About {{user_profile.full_name or user_profile.username}}</h2>
+                <h2 class="adw-preferences-group__title title-2" id="profile-details-title-{{user_profile.id}}">About {{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}</h2>
             </div>
             <div class="adw-list-box">
                 {% if user_profile.profile_info %}
@@ -204,7 +206,7 @@
         {# User Posts Section #}
         <div class="adw-preferences-group" role="group" aria-labelledby="user-posts-title-{{user_profile.id}}">
             <div class="adw-preferences-group__title-container">
-                <h2 class="adw-preferences-group__title title-2" id="user-posts-title-{{user_profile.id}}">Posts by {{ user_profile.full_name or user_profile.username }}</h2>
+                <h2 class="adw-preferences-group__title title-2" id="user-posts-title-{{user_profile.id}}">Posts by {{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}</h2>
             </div>
             {% if posts_pagination and posts_pagination.items %}
                 <div class="blog-posts-container"> {# Use new card container #}
@@ -240,7 +242,7 @@
                 <div class="adw-box adw-box-horizontal justify-center profile-pagination-box">
                     <div class="adw-toggle-group">
                         {% if posts_pagination.has_prev %}
-                            <a href="{{ url_for('profile.view_profile', username=user_profile.username, page=posts_pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
+                            <a href="{{ url_for('profile.view_profile', handle=user_profile.handle, page=posts_pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
                                 <span class="adw-icon icon-actions-go-previous-symbolic"></span>
                             </a>
                         {% else %}
@@ -254,7 +256,7 @@
                                 {% if page_num == posts_pagination.page %}
                                     <button class="adw-button suggested" disabled aria-current="page">{{ page_num }}</button>
                                 {% else %}
-                                    <a href="{{ url_for('profile.view_profile', username=user_profile.username, page=page_num) }}" class="adw-button">{{ page_num }}</a>
+                                    <a href="{{ url_for('profile.view_profile', handle=user_profile.handle, page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
                             {% elif loop.index != 1 and loop.index != posts_pagination.pages + posts_pagination.iter_pages()|length %}
                                 <button class="adw-button flat" disabled>…</button>
@@ -262,7 +264,7 @@
                         {% endfor %}
 
                         {% if posts_pagination.has_next %}
-                             <a href="{{ url_for('profile.view_profile', username=user_profile.username, page=posts_pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
+                             <a href="{{ url_for('profile.view_profile', handle=user_profile.handle, page=posts_pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
                                 <span class="adw-icon icon-actions-go-next-symbolic"></span>
                             </a>
                         {% else %}
@@ -277,7 +279,7 @@
                 <div class="adw-status-page">
                     <span class="adw-icon icon-content-document-new-symbolic adw-status-page-icon app-status-page-icon"></span>
                     <h3 class="adw-status-page-title">No Posts Yet</h3>
-                    <p class="adw-status-page-description">{{ user_profile.full_name or user_profile.username }} has not made any posts.</p>
+                    <p class="adw-status-page-description">{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} has not made any posts.</p>
                 </div>
             {% endif %}
         </div>
@@ -285,14 +287,14 @@
         {# User Comments Section #}
         <div class="adw-preferences-group" role="group" aria-labelledby="user-comments-title-{{user_profile.id}}">
             <div class="adw-preferences-group__title-container">
-                <h2 class="adw-preferences-group__title title-2" id="user-comments-title-{{user_profile.id}}">Comments by {{ user_profile.full_name or user_profile.username }}</h2>
+                <h2 class="adw-preferences-group__title title-2" id="user-comments-title-{{user_profile.id}}">Comments by {{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }}</h2>
             </div>
             {% if comments_pagination and comments_pagination.items %}
                 <div class="adw-list-box">
                     {% for comment in comments_pagination.items %}
                     <a href="{{ url_for('post.view_post', post_id=comment.post_id, _anchor='comment-' ~ comment.id) }}" class="adw-action-row activatable">
                         <div class="adw-action-row__text">
-                            <span class="adw-action-row__title">Comment on post by {{ comment.post.author.full_name or comment.post.author.username }}</span>
+                            <span class="adw-action-row__title">Comment on post by {{ comment.post.author.full_name or ('@' + comment.post.author.handle if comment.post.author.handle else comment.post.author.username) }}</span>
                             <span class="adw-action-row__subtitle">"{{ comment.text | truncate(100, True) }}"</span>
                             <small class="adw-label caption">
                                 <time datetime="{{ comment.created_at.isoformat() }}">{{ comment.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
@@ -308,7 +310,7 @@
                 <div class="adw-box adw-box-horizontal justify-center profile-pagination-box">
                     <div class="adw-toggle-group">
                         {% if comments_pagination.has_prev %}
-                            <a href="{{ url_for('profile.view_profile', username=user_profile.username, comments_page=comments_pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous comments page">
+                            <a href="{{ url_for('profile.view_profile', handle=user_profile.handle, comments_page=comments_pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous comments page">
                                 <span class="adw-icon icon-actions-go-previous-symbolic"></span>
                             </a>
                         {% else %}
@@ -322,7 +324,7 @@
                                 {% if page_num == comments_pagination.page %}
                                     <button class="adw-button suggested" disabled aria-current="page">{{ page_num }}</button>
                                 {% else %}
-                                    <a href="{{ url_for('profile.view_profile', username=user_profile.username, comments_page=page_num) }}" class="adw-button">{{ page_num }}</a>
+                                    <a href="{{ url_for('profile.view_profile', handle=user_profile.handle, comments_page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
                             {% elif loop.index != 1 and loop.index != comments_pagination.pages + comments_pagination.iter_pages()|length %}
                                 <button class="adw-button flat" disabled>…</button>
@@ -330,7 +332,7 @@
                         {% endfor %}
 
                         {% if comments_pagination.has_next %}
-                             <a href="{{ url_for('profile.view_profile', username=user_profile.username, comments_page=comments_pagination.next_num) }}" class="adw-button icon-only" aria-label="Next comments page">
+                             <a href="{{ url_for('profile.view_profile', handle=user_profile.handle, comments_page=comments_pagination.next_num) }}" class="adw-button icon-only" aria-label="Next comments page">
                                 <span class="adw-icon icon-actions-go-next-symbolic"></span>
                             </a>
                         {% else %}
@@ -345,7 +347,7 @@
                 <div class="adw-status-page">
                     <span class="adw-icon icon-content-message-symbolic adw-status-page-icon app-status-page-icon"></span>
                     <h3 class="adw-status-page-title">No Comments Yet</h3>
-                    <p class="adw-status-page-description">{{ user_profile.full_name or user_profile.username }} has not made any comments.</p>
+                    <p class="adw-status-page-description">{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} has not made any comments.</p>
                 </div>
             {% endif %}
         </div>
@@ -393,7 +395,7 @@
                     {% for photo in gallery_photos_preview %}
                     <div class="adw-card gallery-photo-card">
                         <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo.image_filename) }}"
-                             alt="{{ photo.caption or ('Gallery image by ' ~ (user_profile.full_name or user_profile.username)) }}"
+                             alt="{{ photo.caption or ('Gallery image by ' ~ (user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username))) }}"
                              class="gallery-photo-image clickable-gallery-photo"
                              data-fullsrc="{{ url_for('static', filename='uploads/gallery_pics/' + photo.image_filename) }}"
                              data-caption="{{ photo.caption or '' }}"
@@ -420,7 +422,7 @@
                 </div>
                 {% if total_gallery_photos > 0 %} {# Show view all button if there's at least one photo #}
                 <div class="adw-box justify-center" style="margin-top: var(--spacing-m);">
-                    <a href="{{ url_for('profile.view_gallery', username=user_profile.username) }}" class="adw-button">
+                    <a href="{{ url_for('profile.view_gallery', handle=user_profile.handle) }}" class="adw-button">
                         View All Photos ({{ total_gallery_photos }}) <span class="adw-icon icon-actions-go-next-symbolic"></span>
                     </a>
                 </div>
@@ -429,7 +431,7 @@
                 <div class="adw-status-page">
                     <span class="adw-icon icon-media-image-symbolic adw-status-page-icon app-status-page-icon"></span>
                     <h3 class="adw-status-page-title">Empty Gallery</h3>
-                    <p class="adw-status-page-description">{{ user_profile.full_name or user_profile.username }} has not uploaded any photos to their gallery yet.</p>
+                    <p class="adw-status-page-description">{{ user_profile.full_name or ('@' + user_profile.handle if user_profile.handle else user_profile.username) }} has not uploaded any photos to their gallery yet.</p>
                     {% if current_user != user_profile %}
                     <p class="adw-status-page-description">Check back later!</p>
                     {% endif %}
@@ -505,12 +507,17 @@ document.addEventListener('DOMContentLoaded', function () {
         comments.forEach(comment => {
             const commentDiv = document.createElement('div');
             commentDiv.classList.add('adw-action-row'); // Use Adwaita styling for list items
+            // Use author.handle for @mention style display and ensure profile_url is used correctly
+            const authorDisplayName = comment.author.full_name || (comment.author.handle ? `@${comment.author.handle}` : 'Unknown User');
+            const authorProfileUrl = comment.author.profile_url; // This should now be correct from the API
+            const authorAvatarAlt = comment.author.full_name || (comment.author.handle ? `@${comment.author.handle}` : 'User');
+
             commentDiv.innerHTML = `
                 <span class="adw-avatar size-small" style="margin-right: var(--spacing-s);">
-                    <img src="${comment.author.profile_photo_url}" alt="${comment.author.full_name || comment.author.username} avatar">
+                    <img src="${comment.author.profile_photo_url}" alt="${authorAvatarAlt} avatar">
                 </span>
                 <span class="adw-action-row-text-content">
-                    <a href="${comment.author.profile_url}" class="adw-link adw-action-row-title">${comment.author.full_name || comment.author.username}</a>
+                    ${authorProfileUrl ? `<a href="${authorProfileUrl}" class="adw-link adw-action-row-title">${authorDisplayName}</a>` : `<span class="adw-action-row-title">${authorDisplayName}</span>`}
                     <span class="adw-action-row-subtitle">${comment.text}</span>
                     <small class="adw-label caption">${formatCommentDate(comment.created_at)}</small>
                 </span>

--- a/antisocialnet/templates/register.html
+++ b/antisocialnet/templates/register.html
@@ -46,6 +46,23 @@
                     {% endif %}
                 </div>
 
+                {# Public Handle Field #}
+                <div class="adw-entry-row {{ 'has-error' if form.handle.errors else '' }}">
+                    <label for="{{ form.handle.id or 'handle_input' }}" class="adw-entry-row-title">{{ form.handle.label.text }}</label>
+                    <input type="text"
+                           name="{{ form.handle.name }}"
+                           id="{{ form.handle.id or 'handle_input' }}"
+                           class="adw-entry adw-entry-row-entry"
+                           required
+                           placeholder="your_public_handle"
+                           value="{{ form.handle.data or '' }}"
+                           aria-describedby="handle-help">
+                    <small id="handle-help" class="adw-label caption" style="margin-top: 2px; display: block;">This will be part of your profile URL. Letters, numbers, and underscores only.</small>
+                    {% if form.handle.errors %}
+                        <span class="adw-label caption error-text adw-entry-row-subtitle">{{ form.handle.errors|join(' ') }}</span>
+                    {% endif %}
+                </div>
+
                 {# Password Field #}
                 <div class="adw-entry-row {{ 'has-error' if form.password.errors else '' }}">
                     <label for="{{ form.password.id or 'password_input' }}" class="adw-entry-row-title">{{ form.password.label.text }}</label>

--- a/antisocialnet/utils.py
+++ b/antisocialnet/utils.py
@@ -53,42 +53,14 @@ def linkify_mentions(text):
     if text is None:
         return ''
     text = str(text)
-    # Regex to find @username patterns
-    # Allows alphanumeric characters and underscores in usernames
+    # Regex to find @handle patterns
+    # Allows alphanumeric characters and underscores in handles, consistent with form validation
     mention_regex = r'@([a-zA-Z0-9_]+)'
 
     def replace_mention(match):
-        username = match.group(1)
-        # In a real app, you'd use url_for here, but that's not available directly in utils
-        # without app context. This filter is applied in app context, so this is conceptual.
-        # For direct usage if needed outside app context, the URL structure would be hardcoded or passed.
-        # Here, we just format it, assuming url_for will be used in the template filter call.
-        # This utility function should just return the structure that the template filter can use.
-        # For now, it prepares a string that can be made into a link.
-        # The actual href creation is better handled in the template filter or by passing url_for.
-        # However, the current app structure calls this from the markdown filter.
-
-        # Simple version for now, actual URL generation might need app context or url_for
-        # from flask import url_for # This would cause circular import if utils is imported by __init__ too early
-        # For now, let's assume the markdown filter will handle the final URL construction if this
-        # function is only returning the username. Or, we create a placeholder link.
-
-        # Placeholder link structure, actual linking happens in template filter context
-        # This function is more about identifying and formatting, less about final URL generation here.
-        # The existing template filter for linkify_mentions in __init__ seems to expect this to return text.
-        # Then markdown_to_html_and_sanitize_util probably makes it a link.
-        # This function is more about identifying and formatting, less about final URL generation here.
-        # The existing template filter for linkify_mentions in __init__ seems to expect this to return text.
-        # Then markdown_to_html_and_sanitize_util probably makes it a link.
-        # Let's assume this is used by a filter that will then use url_for.
-        # A more direct approach would be for this to generate the <a> tag if it had url_for.
-        # Based on its usage in `actual_markdown_filter` in `__init__.py`, it seems this function
-        # should return text that `markdown_to_html_and_sanitize_util` then processes.
-        # The `linkify_mentions_util` is called *before* markdown.
-
-        # Let's make it generate a markdown link, which markdown_to_html_and_sanitize_util will process.
-        # This is a common pattern.
-        return f'[@{username}](/profile/{username})' # Generates a markdown link
+        handle = match.group(1)
+        # Generates a markdown link. The profile URL uses the handle.
+        return f'[@{handle}](/profile/{handle})'
 
     linked_text = re.sub(mention_regex, replace_mention, text)
     return linked_text
@@ -176,13 +148,14 @@ def allowed_file_util(filename):
 
 def extract_mentions(text):
     """
-    Extracts @username mentions from text.
-    Returns a list of unique usernames without the '@'.
+    Extracts @handle mentions from text.
+    Returns a list of unique handles without the '@'.
     """
     if not text:
         return []
-    # Regex to find @username patterns (alphanumeric, underscores, and hyphens)
-    mention_regex = r'@([a-zA-Z0-9_-]+)'
+    # Regex to find @handle patterns (alphanumeric, underscores)
+    # Consistent with form validation and linkify_mentions
+    mention_regex = r'@([a-zA-Z0-9_]+)'
     mentions = re.findall(mention_regex, text)
     return list(set(mentions)) # Return unique mentions
 
@@ -224,25 +197,32 @@ def update_post_relations_util(post, form_data, current_user_id, is_new_post=Fal
     # Let's assume form_data might contain an explicit list of mentioned usernames,
     # or we re-extract from post.content. For now, re-extracting from content.
 
-    mentioned_usernames = extract_mentions(post.content)
-    if mentioned_usernames:
-        for username in mentioned_usernames:
-            mentioned_user = User.query.filter_by(username=username).first()
+    mentioned_handles = extract_mentions(post.content)
+    if mentioned_handles:
+        for handle in mentioned_handles:
+            mentioned_user = User.query.filter_by(handle=handle).first() # Query by handle
             if mentioned_user and mentioned_user.id != current_user_id:
                 # Check if a notification already exists for this post and user to avoid duplicates
+                # Assuming Notification model's related_post_id is still in use or polymorphic target is set correctly
+                # For now, keeping related_post_id as per original structure.
+                # TODO: Review Notification target logic if it was intended to be polymorphic for mentions too.
+                # The Notification model has target_type and target_id, so this should be:
+                # target_type='post', target_id=post.id
                 existing_notification = Notification.query.filter_by(
                     user_id=mentioned_user.id,
-                    related_post_id=post.id,
-                    type='mention_in_post' # Or a more general mention type
+                    actor_id=current_user_id,
+                    type='mention_in_post',
+                    target_type='post',
+                    target_id=post.id
                 ).first()
 
                 if not existing_notification:
                     notification = Notification(
                         user_id=mentioned_user.id,
                         actor_id=current_user_id,
-                        type='mention_in_post', # Be specific if possible
-                        related_post_id=post.id
-                        # related_comment_id could be added if mentions in comments are handled here too
+                        type='mention_in_post',
+                        target_type='post',
+                        target_id=post.id
                     )
                     db.session.add(notification)
 


### PR DESCRIPTION
This commit introduces significant changes to address PII concerns regarding the use of email addresses as public user identifiers.

Key changes:
- Added a new `handle` field to the User model. This field serves as the primary public, unique, URL-safe identifier for users.
- User.username now strictly stores your email address and is used only for login and password reset purposes.
- Updated registration process (form, route, template) to include and validate the new `handle`.
- Modified profile routes (`/profile/<handle>`) to use the `handle` instead of username (email) for URL generation and user lookups.
- Updated mention utilities (`linkify_mentions`, `extract_mentions`) and associated notification logic to operate with `@handle`.
- Revised templates (profile, post, base, follower/following lists) to:
  - Use `User.full_name` as the primary display name.
  - Use `@User.handle` for secondary display or when full_name is absent.
  - Use `handle` for generating profile links.
- Corrected password reset email lookup to use `User.username` (email).
- Updated API responses (`serialize_actor`, photo comment author data) to return `handle` instead of `username` (email) and use `handle` for URLs.
- Modified `setup_db.py` to require and process `handle` for initial user setup (YAML, CLI, interactive).
- Updated logging across various modules to prefer User ID and Handle over email for log messages, reducing PII exposure in logs.
- Corrected user search in general routes to query by `handle` or `full_name` instead of `username` (email).

The `User.handle` field is currently nullable to facilitate transition and avoid breaking existing user data or tests immediately. A data migration will be required to populate this field for existing users, after which it should be made non-nullable. Test fixtures and user creation utilities will also need updating to provide handles.