### PR TITLE
Fix: Remove duplicate header_title block in base.html

### DIFF
--- a/antisocialnet/templates/base.html
+++ b/antisocialnet/templates/base.html
@@ -207,7 +207,7 @@
                 </div>
                 <div class="adw-header-bar__center">
                     <h1 class="adw-header-bar__title">
-                        {% block header_title %}{{ site_settings.get('site_title', 'Social Demo') }}{% endblock %}
+
                     </h1>
                 </div>
                 <div class="adw-header-bar__end">


### PR DESCRIPTION
This commit resolves a `jinja2.exceptions.TemplateAssertionError` caused by a duplicate `header_title` block in the `base.html` template.

I have removed the second occurrence of the block, which was causing the error and preventing the application from rendering templates that extend `base.html`.

Additionally, I have installed all the missing dependencies that were preventing the application from running.