### PR TITLE
Fix: Correct gallery photo URLs and verify avatar styling

### DIFF
--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -405,10 +405,10 @@
                 <div class="profile-gallery-grid">
                     {% for photo in gallery_photos_preview %}
                     <div class="adw-card gallery-photo-card">
-                        <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo.image_filename) }}"
+                        <img src="{{ url_for('static', filename=photo.image_filename) }}"
                              alt="{{ photo.caption or ('Gallery image by ' ~ (user_profile.full_name or ('User ' ~ user_profile.id))) }}"
                              class="gallery-photo-image clickable-gallery-photo"
-                             data-fullsrc="{{ url_for('static', filename='uploads/gallery_pics/' + photo.image_filename) }}"
+                             data-fullsrc="{{ url_for('static', filename=photo.image_filename) }}"
                              data-caption="{{ photo.caption or '' }}"
                               data-photoid="{{ photo.id }}" {# Added photo ID #}
                              style="cursor: pointer;"


### PR DESCRIPTION
- I corrected the `url_for` static path generation for gallery photo thumbnails and full-size images in `profile.html` to prevent 404 errors for image assets.
- I verified that the CSS for `.adw-avatar` components includes `object-fit: cover` and properties for circular display, which should prevent image stretching.
- I confirmed that the link to the full gallery page (`profile.view_gallery`) is correctly implemented on `profile.html`.