### PR TITLE
Fix: CSRF token error and layout issues

### DIFF
--- a/adwaita-web/scss/_antisocialnet-specific.scss
+++ b/adwaita-web/scss/_antisocialnet-specific.scss
@@ -345,8 +345,8 @@ body { overflow: hidden; }
 .app-content-area {
     flex-grow: 1; display: flex; flex-direction: column; overflow-y: auto;
     background-color: var(--window-bg-color);
-    .page-content-wrapper { flex-grow: 1; }
-    .main-content { padding-top: var(--spacing-xl); padding-bottom: var(--spacing-xl); }
+    .page-content-wrapper { flex-grow: 1; display: flex; flex-direction: column; }
+    .main-content { padding-top: var(--spacing-xl); padding-bottom: var(--spacing-xl); flex-grow: 1; }
     .app-footer { flex-shrink: 0; }
 }
 

--- a/antisocialnet/forms.py
+++ b/antisocialnet/forms.py
@@ -154,6 +154,14 @@ class EditPostForm(FlaskForm):
     submit = SubmitField('Update Post')
 
 
+class FollowForm(FlaskForm):
+    """CSRF-only form for following a user."""
+    submit = SubmitField('Follow')
+
+class UnfollowForm(FlaskForm):
+    """CSRF-only form for unfollowing a user."""
+    submit = SubmitField('Unfollow')
+
 class UnlikeForm(FlaskForm):
     submit = SubmitField('Unlike') # Text can be changed in template if needed for context
 

--- a/antisocialnet/templates/_macros.html
+++ b/antisocialnet/templates/_macros.html
@@ -26,3 +26,47 @@
     <span class="adw-label caption like-count" id="{{ context_prefix }}like-count-{{ item_type }}-{{ item.id }}">{{ item.like_count }}</span>
 </div>
 {% endmacro %}
