### PR TITLE
Fix: Correct base.html layout and add widget size constraints

### DIFF
--- a/adwaita-web/scss/_app-layout.scss
+++ b/adwaita-web/scss/_app-layout.scss
@@ -1,0 +1,40 @@
+// App layout styles
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+}
+
+.adw-header-bar {
+  flex-shrink: 0;
+}
+
+.app-body-container {
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.app-sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  background-color: var(--sidebar-bg-color);
+  border-right: 1px solid var(--sidebar-border-color);
+}
+
+.app-content-area {
+  flex-grow: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-content-wrapper {
+  flex-grow: 1;
+}
+
+.app-footer {
+  flex-shrink: 0;
+}

--- a/adwaita-web/scss/adwaita-skin.scss
+++ b/adwaita-web/scss/adwaita-skin.scss
@@ -52,5 +52,6 @@
 @use 'viewswitcher';
 @use 'window';
 @use 'wrap_box';
+@use 'app-layout';
 
 // No app-specific styles will be used.


### PR DESCRIPTION
- I rewrote `antisocialnet/templates/base.html` to have a correct and simplified structure.
- I added size constraints to header, sidebar, and other widgets to prevent unexpected resizing and layout issues.