### PR TITLE
Fix: Correct image URLs and improve layout on full gallery page

### DIFF
--- a/adwaita-web/scss/_antisocialnet-specific.scss
+++ b/adwaita-web/scss/_antisocialnet-specific.scss
@@ -706,3 +706,22 @@ $app-sidebar-breakpoint: 768px;
   // Ensure it doesn't inherit unwanted styles from generic .adw-button if they conflict
   text-decoration: none; // Links shouldn't be underlined if they are buttons
 }
+
+// Styles for the full-page gallery grid (gallery_full.html)
+.full-page-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); // Larger min size for items
+  gap: var(--spacing-l);
+  // padding-top and padding-bottom are applied inline in the template, which is fine.
+
+  .gallery-photo-card {
+    // Inherits .adw-card styles
+    // Specific overrides for cards within this full-page grid can go here if needed.
+    .gallery-photo-image {
+      width: 100%;
+      height: 220px; // Larger height for images in the full gallery
+      object-fit: cover;
+      border-bottom: 1px solid var(--border-color); // Consistent with profile preview
+    }
+  }
+}

--- a/antisocialnet/templates/gallery_full.html
+++ b/antisocialnet/templates/gallery_full.html
@@ -13,13 +13,12 @@
 {% block content %}
 <div class="adw-clamp adw-clamp-xl">
     {% if gallery_photos %}
-        <div class="profile-gallery-grid" style="padding-top: var(--spacing-l); padding-bottom: var(--spacing-l);"> {# Re-use existing grid style #}
+        <div class="full-page-gallery-grid" style="padding-top: var(--spacing-l); padding-bottom: var(--spacing-l);"> {# Use new class #}
             {% for photo in gallery_photos %}
             <div class="adw-card gallery-photo-card">
-                <img src="{{ url_for('static', filename='uploads/gallery_pics/' + photo.image_filename) }}"
+                <img src="{{ url_for('static', filename=photo.image_filename) }}"
                      alt="{{ photo.caption or 'Gallery image by ' ~ user_profile.username }}"
-                     class="gallery-photo-image"
-                     style="height: 200px;"> {# Adjust height as needed for a larger grid #}
+                     class="gallery-photo-image"> {# Remove inline style #}
                 {% if photo.caption %}
                 <div class="adw-card__content gallery-photo-caption">
                     <p class="adw-label body-2">{{ photo.caption }}</p>


### PR DESCRIPTION
- Fixed incorrect image URL generation in `gallery_full.html` to prevent 404 errors for photo assets.
- Introduced a new CSS class `.full-page-gallery-grid` for `gallery_full.html`.
- Styled `.full-page-gallery-grid` to have larger photo cards (min-width 280px) and taller images (220px height) for a better viewing experience on the dedicated gallery page.