### PR TITLE
Fix: Address multiple warnings and errors in antisocialnet

### DIFF
--- a/antisocialnet/forms.py
+++ b/antisocialnet/forms.py
@@ -66,8 +66,7 @@ class PostForm(FlaskForm):
         get_pk=get_category_pk,
         get_label='name',
         widget=ListWidget(prefix_label=False),
-        option_widget=CheckboxInput(),
-        allow_blank=True
+        option_widget=CheckboxInput()
     )
     tags_string = StringField(
         'Tags (comma-separated)',

--- a/antisocialnet/templates/edit_profile.html
+++ b/antisocialnet/templates/edit_profile.html
@@ -195,7 +195,7 @@
 
       <div class="edit-profile-form-actions form-actions-space-between">
             <div class="actions-start">
-                <a href="{{ url_for('profile.view_profile', username=current_user.username) }}" class="adw-button flat">Cancel</a>
+                <a href="{{ url_for('profile.view_profile', user_id=current_user.id) }}" class="adw-button flat">Cancel</a>
             </div>
             <div class="actions-end">
                 <button type="submit" class="adw-button suggested-action">{{ form.submit.label.text if form.submit.label else 'Update Profile' }}</button>

--- a/antisocialnet/templates/feed.html
+++ b/antisocialnet/templates/feed.html
@@ -14,7 +14,7 @@
                 <article class="adw-card blog-post-item-card">
                     <header class="blog-post-card__header">
                         <div class="adw-box adw-box-horizontal adw-box-spacing-m align-center blog-post-card-author-info">
-                            <a href="{{ url_for('profile.view_profile', username=post_item.author.username) }}" class="adw-link">
+                            <a href="{{ url_for('profile.view_profile', user_id=post_item.author.id) }}" class="adw-link">
                                 <span class="adw-avatar size-m">
                                     {% if post_item.author.profile_photo_url %}
                                     <img src="{{ url_for('static', filename=post_item.author.profile_photo_url) }}" alt="{{ post_item.author.username }} avatar">
@@ -24,7 +24,7 @@
                                 </span>
                             </a>
                             <div class="adw-box adw-box-vertical">
-                                <a href="{{ url_for('profile.view_profile', username=post_item.author.username) }}" class="adw-link">
+                                <a href="{{ url_for('profile.view_profile', user_id=post_item.author.id) }}" class="adw-link">
                                     <strong class="adw-label body-1">{{ post_item.author.full_name or post_item.author.username }}</strong>
                                 </a>
                                  <span class="adw-label caption">@{{ post_item.author.username }}</span>

--- a/antisocialnet/templates/index.html
+++ b/antisocialnet/templates/index.html
@@ -13,7 +13,7 @@
             <header class="blog-post-card__header">
                 {# Post title removed #}
                 <div class="blog-post-card__meta adw-label caption">
-                    By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
+                    By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
                     on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else 'Unknown date' }}</time> {# Show time as well #}
                 </div>
             </header>

--- a/antisocialnet/utils.py
+++ b/antisocialnet/utils.py
@@ -157,7 +157,7 @@ ALLOWED_TAGS_CONFIG = [
 ]
 
 ALLOWED_ATTRIBUTES_CONFIG = {
-    '*': ['class', 'id', 'style'],  # Allow class, id, style on any allowed tag (style should be used with caution)
+    '*': ['class', 'id'],  # Allow class, id on any allowed tag
     'a': ['href', 'title', 'target', 'rel'],
     'img': ['src', 'alt', 'title', 'width', 'height'],
     'table': ['summary'],


### PR DESCRIPTION
- I removed allow_blank=True from QuerySelectMultipleField in forms.py to resolve a UserWarning.
- I removed 'style' from ALLOWED_ATTRIBUTES_CONFIG in utils.py to resolve a NoCssSanitizerWarning.
- I updated url_for calls in feed.html, edit_profile.html, and index.html to use user_id instead of username for the profile.view_profile endpoint, resolving BuildErrors.