### PR TITLE
Diag: Hardcode toast messages to test for escape sequence error source

### DIFF
--- a/antisocialnet/templates/base.html
+++ b/antisocialnet/templates/base.html
@@ -211,10 +211,10 @@
                         <script nonce="{{ csp_nonce() if csp_nonce else '' }}">
                             document.addEventListener('DOMContentLoaded', function() {
                                 if (window.Adw && window.Adw.createToast) {
-                                    window.Adw.createToast("{{ message|escapejs }}");
+                                    window.Adw.createToast("Test message");
                                 } else {
                                     // Fallback if Adw.createToast is not available for some reason
-                                    console.warn("Adw.createToast not found, falling back for message: {{ message|escapejs }}");
+                                    console.warn("Adw.createToast not found, falling back for message: Test message");
                                     // Optional: could add a simple alert or console log as fallback
                                 }
                             });

--- a/antisocialnet/templates/gallery_full.html
+++ b/antisocialnet/templates/gallery_full.html
@@ -133,7 +133,6 @@ document.addEventListener('DOMContentLoaded', function () {
             const authorProfileUrl = comment.author.profile_url;
             const authorAvatarAlt = comment.author.full_name;
 
-            // Re-typed syntax markers for the template literal below
             commentDiv.innerHTML = \`
                 <span class="adw-avatar size-small" style="margin-right: var(--spacing-s);">
                     <img src="\${comment.author.profile_photo_url}" alt="\${authorAvatarAlt} avatar">
@@ -199,7 +198,6 @@ document.addEventListener('DOMContentLoaded', function () {
         const contextPrefix = likeSectionContainer.id.startsWith('dialog-') ? 'dialog-' : '';
 
         let formHtml;
-        // Re-typed syntax markers for the template literal below
         if (userHasLiked) {
             formHtml = \`
                 <form action="/like/unlike/\${itemType}/\${itemId}" method="POST" style="display: inline;" class="like-form">
@@ -211,7 +209,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 </form>
             \`;
         } else {
-            // Re-typed syntax markers for the template literal below
             formHtml = \`
                 <form action="/like/\${itemType}/\${itemId}" method="POST" style="display: inline;" class="like-form">
                     <input type="hidden" name="csrf_token" value="\${csrfTokenVal}">
@@ -222,7 +219,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 </form>
             \`;
         }
-        // Re-typed syntax markers for the template literal part below
         likeSectionContainer.innerHTML = formHtml + \`<span class="adw-label caption like-count" id="\${contextPrefix}like-count-\${itemType}-\${itemId}">\${newLikeCount}</span>\`;
     }
 


### PR DESCRIPTION
This commit temporarily changes the flashed message handling in `base.html`. Instead of rendering the dynamic message content (`{{ message|escapejs }}`) into the JavaScript `createToast` call, it now uses a hardcoded string `"Test message"`.

This is a diagnostic step to determine if the persistent `Uncaught SyntaxError: invalid escape sequence` in the gallery page originates from the content or Jinja escaping of flashed messages. If the error disappears with this change, it points to an issue with message data or the `escapejs` filter's output for certain inputs. If the error persists, the cause lies elsewhere in the gallery page's JavaScript.