### PR TITLE
Fix: Correct sidebar layout and icon colors

### DIFF
--- a/antisocialnet/templates/base.html
+++ b/antisocialnet/templates/base.html
@@ -152,23 +152,23 @@
         {% endif %}
         <div class="adw-list-box flat sidebar-nav" aria-label="Main Navigation">
                 <a href="{{ url_for('general.activity_feed') }}" class="nav-item {{ 'selected' if request.endpoint == 'general.activity_feed' or request.endpoint == 'general.index' }}">
-                    <img src="{{ url_for('static', filename='img/home.svg') }}" class="adw-action-row-icon" alt="Home">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-home adw-action-row-icon"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
                     <span class="adw-action-row-title">Home</span>
                 </a>
                 {% if current_user.is_authenticated %}
                 <a href="{{ url_for('notification.list_notifications') }}" class="nav-item {{ 'selected' if request.blueprint == 'notification' }}">
-                    <img src="{{ url_for('static', filename='img/notifications.svg') }}" class="adw-action-row-icon" alt="Notifications">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-bell adw-action-row-icon"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
                     <span class="adw-action-row-title">Notifications</span>
                     {% if unread_notifications_count > 0 %}
                         <span class="adw-badge suggested-action" title="{{ unread_notifications_count }} unread notifications">{{ unread_notifications_count }}</span>
                     {% endif %}
                 </a>
                 <a href="{{ url_for('post.create_post') }}" class="nav-item {{ 'selected' if request.endpoint == 'post.create_post' }}">
-                    <img src="{{ url_for('static', filename='img/new_post.svg') }}" class="adw-action-row-icon" alt="New Post">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-plus-square adw-action-row-icon"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
                     <span class="adw-action-row-title">New Post</span>
                 </a>
                 <a href="{{ url_for('general.dashboard') }}" class="nav-item {{ 'selected' if request.endpoint == 'general.dashboard' }}">
-                    <img src="{{ url_for('static', filename='img/dashboard.svg') }}" class="adw-action-row-icon" alt="Dashboard">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-grid adw-action-row-icon"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
                     <span class="adw-action-row-title">Dashboard</span>
                 </a>
                 {% endif %}


### PR DESCRIPTION
- Set flex-direction to row for nav-items to ensure they are on separate lines.
- Styled inline SVGs to use theme colors for better visibility in both light and dark modes.