### PR TITLE
Fix test suite issues - Round 1

### DIFF
--- a/antisocialnet/templates/admin_flags.html
+++ b/antisocialnet/templates/admin_flags.html
@@ -66,7 +66,7 @@
                     {% else %}
                         <a href="{{ url_for('admin.view_flags', page=page_num) }}" class="adw-button">{{ page_num }}</a>
                     {% endif %}
-                {% elif loop.index != 1 and loop.index != flag_pagination.pages + 2 %}
+                {% else %}
                      <button class="adw-button flat" disabled style="pointer-events: none;">&hellip;</button>
                 {% endif %}
             {% endfor %}

--- a/antisocialnet/templates/feed.html
+++ b/antisocialnet/templates/feed.html
@@ -91,7 +91,8 @@
                         {% else %}
                             <a href="{{ url_for('general.activity_feed', page=page_num) }}" class="adw-button">{{ page_num }}</a>
                         {% endif %}
-                    {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
+                    {% else %}
+                        {# If page_num is None, iter_pages wants an ellipsis here #}
                         <button class="adw-button flat" disabled>…</button>
                     {% endif %}
                 {% endfor %}

--- a/antisocialnet/templates/index.html
+++ b/antisocialnet/templates/index.html
@@ -84,7 +84,7 @@
                 {% else %}
                     <a href="{{ url_for('general.index', page=page_num) }}" class="adw-button">{{ page_num }}</a>
                 {% endif %}
-            {% elif loop.index != 1 and loop.index != pagination.pages + 2 %}
+            {% else %}
                  <button class="adw-button flat" disabled style="pointer-events: none;">&hellip;</button>
             {% endif %}
         {% endfor %}

--- a/antisocialnet/templates/notifications.html
+++ b/antisocialnet/templates/notifications.html
@@ -124,7 +124,7 @@
                         {% else %}
                             <a href="{{ url_for('notification.list_notifications', page=page_num) }}" class="adw-button">{{ page_num }}</a>
                         {% endif %}
-                    {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
+                    {% else %}
                         <button class="adw-button flat" disabled>…</button>
                     {% endif %}
                 {% endfor %}

--- a/antisocialnet/templates/posts_by_category.html
+++ b/antisocialnet/templates/posts_by_category.html
@@ -80,7 +80,7 @@
                             {% else %}
                                 <adw-button text="{{ page_num }}" href="{{ url_for('post.posts_by_category', category_slug=category.slug, page=page_num) }}"></adw-button>
                             {% endif %}
-                        {% elif loop.index != 1 and loop.index != pagination.pages + 2 %}
+                        {% else %}
                             <adw-button text="…" flat disabled style="pointer-events: none;"></adw-button>
                         {% endif %}
                     {% endfor %}

--- a/antisocialnet/templates/posts_by_tag.html
+++ b/antisocialnet/templates/posts_by_tag.html
@@ -80,7 +80,7 @@
                             {% else %}
                                 <adw-button text="{{ page_num }}" href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug, page=page_num) }}"></adw-button>
                             {% endif %}
-                        {% elif loop.index != 1 and loop.index != pagination.pages + 2 %}
+                        {% else %}
                             <adw-button text="…" flat disabled style="pointer-events: none;"></adw-button>
                         {% endif %}
                     {% endfor %}

--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -269,7 +269,7 @@
                                 {% else %}
                                     <a href="{{ url_for('profile.view_profile', user_id=user_profile.id, page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
-                            {% elif loop.index != 1 and loop.index != posts_pagination.pages + posts_pagination.iter_pages()|length %}
+                            {% else %}
                                 <button class="adw-button flat" disabled>…</button>
                             {% endif %}
                         {% endfor %}
@@ -337,7 +337,7 @@
                                 {% else %}
                                     <a href="{{ url_for('profile.view_profile', user_id=user_profile.id, comments_page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
-                            {% elif loop.index != 1 and loop.index != comments_pagination.pages + comments_pagination.iter_pages()|length %}
+                            {% else %}
                                 <button class="adw-button flat" disabled>…</button>
                             {% endif %}
                         {% endfor %}

--- a/antisocialnet/templates/search_results.html
+++ b/antisocialnet/templates/search_results.html
@@ -67,7 +67,7 @@
                                 {% else %}
                                     <a href="{{ url_for('general.search_results', q=query, page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
-                            {% elif loop.index != 1 and loop.index != users_pagination.pages + 2 %}
+                            {% else %}
                                  <button class="adw-button flat" disabled style="pointer-events: none;">&hellip;</button>
                             {% endif %}
                         {% endfor %}
@@ -155,7 +155,7 @@
                                 {% else %}
                                     <a href="{{ url_for('general.search_results', q=query, page=page_num) }}" class="adw-button">{{ page_num }}</a>
                                 {% endif %}
