### PR TITLE
feat: Implement multiple photo uploads and theme corrections

### DIFF
--- a/adwaita-web/scss/_variables.scss
+++ b/adwaita-web/scss/_variables.scss
@@ -35,16 +35,17 @@ $accent-yellow-fg: rgba(0, 0, 0, 0.8); // Yellow is an exception, matches docs @
 
 // Standalone colors (meant for text on neutral backgrounds)
 // These are updated to match the Libadwaita 1.5 docs for @accent_color, @destructive_color etc.
+// Further updated to align more closely with Libadwaita main spec for accent shades.
 $accent-standalone-colors: (
-  "blue":   (light: #1c71d8, dark: #78aeed), // From @accent_color
-  "teal":   (light: #007184, dark: #7bdff4), // Kept from previous, good standalone teal
-  "green":  (light: #1b8553, dark: #8ff0a4), // From @success_color
-  "yellow": (light: #9c6e03, dark: #f8e45c), // From @warning_color
-  "orange": (light: #b62200, dark: #ff9c5b), // Kept from previous, good standalone orange
-  "red":    (light: #c01c28, dark: #ff7b63), // From @destructive_color / @error_color
-  "pink":   (light: #a2326c, dark: #ffa0d8), // Kept from previous, good standalone pink
-  "purple": (light: #813d9c, dark: #c061cb), // Using purple-4 and purple-2 for better contrast than original
-  "slate":  (light: #526678, dark: #bbd1e5)  // Kept from previous, good standalone slate
+  "blue":   (light: #1c71d8, dark: #78aeed), // Libadwaita: @accent_color light @blue_4, dark a lighter blue
+  "teal":   (light: #007184, dark: #63d2e7), // Libadwaita: light @teal_4, dark @teal_2
+  "green":  (light: #26a269, dark: #8ff0a4), // Libadwaita @success_color: light @green_5, dark @green_1
+  "yellow": (light: #9c6e03, dark: #f8e45c), // Libadwaita @warning_color: light desaturated @yellow_5, dark @yellow_2
+  "orange": (light: #e66100, dark: #ffa348), // Libadwaita: light @orange_4, dark @orange_2
+  "red":    (light: #c01c28, dark: #ff7b63), // Libadwaita @destructive_color: light @red_4, dark adjusted @red_1
+  "pink":   (light: #a2326c, dark: #ffa0d8), // Custom accent, kept as is
+  "purple": (light: #813d9c, dark: #c061cb), // Libadwaita: light @purple_4, dark @purple_2
+  "slate":  (light: #526678, dark: #bbd1e5)  // Custom accent, kept as is
 );
 
 
@@ -84,8 +85,8 @@ $view-bg-color-dark: #1e1e1e;
 $headerbar-bg-color-dark: #303030;
 $headerbar-shade-color-dark: rgba(0, 0, 0, 0.36);
 $headerbar-darker-shade-color-dark: rgba(0, 0, 0, 0.9);
-$sidebar-bg-color-dark: #303030;
-$sidebar-backdrop-color-dark: #2a2a2a;
+$sidebar-bg-color-dark: #282828; // Updated to match official Adwaita
+$sidebar-backdrop-color-dark: #222222; // Updated to match official Adwaita for unfocused sidebar
 $sidebar-border-color-dark: rgba(0, 0, 0, 0.36);
 $sidebar-shade-color-dark: rgba(0, 0, 0, 0.25);
 $card-bg-color-dark: rgba(255, 255, 255, 0.08);

--- a/antisocialnet/forms.py
+++ b/antisocialnet/forms.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from wtforms import (
     BooleanField,
-    FileField,
+    MultipleFileField,
     PasswordField,
     StringField,
     SubmitField,
@@ -123,18 +123,19 @@ class SiteSettingsForm(FlaskForm):
     submit = SubmitField('Save Settings')
 
 class GalleryPhotoUploadForm(FlaskForm):
-    photo = FileField(
-        'Photo (Max 5MB)',
+    photos = MultipleFileField(  # Changed from photo to photos and FileField to MultipleFileField
+        'Photos (Max 5MB each)',  # Updated label
         validators=[
-            DataRequired(message="Please select a photo to upload."),
-            # FileAllowed will be added dynamically in the route using current_app.config
+            DataRequired(message="Please select one or more photos to upload."),
+            # FileAllowed will be added dynamically in the route for each file.
+            # Consider adding a validator for the number of files if needed, e.g., Length(min=1, max=10)
         ]
     )
-    caption = TextAreaField(
-        'Caption (Optional)',
+    caption = TextAreaField(  # Caption will apply to all photos in this batch, or adjust logic in route
+        'Caption (Optional, applies to all uploaded photos)',
         validators=[Optional(), Length(max=500)]
     )
-    submit = SubmitField('Upload Photo')
+    submit = SubmitField('Upload Photos') # Updated label
 
 class PhotoCommentForm(FlaskForm):
     text = TextAreaField(

--- a/antisocialnet/templates/gallery_full.html
+++ b/antisocialnet/templates/gallery_full.html
@@ -5,7 +5,7 @@
 {% block header_title %}{{ user_profile.username }}'s Photo Gallery{% endblock %}
 
 {% block header_actions_start %}
-    <a href="{{ url_for('profile.view_profile', username=user_profile.username) }}" class="adw-button">
+    <a href="{{ url_for('profile.view_profile', user_id=user_profile.id) }}" class="adw-button">
         <span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Profile
     </a>
 {% endblock %}
@@ -43,7 +43,7 @@
                 <p class="adw-status-page-description">Check back later!</p>
             {% endif %}
             <div class="adw-status-page-actions">
-                <a href="{{ url_for('profile.view_profile', username=user_profile.username) }}" class="adw-button">Back to Profile</a>
+                <a href="{{ url_for('profile.view_profile', user_id=user_profile.id) }}" class="adw-button">Back to Profile</a>
             </div>
         </div>
     {% endif %}

--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -376,12 +376,12 @@
                 </div>
                 <form method="POST" action="{{ url_for('profile.upload_gallery_photo') }}" enctype="multipart/form-data" class="gallery-upload-form">
                     {{ gallery_upload_form.hidden_tag() if gallery_upload_form else '' }} {# CSRF token #}
-                    <div class="adw-entry-row {{ 'has-error' if gallery_upload_form and gallery_upload_form.photo.errors else '' }}">
+                    <div class="adw-entry-row {{ 'has-error' if gallery_upload_form and gallery_upload_form.photos.errors else '' }}">
                         <div class="adw-entry-row-text-content">
-                            <label for="{{ gallery_upload_form.photo.id if gallery_upload_form else 'gallery_photo_input' }}" class="adw-entry-row-title">{{ gallery_upload_form.photo.label.text if gallery_upload_form else 'Photo File' }}</label>
-                            {% if gallery_upload_form and gallery_upload_form.photo.errors %}<span class="adw-entry-row-subtitle error-text">{{ gallery_upload_form.photo.errors|join(' ') }}</span>{% endif %}
+                            <label for="{{ gallery_upload_form.photos.id if gallery_upload_form else 'gallery_photos_input' }}" class="adw-entry-row-title">{{ gallery_upload_form.photos.label.text if gallery_upload_form else 'Photo Files' }}</label>
+                            {% if gallery_upload_form and gallery_upload_form.photos.errors %}<span class="adw-entry-row-subtitle error-text">{{ gallery_upload_form.photos.errors|join(' ') }}</span>{% endif %}
                         </div>
-                        {{ gallery_upload_form.photo(class="adw-entry adw-entry-row-entry") if gallery_upload_form }}
+                        {{ gallery_upload_form.photos(class="adw-entry adw-entry-row-entry") if gallery_upload_form }}
                     </div>
                     {# Caption Textarea - Revised Structure #}
                     <div class="form-field-container {{ 'has-error' if gallery_upload_form and gallery_upload_form.caption.errors else '' }}" style="padding: var(--spacing-s) var(--spacing-m) var(--spacing-m) var(--spacing-m);">


### PR DESCRIPTION
I've implemented multiple file uploads for the photo gallery:
- Updated `GalleryPhotoUploadForm` to use `MultipleFileField`.
- Modified `profile_routes.py` to handle multiple file processing.
- Adjusted `gallery_full.html` and `profile.html` templates for the new form field and to ensure correct display.

I've also corrected Adwaita dark theme and accent colors:
- Updated `$sidebar-bg-color-dark` and `$sidebar-backdrop-color-dark` in `_variables.scss` to align with Libadwaita specs.
- Verified other core dark theme surface colors (`window`, `view`, `card`, etc.) against specs.
- Updated standalone accent color SCSS variables for Teal, Green, and Orange to better match Libadwaita official shades. Ensured Teal accent is available.

Additionally, I've updated relevant tests in `test_photo_routes.py` to reflect changes to the gallery upload form.

Further manual testing is recommended for full UI and theming verification.