+
+{% macro render_pagination(pagination, endpoint, **kwargs) %}
+<div class="pagination-controls adw-box adw-box-horizontal justify-center adw-box-spacing-xs">
+    {# First page link #}
+    <a href="{{ url_for(endpoint, page=1, **kwargs) }}"
+       class="adw-button flat{{ ' disabled' if not pagination.has_prev }}"
+       aria-label="First page" {{ ' disabled' if not pagination.has_prev }}>
+        <span class="adw-icon icon-actions-go-first-symbolic"></span>
+    </a>
+
+    {# Previous page link #}
+    <a href="{{ url_for(endpoint, page=pagination.prev_num, **kwargs) }}"
+       class="adw-button flat{{ ' disabled' if not pagination.has_prev }}"
+       aria-label="Previous page" {{ ' disabled' if not pagination.has_prev }}>
+        <span class="adw-icon icon-actions-go-previous-symbolic"></span>
+    </a>
+
+    {# Page numbers #}
+    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+        {% if page_num %}
+            <a href="{{ url_for(endpoint, page=page_num, **kwargs) }}"
+               class="adw-button flat{{ ' active' if page_num == pagination.page }}">
+                {{ page_num }}
+            </a>
+        {% else %}
+            <span class="adw-button flat disabled">…</span>
+        {% endif %}
+    {% endfor %}
+
+    {# Next page link #}
+    <a href="{{ url_for(endpoint, page=pagination.next_num, **kwargs) }}"
+       class="adw-button flat{{ ' disabled' if not pagination.has_next }}"
+       aria-label="Next page" {{ ' disabled' if not pagination.has_next }}>
+        <span class="adw-icon icon-actions-go-next-symbolic"></span>
+    </a>
+
+    {# Last page link #}
+    <a href="{{ url_for(endpoint, page=pagination.pages, **kwargs) }}"
+       class="adw-button flat{{ ' disabled' if not pagination.has_next }}"
+       aria-label="Last page" {{ ' disabled' if not pagination.has_next }}>
+        <span class="adw-icon icon-actions-go-last-symbolic"></span>
+    </a>
+</div>
+{% endmacro %}

--- a/antisocialnet/templates/followers_list.html
+++ b/antisocialnet/templates/followers_list.html
@@ -31,13 +31,13 @@
                     {% if current_user.is_authenticated and current_user != listed_user %}
                         {% if current_user.is_following(listed_user) %}
                             <form action="{{ url_for('profile.unfollow_user', user_id=listed_user.id) }}" method="POST" style="display: inline;">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small">Unfollow</button> {# Using .small button variant #}
+                                {{ unfollow_form.hidden_tag() }}
+                                {{ unfollow_form.submit(class="adw-button small") }}
                             </form>
                         {% else %}
                             <form action="{{ url_for('profile.follow_user', user_id=listed_user.id) }}" method="POST" style="display: inline;">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small suggested-action">Follow</button>
+                                {{ follow_form.hidden_tag() }}
+                                {{ follow_form.submit(class="adw-button small suggested-action") }}
                             </form>
                         {% endif %}
                     {% endif %}
@@ -49,39 +49,7 @@
         {# Pagination Controls #}
         {% if pagination and pagination.pages > 1 %}
         <div class="adw-box adw-box-horizontal justify-center list-pagination-box">
-            <div class="adw-toggle-group">
-                {% if pagination.has_prev %}
-                    <a href="{{ url_for('profile.followers_list', user_id=user_profile.id, page=pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
-                        <span class="adw-icon icon-actions-go-previous-symbolic"></span>
-                    </a>
-                {% else %}
-                    <button class="adw-button icon-only" disabled aria-label="Previous page">
-                        <span class="adw-icon icon-actions-go-previous-symbolic"></span>
-                    </button>
-                {% endif %}
-
-                {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-                    {% if page_num %}
-                        {% if page_num == pagination.page %}
-                            <button class="adw-button suggested-action" disabled aria-current="page">{{ page_num }}</button>
-                        {% else %}
-                            <a href="{{ url_for('profile.followers_list', user_id=user_profile.id, page=page_num) }}" class="adw-button">{{ page_num }}</a>
-                        {% endif %}
-                    {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
-                        <button class="adw-button flat" disabled>…</button>
-                    {% endif %}
-                {% endfor %}
-
-                {% if pagination.has_next %}
-                     <a href="{{ url_for('profile.followers_list', user_id=user_profile.id, page=pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
-                        <span class="adw-icon icon-actions-go-next-symbolic"></span>
-                    </a>
-                {% else %}
-                    <button class="adw-button icon-only" disabled aria-label="Next page">
-                        <span class="adw-icon icon-actions-go-next-symbolic"></span>
-                    </button>
-                {% endif %}
-            </div>
+            {{ render_pagination(pagination, 'profile.followers_list', user_id=user_profile.id) }}
         </div>
         {% endif %}
 

--- a/antisocialnet/templates/following_list.html
+++ b/antisocialnet/templates/following_list.html
@@ -31,13 +31,13 @@
                     {% if current_user.is_authenticated and current_user != listed_user %}
                         {% if current_user.is_following(listed_user) %}
                             <form action="{{ url_for('profile.unfollow_user', user_id=listed_user.id) }}" method="POST" style="display: inline;">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small">Unfollow</button>
+                                {{ unfollow_form.hidden_tag() }}
+                                {{ unfollow_form.submit(class="adw-button small") }}
                             </form>
                         {% else %}
                             <form action="{{ url_for('profile.follow_user', user_id=listed_user.id) }}" method="POST" style="display: inline;">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="adw-button small suggested-action">Follow</button>
+                                {{ follow_form.hidden_tag() }}
+                                {{ follow_form.submit(class="adw-button small suggested-action") }}
                             </form>
                         {% endif %}
                     {% elif current_user == listed_user %}
@@ -51,39 +51,7 @@
         {# Pagination Controls #}
         {% if pagination and pagination.pages > 1 %}
         <div class="adw-box adw-box-horizontal justify-center list-pagination-box">
-            <div class="adw-toggle-group">
-                {% if pagination.has_prev %}
-                    <a href="{{ url_for('profile.following_list', user_id=user_profile.id, page=pagination.prev_num) }}" class="adw-button icon-only" aria-label="Previous page">
-                        <span class="adw-icon icon-actions-go-previous-symbolic"></span>
-                    </a>
-                {% else %}
-                    <button class="adw-button icon-only" disabled aria-label="Previous page">
-                        <span class="adw-icon icon-actions-go-previous-symbolic"></span>
-                    </button>
-                {% endif %}
-
-                {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-                    {% if page_num %}
-                        {% if page_num == pagination.page %}
-                            <button class="adw-button suggested-action" disabled aria-current="page">{{ page_num }}</button>
-                        {% else %}
-                            <a href="{{ url_for('profile.following_list', user_id=user_profile.id, page=page_num) }}" class="adw-button">{{ page_num }}</a>
-                        {% endif %}
-                    {% elif loop.index != 1 and loop.index != pagination.pages + pagination.iter_pages()|length %}
-                        <button class="adw-button flat" disabled>…</button>
-                    {% endif %}
-                {% endfor %}
-
-                {% if pagination.has_next %}
-                     <a href="{{ url_for('profile.following_list', user_id=user_profile.id, page=pagination.next_num) }}" class="adw-button icon-only" aria-label="Next page">
-                        <span class="adw-icon icon-actions-go-next-symbolic"></span>
-                    </a>
-                {% else %}
-                    <button class="adw-button icon-only" disabled aria-label="Next page">
-                        <span class="adw-icon icon-actions-go-next-symbolic"></span>
-                    </button>
-                {% endif %}
-            </div>
+            {{ render_pagination(pagination, 'profile.following_list', user_id=user_profile.id) }}
         </div>
         {% endif %}
 

--- a/antisocialnet/templates/post.html
+++ b/antisocialnet/templates/post.html
@@ -5,62 +5,68 @@
 {% block header_title %}Post{% endblock %}
 
 {% block content %}
-<div class="post-view">
-    <article class="post-article adw-card blog-content-card">
-        <header class="post-header">
-            <h1 class="adw-title-1">{{ post.title }}</h1>
-            <div class="post-meta-detail">
-                <p class="adw-label body">
-                    By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.full_name }}</a>
-                    on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }}</time>
-                </p>
-            </div>
-            {% if post.categories %}
-            <div class="post-terms post-categories">
-                <strong class="adw-label caption post-meta-terms-label">Categories:</strong>
-                {% for category in post.categories %}
-                    <a href="{{ url_for('post.posts_by_category', category_slug=category.slug) }}" class="adw-button flat compact">{{ category.name }}</a>
-                {% endfor %}
-            </div>
-            {% endif %}
-            {% if post.tags %}
-            <div class="post-terms post-tags">
-                <strong class="adw-label caption post-meta-terms-label">Tags:</strong>
-                {% for tag in post.tags %}
-                    <a href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug) }}" class="adw-button flat compact tag-pill">{{ tag.name }}</a>
-                {% endfor %}
-            </div>
-            {% endif %}
-        </header>
-        <div class="post-content styled-text-content">
-            {{ post.content_html | safe }}
-        </div>
-        <footer class="adw-card__actions post-interaction-footer" style="padding-top: var(--spacing-m); margin-top: var(--spacing-m); border-top: 1px solid var(--border-color);">
-            <adw-like-button item-id="{{ post.id }}" item-type="post" initial-liked="{{ current_user.has_liked_item('post', post.id) }}" initial-like-count="{{ post.likes.count() }}"></adw-like-button>
-        </footer>
-    </article>
-
-    <div id="comments-container" class="comments-section" aria-labelledby="comments-heading">
-        <h2 id="comments-heading" class="adw-title-2">Comments</h2>
-        <div id="comments-list" class="adw-list-box comments-list flat">
-            {% for comment in post.comments | sort(attribute='created_at') %}
-                {% if not comment.parent_id %}
-                    {% include '_comment.html' %}
+<div class="adw-box adw-box-horizontal adw-box-spacing-l">
+    <div style="flex-grow: 2;">
+        <article class="post-article adw-card blog-content-card">
+            <header class="post-header">
+                <h1 class="adw-title-1">{{ post.title }}</h1>
+                <div class="post-meta-detail">
+                    <p class="adw-label body">
+                        By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.full_name }}</a>
+                        on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d %H:%M') }}</time>
+                    </p>
+                </div>
+                {% if post.categories %}
+                <div class="post-terms post-categories">
+                    <strong class="adw-label caption post-meta-terms-label">Categories:</strong>
+                    {% for category in post.categories %}
+                        <a href="{{ url_for('post.posts_by_category', category_slug=category.slug) }}" class="adw-button flat compact">{{ category.name }}</a>
+                    {% endfor %}
+                </div>
                 {% endif %}
-            {% endfor %}
-        </div>
-    </div>
-
-    <div id="comment-form-container" class="comment-form-section">
-        <h2 class="adw-title-2">Leave a Comment</h2>
-        <form id="comment-form" method="POST" action="{{ url_for('post.view_post', post_id=post.id) }}">
-            {{ form.hidden_tag() }}
-            {{ form.parent_id }}
-            <div class="form-group">
-                {{ form.text(class="adw-textarea", rows="4", placeholder="Write a comment...") }}
+                {% if post.tags %}
+                <div class="post-terms post-tags">
+                    <strong class="adw-label caption post-meta-terms-label">Tags:</strong>
+                    {% for tag in post.tags %}
+                        <a href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug) }}" class="adw-button flat compact tag-pill">{{ tag.name }}</a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </header>
+            <div class="post-content styled-text-content">
+                {{ post.content_html | safe }}
             </div>