-                            {% elif loop.index != 1 and loop.index != posts_pagination.pages + 2 %}
+                            {% else %}
                                  <button class="adw-button flat" disabled style="pointer-events: none;">&hellip;</button>
                             {% endif %}
                         {% endfor %}

--- a/antisocialnet/tests/test_api_routes.py
+++ b/antisocialnet/tests/test_api_routes.py
@@ -1,6 +1,6 @@
 import pytest
 from flask import url_for
-from antisocialnet.models import User, Post, UserPhoto, PostLike, Activity # Added Activity for potential future feed items
+from antisocialnet.models import User, Post, UserPhoto, Like, Activity # Added Activity for potential future feed items
 from antisocialnet import db
 from datetime import datetime, timedelta, timezone
 
@@ -68,7 +68,7 @@ def test_api_feed_authenticated_empty(client, logged_in_client):
 
 def test_api_feed_with_only_posts(client, logged_in_client, db, create_test_user):
     """Test API feed when only posts exist."""
-    author = create_test_user(username="api_post_author", email="aposta@example.com")
+    author = create_test_user(email_address="aposta@example.com", full_name="API Post Author")
     post1 = create_api_test_post(db, author, content="API Post 1", days_offset=1) # Older
     post2 = create_api_test_post(db, author, content="API Post 2", days_offset=0) # Newer
 
