### PR TITLE
Fix: Correct BuildError in posts_by_tag.html

### DIFF
--- a/antisocialnet/templates/posts_by_tag.html
+++ b/antisocialnet/templates/posts_by_tag.html
@@ -26,7 +26,7 @@
                             <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.title }}</a>
                         </h2>
                         <div class="blog-post-card__meta adw-label caption">
-                            By: <a href="{{ url_for('profile.view_profile', username=post.author.username) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
+                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
                             on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         </div>
                     </header>


### PR DESCRIPTION
I updated the url_for call in posts_by_tag.html to use user_id instead of username for the profile.view_profile endpoint.

This is a follow-up to the previous commit to address the same error in a different template.