-            <button type="submit" class="adw-button suggested-action">Submit</button>
-        </form>
+            <footer class="adw-card__actions post-interaction-footer" style="padding-top: var(--spacing-m); margin-top: var(--spacing-m); border-top: 1px solid var(--border-color);">
+                <adw-like-button item-id="{{ post.id }}" item-type="post" initial-liked="{{ current_user.has_liked_item('post', post.id) }}" initial-like-count="{{ post.likes.count() }}"></adw-like-button>
+            </footer>
+        </article>
+    </div>
+    <div style="flex-grow: 1;">
+        <div class="adw-preferences-group">
+            <h2 class="adw-preferences-group__title">Comments</h2>
+            <div id="comments-list" class="adw-list-box comments-list flat">
+                {% for comment in post.comments | sort(attribute='created_at') %}
+                    {% if not comment.parent_id %}
+                        {% include '_comment.html' %}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+        <div class="adw-preferences-group">
+            <h2 class="adw-preferences-group__title">Leave a Comment</h2>
+            <div class="adw-list-box">
+                <div id="comment-form-container" class="comment-form-section">
+                    <form id="comment-form" method="POST" action="{{ url_for('post.view_post', post_id=post.id) }}">
+                        {{ form.hidden_tag() }}
+                        {{ form.parent_id }}
+                        <div class="form-group">
+                            {{ form.text(class="adw-textarea", rows="4", placeholder="Write a comment...") }}
+                        </div>
+                        <button type="submit" class="adw-button suggested-action">Submit</button>
+                    </form>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/antisocialnet/templates/posts_by_category.html
+++ b/antisocialnet/templates/posts_by_category.html
@@ -26,7 +26,7 @@
                             <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.title }}</a>
                         </h2>
                         <div class="blog-post-card__meta adw-label caption">
