### PR TITLE
Fix: Correct timestamp and admin user display logic

### DIFF
--- a/antisocialnet/templates/admin_flags.html
+++ b/antisocialnet/templates/admin_flags.html
@@ -20,14 +20,14 @@
             <div class="adw-action-row-content" style="display: flex; flex-direction: column; align-items: flex-start;">
                 <h4 class="adw-action-row-title" style="margin-bottom: var(--spacing-xs);">
                     <a href="{{ url_for('post.view_post', post_id=flag.comment.post_id, _anchor='comment-' ~ flag.comment_id) }}" target="_blank" class="adw-link">
-                        Comment by {{ flag.comment.author.username }} on post "{{ flag.comment.post.title }}"
+                        Comment by {{ flag.comment.author.full_name or "Unnamed User" }} ({{ flag.comment.author.username }}) on post "{{ flag.comment.post.title }}"
                     </a>
                 </h4>
                 <blockquote class="flagged-comment-text styled-text-content" style="font-size: var(--font-size-small); color: var(--text-color-secondary); border-left: 3px solid var(--warning-color); padding-left: var(--spacing-s); margin-left: 0; margin-bottom: var(--spacing-xs);">
                     "{{ flag.comment.text | truncate(150, True) }}"
                 </blockquote>
                 <small class="adw-label caption">
-                    Flagged by: {{ flag.flagger.username }} on {{ flag.created_at.strftime('%Y-%m-%d %H:%M') }} UTC
+                    Flagged by: {{ flag.flagger.full_name or "Unnamed User" }} ({{ flag.flagger.username }}) on {{ flag.created_at.strftime('%Y-%m-%d %H:%M') }} UTC
                     {% if flag.reason %}(Reason: {{ flag.reason }}){% endif %}
                 </small>
             </div>

--- a/antisocialnet/templates/admin_pending_users.html
+++ b/antisocialnet/templates/admin_pending_users.html
@@ -20,7 +20,8 @@
             {% for user_account in pending_users %}
             <div class="adw-action-row">
                 <div class="adw-action-row__text">
-                    <span class="adw-action-row__title">{{ user_account.username }}</span>
+                    <span class="adw-action-row__title">{{ user_account.full_name or "Unnamed User" }}</span>
+                    <span class="adw-action-row__subtitle">({{ user_account.username }})</span>
                     {# Could add registration date here if available and desired #}
                     {# <span class="adw-action-row__subtitle">Registered: {{ user_account.created_at|datetimeformat }}</span> #}
                 </div>

--- a/antisocialnet/templates/dashboard.html
+++ b/antisocialnet/templates/dashboard.html
@@ -22,8 +22,11 @@
                     {%- else -%}
                         Created: <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
                     {%- endif -%}
+                    {% set created_datetime = post.published_at or post.created_at %}
+                    {% if post.updated_at and created_datetime and (post.updated_at.timestamp() - created_datetime.timestamp()) > 60 %}
                     <br>
                     Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at.strftime('%Y-%m-%d %H:%M') }} UTC</time>
+                    {% endif %}
                 </div>
             </div>
             <div class="adw-action-row-suffix adw-box adw-box-spacing-s" style="align-items: center;">

--- a/antisocialnet/templates/post.html
+++ b/antisocialnet/templates/post.html
@@ -18,11 +18,9 @@
                         on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at | human_readable_date }}</time>
                     {%- endif -%}
                 </p>
-                {% set updated_str = post.updated_at | human_readable_date %}
-                {% set created_str = (post.published_at or post.created_at) | human_readable_date %}
-
-                {% if post.updated_at and updated_str != created_str %}
-                    <p class="adw-label caption last-updated">(Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ updated_str }}</time>)</p>
+                {% set created_datetime = post.published_at or post.created_at %}
+                {% if post.updated_at and created_datetime and (post.updated_at.timestamp() - created_datetime.timestamp()) > 60 %}
+                    <p class="adw-label caption last-updated">(Last updated: <time datetime="{{ post.updated_at.isoformat() }}">{{ post.updated_at | human_readable_date }}</time>)</p>
                 {% endif %}
             </div>
 


### PR DESCRIPTION
- Modified 'Last updated' timestamp display on post.html and dashboard.html to only show if updated_at is >60s different from created_at/published_at.
- Ensured admin_pending_users.html and admin_flags.html display full_name primarily, with username (email) as secondary info.