### PR TITLE
Fix: Correct TypeError in posts_by_tag.html

### DIFF
--- a/antisocialnet/templates/posts_by_tag.html
+++ b/antisocialnet/templates/posts_by_tag.html
@@ -58,7 +58,7 @@
                     </footer>
                     <div class="adw-card__actions card-secondary-actions">
                         {% from "_macros.html" import like_button_and_count %}
-                        {{ like_button_and_count(post, current_user, csrf_token()) }}
+                        {{ like_button_and_count(post, current_user) }}
                     </div>
                 </article>
                 {% endfor %}


### PR DESCRIPTION
I removed the `csrf_token()` argument from the `like_button_and_count` macro call in `antisocialnet/templates/posts_by_tag.html` to resolve a TypeError. The macro expects only two arguments (post and current_user).