-                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
+                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.full_name if post.author else 'Unknown Author' }}</a>
                             on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         </div>
                     </header>
@@ -58,40 +58,16 @@
                     </footer>
                     <div class="adw-card__actions card-secondary-actions">
                         {% from "_macros.html" import like_button_and_count %}
-                        {{ like_button_and_count(post, current_user, csrf_token()) }}
+                        {{ like_button_and_count(post, 'post', current_user) }}
                     </div>
                 </article>
                 {% endfor %}
             </div>
 
             {% if pagination and pagination.pages > 1 %}
-            <adw-box orientation="horizontal" justify="center" style="margin-top: var(--spacing-l);">
-                <adw-toggle-group>
-                    {% if pagination.has_prev %}
-                        <adw-button icon-name="go-previous-symbolic" href="{{ url_for('post.posts_by_category', category_slug=category.slug, page=pagination.prev_num) }}"></adw-button>
-                    {% else %}
-                        <adw-button icon-name="go-previous-symbolic" disabled></adw-button>
-                    {% endif %}
-
-                    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-                        {% if page_num %}
-                            {% if page_num == pagination.page %}
-                                <adw-button text="{{ page_num }}" suggested disabled aria-current="page"></adw-button>
-                            {% else %}
-                                <adw-button text="{{ page_num }}" href="{{ url_for('post.posts_by_category', category_slug=category.slug, page=page_num) }}"></adw-button>
-                            {% endif %}
-                        {% else %}
-                            <adw-button text="…" flat disabled style="pointer-events: none;"></adw-button>
-                        {% endif %}
-                    {% endfor %}
-
-                    {% if pagination.has_next %}
-                        <adw-button icon-name="go-next-symbolic" href="{{ url_for('post.posts_by_category', category_slug=category.slug, page=pagination.next_num) }}"></adw-button>
-                    {% else %}
-                        <adw-button icon-name="go-next-symbolic" disabled></adw-button>
-                    {% endif %}
-                </adw-toggle-group>
-            </adw-box>
+            <div class="adw-box adw-box-horizontal justify-center" style="margin-top: var(--spacing-l);">
+                {{ render_pagination(pagination, 'post.posts_by_category', category_slug=category.slug) }}
+            </div>
             {% endif %}
         {% else %}
              <adw-status-page icon-name="empty-symbolic" title="No Posts Found" description="There are no posts in the category '{{ category.name }}'.">

