### PR TITLE
Fix: Correct PII in gallery title and enable image click dialog

### DIFF
--- a/antisocialnet/templates/gallery_full.html
+++ b/antisocialnet/templates/gallery_full.html
@@ -1,15 +1,57 @@
 {% extends "base.html" %}
 
-{% block title %}{{ user_profile.username }}'s Photo Gallery{% endblock %}
+{% block title %}{{ user_profile.full_name or ('User ' ~ user_profile.id) }}'s Photo Gallery{% endblock %}
 
-{% block header_title %}{{ user_profile.username }}'s Photo Gallery{% endblock %}
+{% block header_title %}{{ user_profile.full_name or ('User ' ~ user_profile.id) }}'s Photo Gallery{% endblock %}
 
 {% block header_actions_start %}
     <a href="{{ url_for('profile.view_profile', user_id=user_profile.id) }}" class="adw-button">
         <span class="adw-icon icon-actions-go-previous-symbolic"></span> Back to Profile
     </a>
+{% endblock %}
 
-{# Dialog for Full-Size Gallery Photo (copied from profile.html) #}
+{% block content %}
+<div class="adw-clamp adw-clamp-xl">
+    {% if gallery_photos %}
+        <div class="full-page-gallery-grid" style="padding-top: var(--spacing-l); padding-bottom: var(--spacing-l);"> {# Use new class #}
+            {% for photo in gallery_photos %}
+            <div class="adw-card gallery-photo-card">
+                <img src="{{ url_for('static', filename=photo.image_filename) }}"
+                     alt="{{ photo.caption or ('Gallery image by ' ~ (user_profile.full_name or ('User ' ~ user_profile.id))) }}"
+                     class="gallery-photo-image clickable-gallery-photo" {# Added clickable class #}
+                     data-fullsrc="{{ url_for('static', filename=photo.image_filename) }}"
+                     data-caption="{{ photo.caption or '' }}"
+                     data-photoid="{{ photo.id }}">
+                {% if photo.caption %}
+                <div class="adw-card__content gallery-photo-caption">
+                    <p class="adw-label body-2">{{ photo.caption }}</p>
+                </div>
+                {% endif %}
+                <div class="adw-card__actions card-secondary-actions">
+                    {% from "_macros.html" import like_button_and_count %}
+                    {{ like_button_and_count(photo, 'photo', current_user) }}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="adw-status-page" style="margin-top: var(--spacing-xl);">
+            <span class="adw-icon icon-media-image-symbolic adw-status-page-icon app-status-page-icon"></span>
+            <h3 class="adw-status-page-title">Empty Gallery</h3>
+            <p class="adw-status-page-description">{{ (user_profile.full_name or ('User ' ~ user_profile.id)) }} has not uploaded any photos to their gallery yet.</p>
+             {% if current_user == user_profile %}
+                <p class="adw-status-page-description">You can upload photos from your profile page.</p>
+            {% else %}
+                <p class="adw-status-page-description">Check back later!</p>
+            {% endif %}
+            <div class="adw-status-page-actions">
+                <a href="{{ url_for('profile.view_profile', user_id=user_profile.id) }}" class="adw-button">Back to Profile</a>
+            </div>
+        </div>
+    {% endif %}
+</div>
+
+{# Dialog for Full-Size Gallery Photo (copied from profile.html and moved here) #}
 <adw-dialog id="gallery-photo-dialog" title="Gallery Photo">
     <div slot="content" class="dialog-image-content" style="text-align: center; padding: var(--spacing-m);">
         <img id="full-gallery-photo-img" src="" alt="Full-size gallery photo" style="max-width: 100%; max-height: 70vh; display: block; margin: auto;">
@@ -47,7 +89,6 @@
         {% endif %}
     </div>
 </adw-dialog>
-
 {% endblock %}
 
 {% block scripts %}
@@ -239,7 +280,7 @@ document.addEventListener('DOMContentLoaded', function () {
             {% for photo in gallery_photos %}
             <div class="adw-card gallery-photo-card">
                 <img src="{{ url_for('static', filename=photo.image_filename) }}"
-                     alt="{{ photo.caption or 'Gallery image by ' ~ user_profile.username }}"
+                     alt="{{ photo.caption or ('Gallery image by ' ~ (user_profile.full_name or ('User ' ~ user_profile.id))) }}"
                      class="gallery-photo-image clickable-gallery-photo" {# Added clickable class #}
                      data-fullsrc="{{ url_for('static', filename=photo.image_filename) }}"
                      data-caption="{{ photo.caption or '' }}"


### PR DESCRIPTION
- I resolved a PII violation in `gallery_full.html` by ensuring titles and image alt text use `user_profile.full_name` instead of `user_profile.username`.
- I fixed the click functionality on `gallery_full.html` images:
    - I moved the gallery photo dialog HTML into the `content` block.
    - I ensured images have the `clickable-gallery-photo` class and necessary data attributes.
    - The existing JavaScript (copied from profile.html) should now correctly find elements and enable opening the dialog to view full-size images with details.