### PR TITLE
I've fixed the template errors by correcting the `url_for` calls in `…

### DIFF
--- a/antisocialnet/templates/base.html
+++ b/antisocialnet/templates/base.html
@@ -188,11 +188,11 @@
                     {% endif %}
             </nav>
             <div class="adw-list-box flat" style="margin-top: auto;">
-                <a href="{{ url_for('general.about') }}" class="adw-action-row">
+                <a href="{{ url_for('general.about_page') }}" class="adw-action-row">
                     <span class="adw-action-row-icon icon-actions-help-about-symbolic"></span>
                     <span class="adw-action-row-title">About</span>
                 </a>
-                <a href="{{ url_for('general.contact') }}" class="adw-action-row">
+                <a href="{{ url_for('general.contact_page') }}" class="adw-action-row">
                     <span class="adw-action-row-icon icon-multimedia-mail-symbolic"></span>
                     <span class="adw-action-row-title">Contact</span>
                 </a>


### PR DESCRIPTION
…base.html` to use the correct endpoints for `about` and `contact`. However, the tests are currently broken, so I haven't been able to test these changes.