--- a/antisocialnet/templates/posts_by_tag.html
+++ b/antisocialnet/templates/posts_by_tag.html
@@ -26,7 +26,7 @@
                             <a href="{{ url_for('post.view_post', post_id=post.id) }}" class="adw-link">{{ post.title }}</a>
                         </h2>
                         <div class="blog-post-card__meta adw-label caption">
-                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.username if post.author else 'Unknown Author' }}</a>
+                            By: <a href="{{ url_for('profile.view_profile', user_id=post.author.id) }}" class="adw-link">{{ post.author.full_name if post.author else 'Unknown Author' }}</a>
                             on <time datetime="{{ post.created_at.isoformat() }}">{{ post.created_at.strftime('%Y-%m-%d') if post.created_at else 'Unknown date' }}</time>
                         </div>
                     </header>
@@ -58,40 +58,16 @@
                     </footer>
                     <div class="adw-card__actions card-secondary-actions">
                         {% from "_macros.html" import like_button_and_count %}
-                        {{ like_button_and_count(post, current_user) }}
+                        {{ like_button_and_count(post, 'post', current_user) }}
                     </div>
                 </article>
                 {% endfor %}
             </div>
 
             {% if pagination and pagination.pages > 1 %}
-            <adw-box orientation="horizontal" justify="center" style="margin-top: var(--spacing-l);">
-                <adw-toggle-group>
-                    {% if pagination.has_prev %}
-                        <adw-button icon-name="go-previous-symbolic" href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug, page=pagination.prev_num) }}"></adw-button>
-                    {% else %}
-                        <adw-button icon-name="go-previous-symbolic" disabled></adw-button>
-                    {% endif %}
-
-                    {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-                        {% if page_num %}
-                            {% if page_num == pagination.page %}
-                                <adw-button text="{{ page_num }}" suggested disabled aria-current="page"></adw-button>
-                            {% else %}
-                                <adw-button text="{{ page_num }}" href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug, page=page_num) }}"></adw-button>
-                            {% endif %}
-                        {% else %}
-                            <adw-button text="…" flat disabled style="pointer-events: none;"></adw-button>
-                        {% endif %}
-                    {% endfor %}
-
-                    {% if pagination.has_next %}
-                        <adw-button icon-name="go-next-symbolic" href="{{ url_for('post.posts_by_tag', tag_slug=tag.slug, page=pagination.next_num) }}"></adw-button>
-                    {% else %}
-                        <adw-button icon-name="go-next-symbolic" disabled></adw-button>
-                    {% endif %}
-                </adw-toggle-group>
-            </adw-box>
+            <div class="adw-box adw-box-horizontal justify-center" style="margin-top: var(--spacing-l);">
+                {{ render_pagination(pagination, 'post.posts_by_tag', tag_slug=tag.slug) }}
+            </div>
             {% endif %}
         {% else %}
             <adw-status-page icon-name="bookmark-new-symbolic" title="No Posts Found" description="There are no posts with the tag '{{ tag.name }}'.">

