### PR TITLE
fix: Adjust dialogs and header menu based on feedback

### DIFF
--- a/adwaita-web/js/components/aboutdialog.js
+++ b/adwaita-web/js/components/aboutdialog.js
@@ -30,8 +30,9 @@
         display: none; /* Hide title */
       }
       .adw-dialog-close-button { /* This is the close button inside the header */
-        order: -1; /* Move to start of flex container */
-        margin-right: auto; /* Push other items (none visible) to the right */
+        // order: -1; /* Removed */
+        // margin-right: auto; /* Removed */
+        margin-left: auto; /* Pushes button to the far right of the flex container */
       }
       /* Close button styling relies on global .adw-button, .circular, .flat, .adw-icon, .icon-window-close-symbolic */
       /* Ensure these classes are effective or provide minimal overrides if needed for shadow DOM context */

--- a/adwaita-web/scss/_dialog.scss
+++ b/adwaita-web/scss/_dialog.scss
@@ -53,8 +53,9 @@ adw-dialog {
     }
 
     .adw-dialog-close-button {
-      order: -1; // Move to start of flex container
-      margin-right: auto; // Push other items (none visible) to the right
+      // order: -1; // Removed
+      // margin-right: auto; // Removed
+      margin-left: auto; // Pushes button to the far right of the flex container
       // Ensure it's visible and clickable, additional styling if needed:
       // e.g., color if it was inheriting from a now-transparent header
     }

--- a/adwaita-web/scss/_popover.scss
+++ b/adwaita-web/scss/_popover.scss
@@ -12,6 +12,10 @@
   transform: scale(0.95) translateY(-10px); // Initial state for animation
   transform-origin: top center; // Default origin, JS might adjust based on arrow
   visibility: hidden;
+  // Default positioning if JS doesn't override (e.g. for the header menu)
+  // Set a default top, but right/left should be specific to context.
+  // top: var(--headerbar-height, 56px); // Example if headerbar-height is a var
+
   transition: opacity var(--animation-duration-short) var(--animation-ease-out-cubic),
               transform var(--animation-duration-short) var(--animation-ease-out-cubic),
               visibility 0s linear var(--animation-duration-short);
@@ -28,9 +32,25 @@
   &.menu-popover, &.menu { // Allow .menu as a general class for menu popovers
     background-color: var(--popover-bg-color);
     color: var(--window-fg-color);
-    border-radius: var(--border-radius-large); // Libadwaita popovers often use larger radius
+    border-radius: var(--border-radius-large);
     box-shadow: var(--popover-box-shadow);
-    padding: var(--spacing-xs) 0; // Menus have tighter vertical padding, no horizontal on surface
+    padding: var(--spacing-xs) 0;
+    min-width: 200px; // Ensure a reasonable minimum width for menus
+
+    // Default positioning for a menu popover, e.g. the main app menu in the header.
+    // Applied if JS doesn't set top/left inline styles.
+    // Assumes .main-app-menu-container is the reference for this specific menu.
+    // Since .adw-popover is position:fixed, these are viewport relative.
+    &.menu-popover { // Be more specific for the headerbar's menu popover
+        // Check if it's the one in the headerbar (which has no explicit JS positioning)
+        // This is a bit of a heuristic. A dedicated class would be better.
+        &:not([style*="top:"]):not([style*="left:"]) {
+             // Approx header height (48px from _headerbar.scss) + small gap (4px)
+            top: calc(48px + 4px);
+            right: var(--spacing-s, 6px); // Offset from the right viewport edge
+            transform-origin: top right; // Animation origin for right-aligned popover
+        }
+    }
 
     .adw-list-box { // ListBox inside a menu popover
       background-color: transparent; // ListBox itself is transparent

--- a/adwaita-web/scss/_symbolic_icons.scss
+++ b/adwaita-web/scss/_symbolic_icons.scss
@@ -4182,6 +4182,12 @@ $icon-base-path: '../data/icons/symbolic/';
   mask-image: url($icon-base-path + 'web-browser-symbolic.svg');
 }
 
+.icon-actions-close-symbolic { // Added definition for dialogs
+  @extend %symbolic-icon-base;
+  -webkit-mask-image: url($icon-base-path + 'window-close-symbolic.svg'); // Assuming same icon as window-close
+  mask-image: url($icon-base-path + 'window-close-symbolic.svg');
+}
+
 .icon-window-close-symbolic {
   @extend %symbolic-icon-base;
   -webkit-mask-image: url($icon-base-path + 'window-close-symbolic.svg');


### PR DESCRIPTION
- Position dialog close buttons to top-right for adw-dialog and adw-about-dialog.
- Fix close icon visibility by adding definition for .icon-actions-close-symbolic.
- Adjust headerbar dropdown menu CSS for better viewport positioning.
- Re-build assets.