### PR TITLE
fix: Resolve UndefinedError and profile image path

### DIFF
--- a/antisocialnet/config.py
+++ b/antisocialnet/config.py
@@ -9,12 +9,10 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     WTF_CSRF_TIME_LIMIT = 14400 # 4 hours, for diagnosing "CSRF token invalid" errors
-    UPLOAD_FOLDER = 'static/uploads/profile_pics' # Relative to app root (antisocialnet/).
-                                                  # Will be made absolute in __init__.py to antisocialnet/static/uploads/profile_pics
+    UPLOAD_FOLDER = 'uploads/profile_pics' # Relative to app.static_folder
     ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
     MAX_PROFILE_PHOTO_SIZE_BYTES = 2 * 1024 * 1024  # 2MB
-    GALLERY_UPLOAD_FOLDER = 'static/uploads/gallery_pics' # Relative to app root (antisocialnet/)
-                                                       # Will be made absolute in __init__.py
+    GALLERY_UPLOAD_FOLDER = 'uploads/gallery_pics' # Relative to app.static_folder
     MAX_GALLERY_PHOTO_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # Max overall request size 10MB (increased for gallery)
     POSTS_PER_PAGE = 10 # Default, can be overridden by SiteSetting

--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -242,7 +242,7 @@
                         </footer>
                         <div class="adw-card__actions card-secondary-actions">
                             {% from "_macros.html" import like_button_and_count %}
-                            {{ like_button_and_count(post, current_user) }}
+                            {{ like_button_and_count(post, 'post', current_user) }}
                         </div>
                     </article>
                     {% endfor %}


### PR DESCRIPTION
- Correct arguments in `like_button_and_count` macro call in profile.html to fix `UndefinedError: parameter 'current_user' was not provided`.
- Update default UPLOAD_FOLDER and GALLERY_UPLOAD_FOLDER paths in config.py to remove leading 'static/', preventing double 'static/static/' in image URLs.