--- a/antisocialnet/templates/profile.html
+++ b/antisocialnet/templates/profile.html
@@ -12,7 +12,7 @@
         </div>
         <div class="adw-box adw-box-vertical adw-box-spacing-xs">
             <h1 class="adw-label title-1">{{ user_profile.full_name }}</h1>
-            <div><span class="adw-label adw-caption">@{{ user_profile.username }}</span></div>
+            <div><span class="adw-label adw-caption">@{{ user_profile.full_name }}</span></div>
             <div class="adw-box adw-box-horizontal adw-box-spacing-s profile-follow-stats">
                 <a href="{{ url_for('profile.followers_list', user_id=user_profile.id) }}" class="adw-link">
                     <span class="adw-label body-2"><strong>{{ user_profile.followers.count() }}</strong> Followers</span>
@@ -25,11 +25,13 @@
                 <div class="profile-follow-actions">
                     {% if current_user.is_following(user_profile) %}
                         <form action="{{ url_for('profile.unfollow_user', user_id=user_profile.id) }}" method="POST">
-                            <button type="submit" class="adw-button">Unfollow</button>
+                            {{ unfollow_form.hidden_tag() }}
+                            {{ unfollow_form.submit(class="adw-button") }}
                         </form>
                     {% else %}
                         <form action="{{ url_for('profile.follow_user', user_id=user_profile.id) }}" method="POST">
-                            <button type="submit" class="adw-button suggested-action">Follow</button>
+                            {{ follow_form.hidden_tag() }}
+                            {{ follow_form.submit(class="adw-button suggested-action") }}
                         </form>
                     {% endif %}
                 </div>
@@ -95,13 +97,8 @@
             {% endif %}
         </div>
         {% if posts_pagination and posts_pagination.pages > 1 %}
-        <div class="pagination">
-            {% if posts_pagination.has_prev %}
-                <a href="{{ url_for('profile.view_profile', user_id=user_profile.id, page=posts_pagination.prev_num) }}" class="adw-button">Previous</a>
-            {% endif %}
-            {% if posts_pagination.has_next %}
-                <a href="{{ url_for('profile.view_profile', user_id=user_profile.id, page=posts_pagination.next_num) }}" class="adw-button">Next</a>
-            {% endif %}
+        <div class="adw-box adw-box-horizontal justify-center" style="margin-top: var(--spacing-l);">
+            {{ render_pagination(posts_pagination, 'profile.view_profile', user_id=user_profile.id) }}
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
This commit fixes the CSRF token error that occurred when following or unfollowing a user. It also addresses several layout issues to improve the overall UI and ensure consistency with the GNOME HIG.

Fixes:
- **CSRF Token Error:** The follow/unfollow functionality now uses a form with a CSRF token, which resolves the CSRF token error.
- **Layout Issues:**
    - The footer is now correctly positioned at the bottom of the page.
    - The content widgets on the new post page and the post details page are now laid out horizontally.
    - The pagination has been improved and is now consistent across all pages.
- **Display Issues:**
    - The author's full name is now displayed instead of their username.

Refactoring:
- The `FollowForm` and `UnfollowForm` have been added.
- The `profile_routes.py` file has been updated to use the new forms.
- The `profile.html`, `posts_by_category.html`, `posts_by_tag.html`, `followers_list.html`, and `following_list.html` templates have been updated to use the new forms and pagination macro.
- The `_macros.html` template has been updated with a new pagination macro.
- The `_antisocialnet-specific.scss` file has been updated with new styles to fix the layout issues.