@@ -100,7 +100,7 @@ def test_api_feed_with_only_posts(client, logged_in_client, db, create_test_user
 
 def test_api_feed_with_only_photos(client, logged_in_client, db, create_test_user):
     """Test API feed when only photos exist."""
-    uploader = create_test_user(username="api_photo_uploader", email="aphou@example.com")
+    uploader = create_test_user(email_address="aphou@example.com", full_name="API Photo Uploader")
     photo1 = create_api_test_photo(db, uploader, caption="API Photo 1", days_offset=2) # Oldest
     photo2 = create_api_test_photo(db, uploader, caption="API Photo 2", days_offset=0) # Newest
 
@@ -127,8 +127,8 @@ def test_api_feed_with_only_photos(client, logged_in_client, db, create_test_use
 
 def test_api_feed_mixed_content_sorted_correctly(client, logged_in_client, db, create_test_user):
     """Test API feed with mixed posts and photos, ensuring correct chronological order."""
-    user1 = create_test_user(username="mixer1", email="mix1@example.com")
-    user2 = create_test_user(username="mixer2", email="mix2@example.com")
+    user1 = create_test_user(email_address="mix1@example.com", full_name="Mixer User 1")
+    user2 = create_test_user(email_address="mix2@example.com", full_name="Mixer User 2")
 
     # Create items with varying timestamps
     # Newest
@@ -149,7 +149,7 @@ def test_api_feed_mixed_content_sorted_correctly(client, logged_in_client, db, c
 
 def test_api_feed_pagination(client, app, logged_in_client, db, create_test_user):
     """Test pagination for the API feed."""
-    user = create_test_user(username="api_pager", email="apage@example.com")
+    user = create_test_user(email_address="apage@example.com", full_name="API Pager")
 
     # Override POSTS_PER_PAGE for this test via app config directly (SiteSetting not used by API for per_page)
     # The API route uses app.config.get('POSTS_PER_PAGE', 10) as default per_page
@@ -175,7 +175,8 @@ def test_api_feed_pagination(client, app, logged_in_client, db, create_test_user
     assert json_p1['pagination']['total_pages'] == 3 # 5 items, 2 per page = 3 pages
     assert json_p1['pagination']['has_next'] == True
     assert json_p1['pagination']['has_prev'] == False
-    assert url_for('api.get_feed', page=2, per_page=2, _external=True) in json_p1['pagination']['next_page_url']
+    with app.app_context(): # Ensure context for url_for in assertion
+        assert url_for('api.get_feed', page=2, per_page=2, _external=True) in json_p1['pagination']['next_page_url']
 
     response_p3 = logged_in_client.get(url_for('api.get_feed', page=3, per_page=2))
     json_p3 = response_p3.get_json()
@@ -184,14 +185,15 @@ def test_api_feed_pagination(client, app, logged_in_client, db, create_test_user
     assert json_p3['pagination']['page'] == 3
     assert json_p3['pagination']['has_next'] == False
     assert json_p3['pagination']['has_prev'] == True
-    assert url_for('api.get_feed', page=2, per_page=2, _external=True) in json_p3['pagination']['prev_page_url']
+    with app.app_context(): # Ensure context for url_for in assertion
+        assert url_for('api.get_feed', page=2, per_page=2, _external=True) in json_p3['pagination']['prev_page_url']
 
 def test_api_feed_post_liked_by_current_user(client, logged_in_client, db, create_test_user):
     """Test that 'is_liked_by_current_user' is correctly set for posts in the feed."""
-    post_author = create_test_user(username="likable_author", email="la@example.com")
+    post_author = create_test_user(email_address="la@example.com", full_name="Likable Author")
     test_post = create_api_test_post(db, post_author, content="A post to be liked.")
 
-    liking_user = User.query.filter_by(username="loginuser").first() # This is logged_in_client
+    liking_user = User.query.filter_by(username="login_fixture_user@example.com").first() # This is logged_in_client
 
     # Scenario 1: Post not liked
     response_not_liked = logged_in_client.get(url_for('api.get_feed'))


### PR DESCRIPTION
This commit addresses several categories of errors in the pytest suite for your antisocialnet application.

Summary of changes and progress:

1.  **Environment Setup & Initial Exploration:**
    *   I successfully set up PostgreSQL and installed project dependencies.
    *   I compiled Adwaita-Web assets after installing `sass`.
    *   I identified initial test failures primarily related to `ImportError` for `PostLike`.

2.  **ImportError Resolution:**
    *   I corrected `ImportError: cannot import name 'PostLike' from 'antisocialnet.models'` in `tests/test_api_routes.py` and `tests/test_models.py` by changing imports from `PostLike` to `Like`, reflecting a model rename and polymorphic change.

3.  **`create_test_user` Fixture and `User.email` Attribute Issues:**
    *   I updated calls to the `create_test_user` fixture in `test_admin_routes.py` and `test_api_routes.py` to pass `email_address` instead of `username`, and to provide `full_name`.
    *   I corrected usages of `user.email` to `user.username` in `test_auth_routes.py` where the `User` model stores the email in the `username` field.

4.  **`Like` Model Adaptations in Tests:**
    *   I modified tests in `test_models.py` to use the new polymorphic `Like` model methods:
        *   `user.has_liked_post(post)` changed to `user.has_liked_item(target_type='post', target_id=post.id)`.
        *   `user.like_post(post)` changed to `user.like_item(target_type='post', target_id=post.id)`.
        *   `user.unlike_post(post)` changed to `user.unlike_item(target_type='post', target_id=post.id)`.
        *   `PostLike.query` changed to `Like.query` with appropriate `target_type` filters.

5.  **`admin_client` Fixture (test_admin_routes.py):**
    *   I removed the local `admin_client` fixture from `test_admin_routes.py` which was causing `RuntimeError: Working outside of request context.` This allows usage of the more robust `admin_client` from `conftest.py`.
    *   I corrected user lookup in `test_admin_route_non_admin_authenticated_forbidden` to use the correct email for the user created by `logged_in_client`.
    *   I corrected admin user lookup in `test_resolve_flag_successful` to use the email from the `admin_client` in `conftest.py`.

6.  **Jinja2 `TypeError` in Pagination (Generator Length):**
    *   I fixed `TypeError: object of type 'generator' has no len()` in pagination macros used across multiple templates (`feed.html`, `index.html`, `search_results.html`, `posts_by_category.html`, `posts_by_tag.html`, `profile.html`, `admin_flags.html`, `notifications.html`).
    *   I simplified the logic for displaying ellipses, relying on `iter_pages()` to correctly yield `None` where ellipses are appropriate.

7.  **`url_for` Context Issues (`RuntimeError`):**
    *   I ensured `url_for()` calls used in assertions within `test_api_routes.py` are wrapped in an application context (`with app.app_context():`).
    *   I reviewed `test_auth_routes.py`, `test_general_routes.py`, `test_photo_routes.py`, and `test_profile_routes.py`, confirming that `url_for` calls outside of direct client actions are generally within appropriate contexts.

**Remaining Issues & Next Steps (Intended Plan):** The test suite is still not fully passing. The next steps would have been to continue addressing the remaining error categories systematically:
*   Fix `AttributeError: 'SQLAlchemy' object has no attribute 'add'` by changing `db.add()` to `db.session.add()`.
*   Fix `AttributeError: 'Flask' object has no attribute 'env'` to use `app.config['ENV']`.
*   Correct the path to `setup_db.py` in `test_setup_db.py`.
*   Add missing imports (`render_template` in `photo_routes.py`, `LoginForm` in `test_routes_post.py`).
*   Pass `current_user` to `render_template` in `posts_by_tag` route.
*   Address `AssertionError`s related to response content.
*   Fix utility function tests in `test_utils.py`.
*   Fix `BuildError` for `url_for` calls with incorrect endpoint names or parameters.

I was in the process of systematically working through these errors.