### PR TITLE
feat: Update header menu and dialog styles

### DIFF
--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -16,18 +16,22 @@
         /* Default Adwaita variables should be available here */
         color: var(--dialog-fg-color, inherit);
       }
-      .adw-header-bar {
+      .adw-header-bar { /* This is the header for adw-about-dialog */
         display: flex;
-        justify-content: space-between;
+        /* justify-content: space-between; */ /* Will be handled by button order/margin */
         align-items: center;
-        padding: var(--spacing-s) var(--spacing-m); /* Adjusted for potentially smaller header */
-        border-bottom: 1px solid var(--border-color);
+        padding: var(--spacing-xs); /* Minimal padding */
+        border-bottom: none; /* Remove border */
+        background-color: transparent; /* Remove background */
+        height: auto; /* Minimal height */
         flex-shrink: 0;
       }
       .adw-header-bar__title {
-        font-size: var(--title-4-font-size); /* Smaller title for about dialog header */
-        font-weight: bold;
-        margin: 0; /* Remove default h2 margin */
+        display: none; /* Hide title */
+      }
+      .adw-dialog-close-button { /* This is the close button inside the header */
+        order: -1; /* Move to start of flex container */
+        margin-right: auto; /* Push other items (none visible) to the right */
       }
       /* Close button styling relies on global .adw-button, .circular, .flat, .adw-icon, .icon-window-close-symbolic */
       /* Ensure these classes are effective or provide minimal overrides if needed for shadow DOM context */

--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -39,24 +39,24 @@ adw-about-dialog {
 
 // Specific styles for the generic <adw-dialog> (Light DOM content)
 adw-dialog {
-  > .adw-dialog-header {
+  > .adw-dialog__header { // Changed selector to match JS (.adw-dialog__header)
     display: flex;
-    justify-content: space-between;
+    // justify-content: space-between; // Will be handled by button order/margin
     align-items: center;
-    padding: var(--spacing-m);
-    border-bottom: 1px solid var(--border-color);
+    padding: var(--spacing-xs); // Minimal padding
+    border-bottom: none; // Remove border
+    background-color: transparent; // Remove background
+    height: auto; // Minimal height
 
     .adw-header-bar__title {
-      font-size: var(--title-3-font-size);
-      font-weight: var(--font-weight-bold);
+      display: none; // Hide title
     }
-    // Styling for the close button in generic dialog header (if needed beyond .adw-button classes)
-    .adw-dialog-close-button.adw-button .adw-icon {
-        // Basic icon mask if not provided by global .adw-icon or button styles
-        // background-color: currentColor;
-        // -webkit-mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
-        // mask-image: url('../data/icons/symbolic/window-close-symbolic.svg');
-        // width: var(--icon-size-base); height: var(--icon-size-base);
+
+    .adw-dialog-close-button {
+      order: -1; // Move to start of flex container
+      margin-right: auto; // Push other items (none visible) to the right
+      // Ensure it's visible and clickable, additional styling if needed:
+      // e.g., color if it was inheriting from a now-transparent header
     }
   }
 

--- a/antisocialnet/templates/base.html
+++ b/antisocialnet/templates/base.html
@@ -50,7 +50,9 @@
     </script>
 </head>
 <body>
+{% block dialog_mode %}{% endblock %} {# Define dialog_mode block #}
 
+{% if not dialog_mode %} {# Conditionally render header #}
 <header class="adw-header-bar">
     <div class="adw-header-bar__start">
         <button class="adw-button flat circular app-sidebar-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="app-sidebar">
@@ -86,20 +88,36 @@
                     <button class="adw-action-row activatable" id="about-dialog-trigger" role="menuitem">
                         <span class="adw-action-row-title">About</span>
                     </button>
-                    {# Add other menu items here if needed in the future #}
+                    {% if current_user.is_authenticated %}
+                    <a href="{{ url_for('general.settings_page') }}" class="adw-action-row activatable" role="menuitem">
+                        <span class="adw-action-row-title">Settings</span>
+                    </a>
+                    {% if current_user.is_admin %}
+                    <a href="{{ url_for('admin.site_settings') }}" class="adw-action-row activatable" role="menuitem">
+                        <span class="adw-action-row-title">Site Settings</span>
+                    </a>
+                    <a href="{{ url_for('admin.view_flags') }}" class="adw-action-row activatable" role="menuitem">
+                        <span class="adw-action-row-title">Review Flags</span>
+                    </a>
+                    <a href="{{ url_for('admin.pending_users') }}" class="adw-action-row activatable" role="menuitem">
+                        <span class="adw-action-row-title">Pending Users</span>
+                    </a>
+                    {% endif %}
+                    <a href="{{ url_for('auth.logout') }}" class="adw-action-row activatable" role="menuitem">
+                        <span class="adw-action-row-title">Logout</span>
+                    </a>
+                    {% endif %}
                 </div>
             </div>
         </div>
 
-        {# Settings, Login/Logout #}
-        {% if current_user.is_authenticated %}
-            <a href="{{ url_for('general.settings_page') }}" class="adw-button flat" title="Settings">Settings</a>
-            <a href="{{ url_for('auth.logout') }}" class="adw-button flat">Logout</a>
-        {% else %}
+        {# Login button if not authenticated, otherwise this area is empty as items are in menu #}
+        {% if not current_user.is_authenticated %}
             <a href="{{ url_for('auth.login') }}" class="adw-button">Login</a>
         {% endif %}
     </div>
 </header>
+{% endif %} {# End conditional rendering of header #}
 
 {# Adwaita About Dialog Web Component #}
 <adw-about-dialog id="app-about-dialog"

--- a/antisocialnet/templates/change_password.html
+++ b/antisocialnet/templates/change_password.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block dialog_mode %}true{% endblock %}
 
 {% block title %}Change Password{% endblock %}
 

--- a/antisocialnet/templates/login.html
+++ b/antisocialnet/templates/login.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block dialog_mode %}true{% endblock %}
 {% block title %}Login{% endblock %}
 
 {% block header_title %}Login{% endblock %}

--- a/antisocialnet/templates/register.html
+++ b/antisocialnet/templates/register.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block dialog_mode %}true{% endblock %}
 {% block title %}Register{% endblock %}
 
 {% block header_title %}Create Account{% endblock %}

--- a/antisocialnet/templates/request_reset_password.html
+++ b/antisocialnet/templates/request_reset_password.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block dialog_mode %}true{% endblock %}
 
 {% block title %}{{ title or "Request Password Reset" }}{% endblock %}
 

--- a/antisocialnet/templates/reset_password_with_token.html
+++ b/antisocialnet/templates/reset_password_with_token.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block dialog_mode %}true{% endblock %}
 
 {% block title %}{{ title or "Reset Your Password" }}{% endblock %}
 


### PR DESCRIPTION
- Modify main application menu in base.html:
  - Relocate Settings and Logout links to popover.
  - Add admin-specific links (Site Settings, Review Flags, Pending Users) to popover.
- Implement 'Dialog Mode' for full pages:
  - Add 'dialog_mode' block to base.html to conditionally hide main header.
  - Apply dialog_mode to login, register, and password reset/change pages.
- Modify Adwaita-Web dialog component styling (CSS-only):
  - Update _dialog.scss to hide adw-dialog header and restyle close button to top-left.
  - Update adw-about-dialog internal styles to hide its header and restyle close button to top-left.
- Build: Compile SCSS and copy assets using build-adwaita-web.sh after installing sass.